### PR TITLE
Adding GCLSTM for nodeproppred 

### DIFF
--- a/examples/linkproppred/gcn.py
+++ b/examples/linkproppred/gcn.py
@@ -31,6 +31,12 @@ parser.add_argument('--embed-dim', type=int, default=128, help='embedding dimens
 parser.add_argument(
     '--time-gran',
     type=str,
+    default='s',
+    help='raw time granularity for dataset',
+)
+parser.add_argument(
+    '--batch-time-gran',
+    type=str,
     default='h',
     help='time granularity to operate on for snapshots',
 )
@@ -172,29 +178,38 @@ args = parser.parse_args()
 seed_everything(args.seed)
 
 train_dg = DGraph(
-    args.dataset, time_delta=TimeDeltaDG('s'), split='train', device=args.device
+    args.dataset,
+    time_delta=TimeDeltaDG(args.time_gran),
+    split='train',
+    device=args.device,
 )
 val_dg = DGraph(
-    args.dataset, time_delta=TimeDeltaDG('s'), split='val', device=args.device
+    args.dataset,
+    time_delta=TimeDeltaDG(args.time_gran),
+    split='val',
+    device=args.device,
 )
 test_dg = DGraph(
-    args.dataset, time_delta=TimeDeltaDG('s'), split='test', device=args.device
+    args.dataset,
+    time_delta=TimeDeltaDG(args.time_gran),
+    split='test',
+    device=args.device,
 )
 
 train_loader = DGDataLoader(
     train_dg,
     hook=NegativeEdgeSamplerHook(low=0, high=train_dg.num_nodes),
-    batch_unit=args.time_gran,
+    batch_unit=args.batch_time_gran,
 )
 val_loader = DGDataLoader(
     val_dg,
     hook=NegativeEdgeSamplerHook(low=0, high=val_dg.num_nodes),
-    batch_unit=args.time_gran,
+    batch_unit=args.batch_time_gran,
 )
 test_loader = DGDataLoader(
     test_dg,
     hook=NegativeEdgeSamplerHook(low=0, high=test_dg.num_nodes),
-    batch_unit=args.time_gran,
+    batch_unit=args.batch_time_gran,
 )
 
 if train_dg.dynamic_node_feats_dim is not None:

--- a/examples/nodeproppred/gclstm.py
+++ b/examples/nodeproppred/gclstm.py
@@ -5,12 +5,10 @@ from typing import Tuple
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from torchmetrics import Metric, MetricCollection
-from torchmetrics.classification import BinaryAUROC, BinaryAveragePrecision
+from tgb.nodeproppred.evaluate import Evaluator
 from tqdm import tqdm
 
 from tgm.graph import DGBatch, DGraph
-from tgm.hooks import NegativeEdgeSamplerHook
 from tgm.loader import DGDataLoader
 from tgm.nn.recurrent import GCLSTM
 from tgm.timedelta import TimeDeltaDG
@@ -21,10 +19,11 @@ parser = argparse.ArgumentParser(
     formatter_class=argparse.ArgumentDefaultsHelpFormatter,
 )
 parser.add_argument('--seed', type=int, default=1337, help='random seed to use')
-parser.add_argument('--dataset', type=str, default='tgbl-wiki', help='Dataset name')
+parser.add_argument('--dataset', type=str, default='tgbn-genre', help='Dataset name')
 parser.add_argument('--device', type=str, default='cpu', help='torch device')
 parser.add_argument('--epochs', type=int, default=100, help='number of epochs')
 parser.add_argument('--lr', type=float, default=0.0001, help='learning rate')
+parser.add_argument('--n-layers', type=int, default=2, help='number of GCN layers')
 parser.add_argument('--embed-dim', type=int, default=128, help='embedding dimension')
 parser.add_argument(
     '--time-gran',
@@ -35,16 +34,16 @@ parser.add_argument(
 parser.add_argument(
     '--batch-time-gran',
     type=str,
-    default='h',
+    default='D',
     help='time granularity to operate on for snapshots',
 )
 
 
 class GCLSTM_Model(nn.Module):
-    def __init__(self, node_dim: int, embed_dim: int) -> None:
+    def __init__(self, node_dim: int, embed_dim: int, num_classes: int) -> None:
         super().__init__()
         self.encoder = RecurrentGCN(node_dim=node_dim, embed_dim=embed_dim, K=1)
-        self.decoder = LinkPredictor(embed_dim)
+        self.decoder = NodePredictor(in_dim=embed_dim, out_dim=num_classes)
 
     def forward(
         self,
@@ -56,10 +55,9 @@ class GCLSTM_Model(nn.Module):
         edge_index = torch.stack([batch.src, batch.dst], dim=0)
         edge_weight = batch.edge_weight if hasattr(batch, 'edge_weight') else None  # type: ignore
         z, h_0, c_0 = self.encoder(node_feat, edge_index, edge_weight, h_0, c_0)
-        z_src, z_dst, z_neg = z[batch.src], z[batch.dst], z[batch.neg]  # type: ignore
-        pos_out = self.decoder(z_src, z_dst)
-        neg_out = self.decoder(z_src, z_neg)
-        return pos_out, neg_out, h_0, c_0
+        z_node = z[batch.node_ids]
+        pred = self.decoder(z_node)
+        return pred, h_0, c_0
 
 
 class RecurrentGCN(torch.nn.Module):
@@ -82,17 +80,17 @@ class RecurrentGCN(torch.nn.Module):
         return h, h_0, c_0
 
 
-class LinkPredictor(nn.Module):
-    def __init__(self, dim: int) -> None:
+class NodePredictor(torch.nn.Module):
+    def __init__(self, in_dim, out_dim):
         super().__init__()
-        self.lin_src = nn.Linear(dim, dim)
-        self.lin_dst = nn.Linear(dim, dim)
-        self.lin_out = nn.Linear(dim, 1)
+        self.lin_node = nn.Linear(in_dim, in_dim)
+        self.out = nn.Linear(in_dim, out_dim)
 
-    def forward(self, z_src: torch.Tensor, z_dst: torch.Tensor) -> torch.Tensor:
-        h = self.lin_src(z_src) + self.lin_dst(z_dst)
+    def forward(self, node_embed):
+        h = self.lin_node(node_embed)
         h = h.relu()
-        return self.lin_out(h).sigmoid().view(-1)
+        h = self.out(h)
+        return h
 
 
 def train(
@@ -104,15 +102,18 @@ def train(
     model.train()
     total_loss = 0
     h_0, c_0 = None, None
+    criterion = torch.nn.CrossEntropyLoss()
     for batch in tqdm(loader):
         # TODO: Consider skipping empty batches natively, when iterating by time (instead of events)
         if not len(batch.src):
             continue
 
         opt.zero_grad()
-        pos_out, neg_out, h_0, c_0 = model(batch, node_feat, h_0, c_0)
-        loss = F.mse_loss(pos_out, torch.ones_like(pos_out))
-        loss += F.mse_loss(neg_out, torch.zeros_like(neg_out))
+        label = batch.dynamic_node_feats
+        if label is None:
+            continue
+        pred, h_0, c_0 = model(batch, node_feat, h_0, c_0)
+        loss = criterion(pred, label)
         loss.backward()
         opt.step()
         total_loss += float(loss)
@@ -124,29 +125,34 @@ def train(
 def eval(
     loader: DGDataLoader,
     model: nn.Module,
-    metrics: Metric,
     node_feat: torch.Tensor,
     h_0: torch.Tensor | None = None,
     c_0: torch.Tensor | None = None,
 ) -> Tuple[dict, torch.Tensor, torch.Tensor]:
     model.eval()
+    eval_metric = 'ndcg'
+    total_score = 0
     for batch in tqdm(loader):
         # TODO: Consider skipping empty batches natively, when iterating by time (instead of events)
         if not len(batch.src):
             continue
-
-        pos_out, neg_out, h_0, c_0 = model(batch, node_feat, h_0, c_0)
-        y_pred = torch.cat([pos_out, neg_out], dim=0).float()
-        y_true = (
-            torch.cat(
-                [torch.ones(pos_out.size(0)), torch.zeros(neg_out.size(0))], dim=0
-            )
-            .long()
-            .to(y_pred.device)
-        )
-        indexes = torch.zeros(y_pred.size(0), dtype=torch.long, device=y_pred.device)
-        metrics(y_pred, y_true, indexes=indexes)
-    return metrics.compute(), h_0, c_0
+        label = batch.dynamic_node_feats
+        if label is None:
+            continue
+        pred, h_0, c_0 = model(batch, node_feat, h_0, c_0)
+        np_pred = pred.cpu().detach().numpy()
+        np_true = label.cpu().detach().numpy()
+        input_dict = {
+            'y_true': np_true,
+            'y_pred': np_pred,
+            'eval_metric': [eval_metric],
+        }
+        result_dict = evaluator.eval(input_dict)
+        score = result_dict[eval_metric]
+        total_score += score
+    metric_dict = {}
+    metric_dict[eval_metric] = float(total_score) / len(loader)
+    return metric_dict, h_0, c_0
 
 
 args = parser.parse_args()
@@ -171,37 +177,30 @@ test_dg = DGraph(
     device=args.device,
 )
 
+num_nodes = DGraph(args.dataset).num_nodes
+label_dim = train_dg.dynamic_node_feats_dim
+evaluator = Evaluator(name=args.dataset)
+
 train_loader = DGDataLoader(
     train_dg,
-    hook=NegativeEdgeSamplerHook(low=0, high=train_dg.num_nodes),
     batch_unit=args.batch_time_gran,
 )
 val_loader = DGDataLoader(
     val_dg,
-    hook=NegativeEdgeSamplerHook(low=0, high=val_dg.num_nodes),
     batch_unit=args.batch_time_gran,
 )
 test_loader = DGDataLoader(
     test_dg,
-    hook=NegativeEdgeSamplerHook(low=0, high=test_dg.num_nodes),
     batch_unit=args.batch_time_gran,
 )
-
-if train_dg.dynamic_node_feats is not None:
-    raise ValueError(
-        'node features are not supported yet, make sure to incorporate them in the model'
-    )
 
 # TODO: add static node features to DGraph
 args.node_dim = args.embed_dim
 static_node_feats = torch.randn((test_dg.num_nodes, args.node_dim), device=args.device)
-
-model = GCLSTM_Model(node_dim=args.node_dim, embed_dim=args.embed_dim).to(args.device)
-
+model = GCLSTM_Model(
+    node_dim=args.node_dim, embed_dim=args.embed_dim, num_classes=label_dim
+).to(args.device)
 opt = torch.optim.Adam(model.parameters(), lr=float(args.lr))
-metrics = [BinaryAveragePrecision(), BinaryAUROC()]
-val_metrics = MetricCollection(metrics, prefix='Validation')
-test_metrics = MetricCollection(metrics, prefix='Test')
 
 for epoch in range(1, args.epochs + 1):
     start_time = time.perf_counter()
@@ -209,15 +208,12 @@ for epoch in range(1, args.epochs + 1):
     end_time = time.perf_counter()
     latency = end_time - start_time
 
-    val_results, h_0, c_0 = eval(
-        val_loader, model, val_metrics, static_node_feats, h_0, c_0
-    )
-    val_metrics.reset()
+    val_results, h_0, c_0 = eval(val_loader, model, static_node_feats, h_0, c_0)
 
     print(
         f'Epoch={epoch:02d} Latency={latency:.4f} Loss={loss:.4f} '
-        + ' '.join(f'{k}={v.item():.4f}' for k, v in val_results.items())
+        + ' '.join(f'{k}={v:.4f}' for k, v in val_results.items())
     )
 
-test_results, h_0, c_0 = eval(test_loader, model, test_metrics, static_node_feats)
-print(' '.join(f'{k}={v.item():.4f}' for k, v in test_results.items()))
+test_results, h_0, c_0 = eval(test_loader, model, static_node_feats, h_0, c_0)
+print(' '.join(f'{k}={v:.4f}' for k, v in test_results.items()))

--- a/examples/nodeproppred/gclstm.py
+++ b/examples/nodeproppred/gclstm.py
@@ -86,7 +86,7 @@ class RecurrentGCN(torch.nn.Module):
 
 
 class NodePredictor(torch.nn.Module):
-    def __init__(self, in_dim, out_dim):
+    def __init__(self, in_dim: int, out_dim: int) -> None:
         super().__init__()
         self.lin_node = nn.Linear(in_dim, in_dim)
         self.out = nn.Linear(in_dim, out_dim)

--- a/examples/nodeproppred/gclstm.py
+++ b/examples/nodeproppred/gclstm.py
@@ -1,3 +1,8 @@
+r"""python -u gclstm.py --dataset tgbn-trade --time-gran r --batch-time-gran r
+python -u gclstm.py --dataset tgbn-genre --time-gran s --batch-time-gran D\
+example commands to run this script.
+"""
+
 import argparse
 import time
 from typing import Tuple

--- a/examples/nodeproppred/gcn.py
+++ b/examples/nodeproppred/gcn.py
@@ -1,3 +1,8 @@
+"""python -u gcn.py --dataset tgbn-trade --time-gran r --batch-time-gran r
+python -u gcn.py --dataset tgbn-genre --time-gran s --batch-time-gran D
+.
+"""
+
 import argparse
 import time
 from typing import Tuple
@@ -28,6 +33,12 @@ parser.add_argument('--n-layers', type=int, default=2, help='number of GCN layer
 parser.add_argument('--embed-dim', type=int, default=128, help='embedding dimension')
 parser.add_argument(
     '--time-gran',
+    type=str,
+    default='s',
+    help='raw time granularity for dataset',
+)
+parser.add_argument(
+    '--batch-time-gran',
     type=str,
     default='D',
     help='time granularity to operate on for snapshots',
@@ -172,7 +183,7 @@ def eval(
         score = result_dict[eval_metric]
         total_score += score
     metric_dict = {}
-    metric_dict[eval_metric] = total_score / len(loader)
+    metric_dict[eval_metric] = float(total_score) / len(loader)
     return metric_dict
 
 
@@ -180,31 +191,42 @@ args = parser.parse_args()
 seed_everything(args.seed)
 
 train_dg = DGraph(
-    args.dataset, time_delta=TimeDeltaDG('s'), split='train', device=args.device
+    args.dataset,
+    time_delta=TimeDeltaDG(args.time_gran),
+    split='train',
+    device=args.device,
 )
 val_dg = DGraph(
-    args.dataset, time_delta=TimeDeltaDG('s'), split='val', device=args.device
+    args.dataset,
+    time_delta=TimeDeltaDG(args.time_gran),
+    split='val',
+    device=args.device,
 )
 test_dg = DGraph(
-    args.dataset, time_delta=TimeDeltaDG('s'), split='test', device=args.device
+    args.dataset,
+    time_delta=TimeDeltaDG(args.time_gran),
+    split='test',
+    device=args.device,
 )
 
-num_nodes = DGraph(args.dataset).num_nodes
+dgraph = DGraph(args.dataset)
+num_nodes = dgraph.num_nodes
+print(dgraph.start_time, dgraph.end_time, num_nodes)
 label_dim = train_dg.dynamic_node_feats_dim
 evaluator = Evaluator(name=args.dataset)
 
 
 train_loader = DGDataLoader(
     train_dg,
-    batch_unit=args.time_gran,
+    batch_unit=args.batch_time_gran,
 )
 val_loader = DGDataLoader(
     val_dg,
-    batch_unit=args.time_gran,
+    batch_unit=args.batch_time_gran,
 )
 test_loader = DGDataLoader(
     test_dg,
-    batch_unit=args.time_gran,
+    batch_unit=args.batch_time_gran,
 )
 
 if train_dg.static_node_feats is not None:
@@ -235,8 +257,8 @@ for epoch in range(1, args.epochs + 1):
     val_results = eval(val_loader, model, static_node_feats, evaluator)
     print(
         f'Epoch={epoch:02d} Latency={latency:.4f} Loss={loss:.4f} '
-        + ' '.join(f'{k}={v.item():.4f}' for k, v in val_results.items())
+        + ' '.join(f'{k}={v:.4f}' for k, v in val_results.items())
     )
 
 test_results = eval(test_loader, model, static_node_feats, evaluator)
-print(' '.join(f'{k}={v.item():.4f}' for k, v in test_results.items()))
+print(' '.join(f'{k}={v:.4f}' for k, v in test_results.items()))

--- a/examples/nodeproppred/gcn.py
+++ b/examples/nodeproppred/gcn.py
@@ -1,6 +1,6 @@
-"""python -u gcn.py --dataset tgbn-trade --time-gran r --batch-time-gran r
+r"""python -u gcn.py --dataset tgbn-trade --time-gran r --batch-time-gran r
 python -u gcn.py --dataset tgbn-genre --time-gran s --batch-time-gran D
-.
+example commands to run this script.
 """
 
 import argparse
@@ -211,11 +211,8 @@ test_dg = DGraph(
 
 dgraph = DGraph(args.dataset)
 num_nodes = dgraph.num_nodes
-print(dgraph.start_time, dgraph.end_time, num_nodes)
 label_dim = train_dg.dynamic_node_feats_dim
 evaluator = Evaluator(name=args.dataset)
-
-
 train_loader = DGDataLoader(
     train_dg,
     batch_unit=args.batch_time_gran,

--- a/tgm/_storage/backends/array_backend.py
+++ b/tgm/_storage/backends/array_backend.py
@@ -159,7 +159,7 @@ class DGStorageArrayBackend(DGStorageBase):
         edge_mask = (self._data.edge_event_idx >= lb_idx) & (
             self._data.edge_event_idx < ub_idx
         )
-        if edge_mask.sum() != 0 and self._data.edge_index[edge_mask].numel() > 0:
+        if edge_mask.sum() != 0 and len(self._data.edge_index[edge_mask]):
             max_node_id = max(max_node_id, self._data.edge_index[edge_mask].max())  # type: ignore
 
         max_time = slice.end_time or self._data.timestamps[ub_idx - 1]

--- a/tgm/_storage/backends/array_backend.py
+++ b/tgm/_storage/backends/array_backend.py
@@ -159,7 +159,7 @@ class DGStorageArrayBackend(DGStorageBase):
         edge_mask = (self._data.edge_event_idx >= lb_idx) & (
             self._data.edge_event_idx < ub_idx
         )
-        if edge_mask.sum() != 0:
+        if edge_mask.sum() != 0 and self._data.edge_index[edge_mask].numel() > 0:
             max_node_id = max(max_node_id, self._data.edge_index[edge_mask].max())  # type: ignore
 
         max_time = slice.end_time or self._data.timestamps[ub_idx - 1]
@@ -188,7 +188,8 @@ class DGStorageArrayBackend(DGStorageBase):
             node_mask = (self._data.node_event_idx >= lb_idx) & (
                 self._data.node_event_idx < ub_idx
             )
-            max_node_id = max(max_node_id, self._data.node_ids[node_mask].max())  # type: ignore
+            if self._data.node_ids[node_mask].numel() > 0:  # type: ignore
+                max_node_id = max(max_node_id, self._data.node_ids[node_mask].max())  # type: ignore
 
         max_time = slice.end_time or self._data.timestamps[ub_idx - 1]
         edge_feats_dim = self.get_edge_feats_dim()

--- a/tgm/_storage/backends/array_backend.py
+++ b/tgm/_storage/backends/array_backend.py
@@ -188,7 +188,7 @@ class DGStorageArrayBackend(DGStorageBase):
             node_mask = (self._data.node_event_idx >= lb_idx) & (
                 self._data.node_event_idx < ub_idx
             )
-            if self._data.node_ids[node_mask].numel() > 0:  # type: ignore
+            if len(self._data.node_ids[node_mask]):  # type: ignore
                 max_node_id = max(max_node_id, self._data.node_ids[node_mask].max())  # type: ignore
 
         max_time = slice.end_time or self._data.timestamps[ub_idx - 1]

--- a/tgm/data.py
+++ b/tgm/data.py
@@ -406,7 +406,6 @@ class DGData:
 
             num_node_events = 0
             node_label_dim = 0
-            split_start, split_end = timestamps[0], timestamps[-1]
             for t in node_label_dict:
                 for node_id, label in node_label_dict[t].items():
                     num_node_events += 1

--- a/tgm/data.py
+++ b/tgm/data.py
@@ -402,10 +402,12 @@ class DGData:
 
             num_node_events = 0
             node_label_dim = 0
+            split_start, split_end = timestamps[0], timestamps[-1]
             for t in node_label_dict:
-                for node_id, label in node_label_dict[t].items():
-                    num_node_events += 1
-                    node_label_dim = label.shape[0]
+                if (t >= split_start) and (t < split_end):
+                    for node_id, label in node_label_dict[t].items():
+                        num_node_events += 1
+                        node_label_dim = label.shape[0]
             temp_node_timestamps = np.zeros(num_node_events, dtype=np.int64)
             temp_node_ids = np.zeros(num_node_events, dtype=np.int64)
             temp_dynamic_node_feats = np.zeros(
@@ -413,11 +415,12 @@ class DGData:
             )
             idx = 0
             for t in node_label_dict:
-                for node_id, label in node_label_dict[t].items():
-                    temp_node_timestamps[idx] = t
-                    temp_node_ids[idx] = node_id
-                    temp_dynamic_node_feats[idx] = label
-                    idx += 1
+                if (t >= split_start) and (t < split_end):
+                    for node_id, label in node_label_dict[t].items():
+                        temp_node_timestamps[idx] = t
+                        temp_node_ids[idx] = node_id
+                        temp_dynamic_node_feats[idx] = label
+                        idx += 1
             node_timestamps = torch.from_numpy(temp_node_timestamps).long()
             node_ids = torch.from_numpy(temp_node_ids).long()
             dynamic_node_feats = torch.from_numpy(temp_dynamic_node_feats).float()

--- a/tgm/data.py
+++ b/tgm/data.py
@@ -396,7 +396,11 @@ class DGData:
         node_timestamps, node_ids, dynamic_node_feats = None, None, None
         if name.startswith('tgbn-'):
             if 'node_label_dict' in data:
-                node_label_dict = data['node_label_dict']
+                node_label_dict = {
+                    t: v
+                    for t, v in data['node_label_dict'].items()
+                    if timestamps[0] <= t < timestamps[-1]
+                }
             else:
                 raise ValueError('please update your tgb package or install by source')
 
@@ -404,10 +408,9 @@ class DGData:
             node_label_dim = 0
             split_start, split_end = timestamps[0], timestamps[-1]
             for t in node_label_dict:
-                if (t >= split_start) and (t < split_end):
-                    for node_id, label in node_label_dict[t].items():
-                        num_node_events += 1
-                        node_label_dim = label.shape[0]
+                for node_id, label in node_label_dict[t].items():
+                    num_node_events += 1
+                    node_label_dim = label.shape[0]
             temp_node_timestamps = np.zeros(num_node_events, dtype=np.int64)
             temp_node_ids = np.zeros(num_node_events, dtype=np.int64)
             temp_dynamic_node_feats = np.zeros(
@@ -415,12 +418,11 @@ class DGData:
             )
             idx = 0
             for t in node_label_dict:
-                if (t >= split_start) and (t < split_end):
-                    for node_id, label in node_label_dict[t].items():
-                        temp_node_timestamps[idx] = t
-                        temp_node_ids[idx] = node_id
-                        temp_dynamic_node_feats[idx] = label
-                        idx += 1
+                for node_id, label in node_label_dict[t].items():
+                    temp_node_timestamps[idx] = t
+                    temp_node_ids[idx] = node_id
+                    temp_dynamic_node_feats[idx] = label
+                    idx += 1
             node_timestamps = torch.from_numpy(temp_node_timestamps).long()
             node_ids = torch.from_numpy(temp_node_ids).long()
             dynamic_node_feats = torch.from_numpy(temp_dynamic_node_feats).float()


### PR DESCRIPTION
Running into error when running the example
```
python -u gcn.py --dataset tgbn-trade --time-gran r --batch-time-gran r
python -u gcn.py --dataset tgbn-genre --time-gran s --batch-time-gran D
```

- `tgbn-trade` is a yearly trade datasets
`start_time`= 1986 
`end_time`= 2016
`python -u gcn.py --dataset tgbn-trade --time-gran r --batch-time-gran r` 

- `tgbn-genre` is a second wise dataset with snapshots / labels daily
`start_time`= 1108357203
`end_time`= 1245461220
`python -u gcn.py --dataset tgbn-genre --time-gran s --batch-time-gran D` 


- [x] fixed error with not using splits in TGB node prop pred datasets
- [x] added GCLSTM example in nodeproppred achieving `0.4985` NDCG (a few epochs)
- [x] updated GCN example in nodeproppred achieving `0.3164` NDCG (a few epochs)
- [x] fixing error where if some snapshots are missing dynamic node feature, the dataloader wouldn't work