### PR TITLE
Deduplication Batch Index Hook

### DIFF
--- a/examples/linkproppred/gclstm.py
+++ b/examples/linkproppred/gclstm.py
@@ -50,7 +50,7 @@ class GCLSTM_Model(nn.Module):
         edge_index = torch.stack([batch.src, batch.dst], dim=0)
         edge_weight = batch.edge_weight if hasattr(batch, 'edge_weight') else None  # type: ignore
         z, h_0, c_0 = self.encoder(node_feat, edge_index, edge_weight, h_0, c_0)
-        z_src, z_dst, z_neg = z[batch.src], z[batch.dst], z[batch.neg]  # type: ignore
+        z_src, z_dst, z_neg = z[batch.src_idx], z[batch.dst_idx], z[batch.neg_idx]  # type: ignore
         pos_out = self.decoder(z_src, z_dst)
         neg_out = self.decoder(z_src, z_neg)
         return pos_out, neg_out, h_0, c_0

--- a/examples/linkproppred/gcn.py
+++ b/examples/linkproppred/gcn.py
@@ -60,7 +60,7 @@ class GCN(nn.Module):
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         edge_index = torch.stack([batch.src, batch.dst], dim=0)
         z = self.encoder(node_feat, edge_index)
-        z_src, z_dst, z_neg = z[batch.src], z[batch.dst], z[batch.neg]  # type: ignore
+        z_src, z_dst, z_neg = z[batch.src_idx], z[batch.dst_idx], z[batch.neg_idx]  # type: ignore
         pos_out = self.decoder(z_src, z_dst)
         neg_out = self.decoder(z_src, z_neg)
         return pos_out, neg_out

--- a/examples/linkproppred/graphmixer.py
+++ b/examples/linkproppred/graphmixer.py
@@ -116,7 +116,7 @@ class GraphMixer(nn.Module):
 
         # Link Decoder
         z = self.output_layer(torch.cat([z_link, z_node], dim=1))
-        z_src, z_dst, z_neg = z.chunk(3, dim=0)
+        z_src, z_dst, z_neg = z[batch.src_idx], z[batch.dst_idx], z[batch.neg_idx]  # type: ignore
         pos_out = self.link_predictor(z_src, z_dst)
         neg_out = self.link_predictor(z_src, z_neg)
         return pos_out, neg_out

--- a/examples/linkproppred/tgat.py
+++ b/examples/linkproppred/tgat.py
@@ -96,7 +96,7 @@ class TGAT(nn.Module):
             edge_feat=batch.nbr_feats[hop],
             nbr_mask=batch.nbr_mask[hop],
         )
-        z_src, z_dst, z_neg = z.chunk(3, dim=0)
+        z_src, z_dst, z_neg = z[batch.src_idx], z[batch.dst_idx], z[batch.neg_idx]  # type: ignore
         pos_out = self.link_predictor(z_src, z_dst)
         neg_out = self.link_predictor(z_src, z_neg)
         return pos_out, neg_out

--- a/examples/linkproppred/tgn.py
+++ b/examples/linkproppred/tgn.py
@@ -289,7 +289,7 @@ class GraphAttentionEmbedding(nn.Module):
             edge_feat=batch.nbr_feats[hop],
             nbr_mask=batch.nbr_mask[hop],
         )
-        z_src, z_dst, z_neg = z.chunk(3, dim=0)
+        z_src, z_dst, z_neg = z[batch.src_idx], z[batch.dst_idx], z[batch.neg_idx]  # type: ignore
         pos_out = self.link_predictor(z_src, z_dst)
         neg_out = self.link_predictor(z_src, z_neg)
         return pos_out, neg_out

--- a/examples/nodeproppred/gclstm.py
+++ b/examples/nodeproppred/gclstm.py
@@ -60,7 +60,7 @@ class GCLSTM_Model(nn.Module):
         edge_index = torch.stack([batch.src, batch.dst], dim=0)
         edge_weight = batch.edge_weight if hasattr(batch, 'edge_weight') else None  # type: ignore
         z, h_0, c_0 = self.encoder(node_feat, edge_index, edge_weight, h_0, c_0)
