### PR TITLE
Adding TGB negative sampling hook 

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -2,5 +2,6 @@
 
 ::: tgm.hooks.DGHook
 ::: tgm.hooks.NeighborSamplerHook
+::: tgm.hooks.TGBNegativeEdgeSamplerHook
 ::: tgm.hooks.NegativeEdgeSamplerHook
 ::: tgm.hooks.RecencyNeighborHook

--- a/examples/linkproppred/TGB/edgebank.py
+++ b/examples/linkproppred/TGB/edgebank.py
@@ -1,0 +1,102 @@
+import argparse
+
+import numpy as np
+import torch
+from tgb.linkproppred.dataset_pyg import PyGLinkPropPredDataset
+from tgb.linkproppred.evaluate import Evaluator
+from tqdm import tqdm
+
+from tgm.graph import DGraph
+from tgm.hooks import TGBNegativeEdgeSamplerHook
+from tgm.loader import DGDataLoader
+from tgm.nn import EdgeBankPredictor
+from tgm.timedelta import TimeDeltaDG
+from tgm.util.seed import seed_everything
+
+parser = argparse.ArgumentParser(
+    description='EdgeBank TGB Example',
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+)
+parser.add_argument('--seed', type=int, default=1337, help='random seed to use')
+parser.add_argument('--dataset', type=str, default='tgbl-wiki', help='Dataset name')
+parser.add_argument('--bsize', type=int, default=200, help='batch size')
+parser.add_argument('--window_ratio', type=float, default=0.15, help='Window ratio')
+parser.add_argument('--pos_prob', type=float, default=1.0, help='Positive edge prob')
+parser.add_argument(
+    '--memory_mode',
+    type=str,
+    default='unlimited',
+    choices=['unlimited', 'fixed'],
+    help='Memory mode',
+)
+
+
+def eval(
+    loader: DGDataLoader,
+    model: EdgeBankPredictor,
+    eval_metric: str,
+    evaluator: Evaluator,
+) -> dict:
+    perf_list = []
+    for batch in tqdm(loader):
+        neg_batch_list = batch.neg_batch_list
+        for idx, neg_batch in enumerate(neg_batch_list):
+            query_src = torch.tensor(
+                [batch.src[idx] for _ in range(len(neg_batch) + 1)]
+            )
+            query_dst = torch.cat([torch.tensor([batch.dst[idx]]), neg_batch])
+
+            y_pred = model(query_src, query_dst)
+            # compute MRR
+            input_dict = {
+                'y_pred_pos': np.array([y_pred[0]]),
+                'y_pred_neg': np.array(y_pred[1:]),
+                'eval_metric': [eval_metric],
+            }
+            perf_list.append(evaluator.eval(input_dict)[eval_metric])
+        model.update(batch.src, batch.dst, batch.time)
+    metric_dict = {}
+    metric_dict[eval_metric] = float(np.mean(perf_list))
+    return metric_dict
+
+
+args = parser.parse_args()
+seed_everything(args.seed)
+
+# * setting up tgb neg sampler
+dataset = PyGLinkPropPredDataset(name=args.dataset, root='datasets')
+eval_metric = dataset.eval_metric
+neg_sampler = dataset.negative_sampler
+evaluator = Evaluator(name=args.dataset)
+dataset.load_val_ns()
+dataset.load_test_ns()
+
+train_dg = DGraph(args.dataset, time_delta=TimeDeltaDG('r'), split='train')
+val_dg = DGraph(args.dataset, time_delta=TimeDeltaDG('r'), split='val')
+test_dg = DGraph(args.dataset, time_delta=TimeDeltaDG('r'), split='test')
+
+train_data = train_dg.materialize(materialize_features=False)
+val_loader = DGDataLoader(
+    val_dg,
+    hook=[TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='val')],
+    batch_size=args.bsize,
+)
+test_loader = DGDataLoader(
+    test_dg,
+    hook=[TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='test')],
+    batch_size=args.bsize,
+)
+
+model = EdgeBankPredictor(
+    train_data.src,
+    train_data.dst,
+    train_data.time,
+    memory_mode=args.memory_mode,
+    window_ratio=args.window_ratio,
+    pos_prob=args.pos_prob,
+)
+
+val_results = eval(val_loader, model, eval_metric, evaluator)
+print(' '.join(f'{k}={v:.4f}' for k, v in val_results.items()))
+test_results = eval(test_loader, model, eval_metric, evaluator)
+print(' '.join(f'{k}={v:.4f}' for k, v in test_results.items()))

--- a/examples/linkproppred/gclstm.py
+++ b/examples/linkproppred/gclstm.py
@@ -150,7 +150,7 @@ train_dg = DGraph(
     args.dataset, time_delta=TimeDeltaDG('s'), split='train', device=args.device
 )
 val_dg = DGraph(
-    args.dataset, time_delta=TimeDeltaDG('s'), split='valid', device=args.device
+    args.dataset, time_delta=TimeDeltaDG('s'), split='val', device=args.device
 )
 test_dg = DGraph(
     args.dataset, time_delta=TimeDeltaDG('s'), split='test', device=args.device

--- a/examples/linkproppred/gcn.py
+++ b/examples/linkproppred/gcn.py
@@ -175,7 +175,7 @@ train_dg = DGraph(
     args.dataset, time_delta=TimeDeltaDG('s'), split='train', device=args.device
 )
 val_dg = DGraph(
-    args.dataset, time_delta=TimeDeltaDG('s'), split='valid', device=args.device
+    args.dataset, time_delta=TimeDeltaDG('s'), split='val', device=args.device
 )
 test_dg = DGraph(
     args.dataset, time_delta=TimeDeltaDG('s'), split='test', device=args.device

--- a/examples/linkproppred/graphmixer.py
+++ b/examples/linkproppred/graphmixer.py
@@ -243,7 +243,7 @@ train_dg = DGraph(
     args.dataset, time_delta=TimeDeltaDG('r'), split='train', device=args.device
 )
 val_dg = DGraph(
-    args.dataset, time_delta=TimeDeltaDG('r'), split='valid', device=args.device
+    args.dataset, time_delta=TimeDeltaDG('r'), split='val', device=args.device
 )
 test_dg = DGraph(
     args.dataset, time_delta=TimeDeltaDG('r'), split='test', device=args.device

--- a/examples/linkproppred/tgat.py
+++ b/examples/linkproppred/tgat.py
@@ -154,7 +154,7 @@ train_dg = DGraph(
     args.dataset, time_delta=TimeDeltaDG('r'), split='train', device=args.device
 )
 val_dg = DGraph(
-    args.dataset, time_delta=TimeDeltaDG('r'), split='valid', device=args.device
+    args.dataset, time_delta=TimeDeltaDG('r'), split='val', device=args.device
 )
 test_dg = DGraph(
     args.dataset, time_delta=TimeDeltaDG('r'), split='test', device=args.device

--- a/examples/linkproppred/tgn.py
+++ b/examples/linkproppred/tgn.py
@@ -351,7 +351,7 @@ train_dg = DGraph(
     args.dataset, time_delta=TimeDeltaDG('r'), split='train', device=args.device
 )
 val_dg = DGraph(
-    args.dataset, time_delta=TimeDeltaDG('r'), split='valid', device=args.device
+    args.dataset, time_delta=TimeDeltaDG('r'), split='val', device=args.device
 )
 test_dg = DGraph(
     args.dataset, time_delta=TimeDeltaDG('r'), split='test', device=args.device

--- a/examples/nodeproppred/gcn.py
+++ b/examples/nodeproppred/gcn.py
@@ -183,7 +183,7 @@ train_dg = DGraph(
     args.dataset, time_delta=TimeDeltaDG('s'), split='train', device=args.device
 )
 val_dg = DGraph(
-    args.dataset, time_delta=TimeDeltaDG('s'), split='valid', device=args.device
+    args.dataset, time_delta=TimeDeltaDG('s'), split='val', device=args.device
 )
 test_dg = DGraph(
     args.dataset, time_delta=TimeDeltaDG('s'), split='test', device=args.device

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -545,11 +545,11 @@ test_indices = np.arange(num_train + num_val, num_events)
     'split,expected_indices,with_node_features',
     [
         ('train', train_indices, False),
-        ('valid', val_indices, False),
+        ('val', val_indices, False),
         ('test', test_indices, False),
         ('all', np.arange(num_events), False),
         ('train', train_indices, True),
-        ('valid', val_indices, True),
+        ('val', val_indices, True),
         ('test', test_indices, True),
         ('all', np.arange(num_events), True),
     ],
@@ -649,7 +649,7 @@ def test_from_tgb_with_node_events(mock_dataset_cls, split, expected_indices):
     mock_dataset = MagicMock()
     if split == 'train':
         mask = train_mask
-    elif split == 'valid':
+    elif split == 'val':
         mask = val_mask
     elif split == 'test':
         mask = test_mask

--- a/tgm/data.py
+++ b/tgm/data.py
@@ -373,7 +373,7 @@ class DGData:
 
         split_masks = {
             'train': dataset.train_mask,
-            'valid': dataset.val_mask,
+            'val': dataset.val_mask,
             'test': dataset.test_mask,
         }
 


### PR DESCRIPTION
- [ ] unified all split-mode for validation set to be called `val` instead of `valid` for unification
- [ ] added `TGBNegativeEdgeSamplerHook` in `hooks.py`
- [ ] added TGB example for edgebank, getting the same performance, dataloader and negative sampling hook works
- [ ] added test for `TGBNegativeEdgeSamplerHook`

To do 
- [ ] add TGAT and TGN example with TGB hook, maybe that goes in a different PR