-        z_node = z[batch.node_ids]
+        z_node = z[batch.nid_to_idx[batch.node_ids]]  # type: ignore
         pred = self.decoder(z_node)
         return pred, h_0, c_0
 

--- a/examples/nodeproppred/gcn.py
+++ b/examples/nodeproppred/gcn.py
@@ -59,7 +59,7 @@ class GCN(nn.Module):
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         edge_index = torch.stack([batch.src, batch.dst], dim=0).to(node_feat.device)
         z = self.encoder(node_feat, edge_index)
-        z_node = z[batch.node_ids]
+        z_node = z[batch.nid_to_idx[batch.node_ids]]  # type: ignore
         pred = self.decoder(z_node)
         return pred
 

--- a/test/test_hooks/test_deduplication_hook.py
+++ b/test/test_hooks/test_deduplication_hook.py
@@ -1,0 +1,39 @@
+import pytest
+import torch
+
+from tgm.data import DGData
+from tgm.hooks import DeduplicationHook
+
+
+@pytest.fixture
+def data():
+    edge_index = torch.LongTensor([[2, 2], [2, 4], [1, 8]])
+    edge_timestamps = torch.LongTensor([1, 5, 20])
+    return DGData.from_raw(edge_timestamps, edge_index)
+
+
+def test_hook_dependancies():
+    assert DeduplicationHook.requires == set()
+    assert DeduplicationHook.produces == {
+        'unique_nids',
+        'nid_to_idx',
+        'src_idx',
+        'dst_idx',
+        'neg_idx',
+        'nbr_nids_idx',
+    }
+
+
+def test_dedup():
+    pass
+
+
+def test_dedup_with_negatives():
+    # dg = DGraph(data)
+    # hook = NegativeEdgeSamplerHook(low=0, high=10)
+    # batch = hook(dg, dg.materialize())
+    pass
+
+
+def test_dedup_with_nbrs():
+    pass

--- a/test/test_hooks/test_deduplication_hook.py
+++ b/test/test_hooks/test_deduplication_hook.py
@@ -65,6 +65,7 @@ def test_dedup_with_nbrs(dg):
         torch.LongTensor([1, 5]),  # First hop
         torch.LongTensor([10]),  # Second hop
     ]
+    batch.nbr_mask = [torch.LongTensor([1, 1]), torch.LongTensor([1])]
 
     processed_batch = hook(dg, batch)
     torch.testing.assert_close(

--- a/test/test_hooks/test_deduplication_hook.py
+++ b/test/test_hooks/test_deduplication_hook.py
@@ -2,14 +2,16 @@ import pytest
 import torch
 
 from tgm.data import DGData
+from tgm.graph import DGraph
 from tgm.hooks import DeduplicationHook
 
 
 @pytest.fixture
-def data():
+def dg():
     edge_index = torch.LongTensor([[2, 2], [2, 4], [1, 8]])
     edge_timestamps = torch.LongTensor([1, 5, 20])
-    return DGData.from_raw(edge_timestamps, edge_index)
+    data = DGData.from_raw(edge_timestamps, edge_index)
+    return DGraph(data)
 
 
 def test_hook_dependancies():
@@ -24,16 +26,57 @@ def test_hook_dependancies():
     }
 
 
-def test_dedup():
-    pass
+def test_dedup(dg):
+    hook = DeduplicationHook()
+    batch = dg.materialize()
+    processed_batch = hook(dg, batch)
+    torch.testing.assert_close(
+        processed_batch.unique_nids, torch.LongTensor([1, 2, 4, 8])
+    )
+    torch.testing.assert_close(
+        processed_batch.nid_to_idx, torch.LongTensor([-1, 0, 1, -1, 2, -1, -1, -1, 3])
+    )
+    torch.testing.assert_close(processed_batch.src_idx, torch.LongTensor([1, 1, 0]))
+    torch.testing.assert_close(processed_batch.dst_idx, torch.LongTensor([1, 2, 3]))
 
 
-def test_dedup_with_negatives():
-    # dg = DGraph(data)
-    # hook = NegativeEdgeSamplerHook(low=0, high=10)
-    # batch = hook(dg, dg.materialize())
-    pass
+def test_dedup_with_negatives(dg):
+    hook = DeduplicationHook()
+    batch = dg.materialize()
+    batch.neg = torch.LongTensor([1, 5, 10])  # add some mock negatives
+
+    processed_batch = hook(dg, batch)
+    torch.testing.assert_close(
+        processed_batch.unique_nids, torch.LongTensor([1, 2, 4, 5, 8, 10])
+    )
+    torch.testing.assert_close(
+        processed_batch.nid_to_idx,
+        torch.LongTensor([-1, 0, 1, -1, 2, 3, -1, -1, 4, -1, 5]),
+    )
+    torch.testing.assert_close(processed_batch.src_idx, torch.LongTensor([1, 1, 0]))
+    torch.testing.assert_close(processed_batch.dst_idx, torch.LongTensor([1, 2, 4]))
+    torch.testing.assert_close(processed_batch.neg_idx, torch.LongTensor([0, 3, 5]))
 
 
-def test_dedup_with_nbrs():
-    pass
+def test_dedup_with_nbrs(dg):
+    hook = DeduplicationHook()
+    batch = dg.materialize()
+    batch.nbr_nids = [  # add some mock neighbours
+        torch.LongTensor([1, 5]),  # First hop
+        torch.LongTensor([10]),  # Second hop
+    ]
+
+    processed_batch = hook(dg, batch)
+    torch.testing.assert_close(
+        processed_batch.unique_nids, torch.LongTensor([1, 2, 4, 5, 8, 10])
+    )
+    torch.testing.assert_close(
+        processed_batch.nid_to_idx,
+        torch.LongTensor([-1, 0, 1, -1, 2, 3, -1, -1, 4, -1, 5]),
+    )
+    torch.testing.assert_close(processed_batch.src_idx, torch.LongTensor([1, 1, 0]))
+    torch.testing.assert_close(processed_batch.dst_idx, torch.LongTensor([1, 2, 4]))
+    torch.testing.assert_close(
+        processed_batch.nbr_nids_idx[0], torch.LongTensor([0, 3])
+    )
+    torch.testing.assert_close(processed_batch.nbr_nids_idx[1], torch.LongTensor([5]))

--- a/tgm/hooks.py
+++ b/tgm/hooks.py
@@ -138,14 +138,12 @@ class DeduplicationHook:
         if hasattr(batch, 'neg'):
             batch.neg_idx = nid_to_idx[batch.neg]  # type: ignore
         if hasattr(batch, 'nbr_nids'):
-            # TODO: Account for nbr masks
-            batch.nbr_nids_idx = [nid_to_idx[hop_nids] for hop_nids in batch.nbr_nids]  # type: ignore
-            # batch.nbr_nids_idx = [
-            #    torch.where(
-            #        hop_mask.bool(), nid_to_idx[hop_nids], torch.full_like(hop_nids, -1)
-            #    )
-            #    for hop_nids, hop_mask in zip(batch.nbr_nids, batch.nbr_mask)
-            # ]
+            batch.nbr_nids_idx = []  # type: ignore
+            for hop in range(len(batch.nbr_nids)):
+                hop_nids, hop_mask = batch.nbr_nids[hop], batch.nbr_mask[hop].bool()  # type: ignore
+                nbr_nids_idx = torch.full_like(hop_nids, -1)
+                nbr_nids_idx[hop_mask] = nid_to_idx[hop_nids[hop_mask]]
+                batch.nbr_nids_idx.append(nbr_nids_idx)  # type: ignore
 
         return batch
 


### PR DESCRIPTION
Close #32 

High-level usage:
```python

# Just do inference on unique ids
z = model(batch.unique_nids) 

# Use *_idx fields to lookup the relevant embeddings
src_z = z[batch.src_idx]
dst_z = z[batch.dst_idx]

# These are optional fields that are added if using negative sampler or nbr sampler, respectively
neg_z = z[batch.neg_idx] if hasattr(batch, 'neg') else None
nbr_z = [z[idx] for idx in batch.nbr_nids_idx] if hasattr(batch, 'nbr_nids') else None

# If you got custom hooks and want to just get the embeddings for some arbitrary node tensors (e.g. tgb)
query_ids: torch.Tensor = ...
z_query_ids = z[batch.nid_to_idx[query_ids]]
```