### PR TITLE
Fix TGAT Attention Bug

### DIFF
--- a/examples/linkproppred/tgat.py
+++ b/examples/linkproppred/tgat.py
@@ -116,9 +116,6 @@ class TGAT(nn.Module):
             )
             z[batch.nid_to_idx[batch.nids[hop]]] = out
 
-            # TODO: Merge layers to combine attention results and node original features
-            # z = self.merge_layers[hop](out, node_feat)
-
         z_src, z_dst, z_neg = z[batch.src_idx], z[batch.dst_idx], z[batch.neg_idx]  # type: ignore
         pos_out = self.link_predictor(z_src, z_dst)
         neg_out = self.link_predictor(z_src, z_neg)

--- a/tgm/_storage/backends/array_backend.py
+++ b/tgm/_storage/backends/array_backend.py
@@ -98,8 +98,8 @@ class DGStorageArrayBackend(DGStorageBase):
 
         # TODO: Node feats
         batch_size = len(seed_nodes)
-        nbr_nids = torch.empty(batch_size, n_nbrs, dtype=torch.long)
-        nbr_times = torch.empty(batch_size, n_nbrs, dtype=torch.long)
+        nbr_nids = torch.zeros(batch_size, n_nbrs, dtype=torch.long)
+        nbr_times = torch.zeros(batch_size, n_nbrs, dtype=torch.long)
         nbr_feats = torch.zeros(batch_size, n_nbrs, self.get_edge_feats_dim())  # type: ignore
         nbr_mask = torch.zeros(batch_size, n_nbrs, dtype=torch.long)
         for i, nbrs_set in enumerate(nbrs.values()):

--- a/tgm/hooks.py
+++ b/tgm/hooks.py
@@ -316,9 +316,9 @@ class RecencyNeighborHook:
                 seed_times = batch.nbr_times[hop - 1][mask].flatten()  # type: ignore
 
             B = len(seed_nodes)
-            nbr_nids = torch.empty(B, num_nbrs, dtype=torch.long, device=device)
-            nbr_times = torch.empty(B, num_nbrs, dtype=torch.long, device=device)
-            nbr_feats = torch.empty(B, num_nbrs, dg.edge_feats_dim, device=device)  # type: ignore
+            nbr_nids = torch.zeros(B, num_nbrs, dtype=torch.long, device=device)
+            nbr_times = torch.zeros(B, num_nbrs, dtype=torch.long, device=device)
+            nbr_feats = torch.zeros(B, num_nbrs, dg.edge_feats_dim, device=device)  # type: ignore
             nbr_mask = torch.zeros(B, num_nbrs, dtype=torch.long, device=device)
 
             unique, inv_idx = seed_nodes.unique(return_inverse=True)


### PR DESCRIPTION
# Purpose
When running multi-hop sampling, there will often be times when the nbr mask is (partially) full. The temporal multi-head attention module will take this mask into account when computing the attention tensor: https://github.com/tgm-team/tgm/blob/5b4949e5cb06b5fe94e8f292b9412c908d7f0795/tgm/nn/attention.py#L64-L76

But the key value heads propagate the features as is: https://github.com/tgm-team/tgm/blob/5b4949e5cb06b5fe94e8f292b9412c908d7f0795/tgm/nn/attention.py#L54-L57

Since nbr tensors are initialized with `torch.empty()` these garbage values mess with network gradients and lead to `nans`.

## Solution
Safely initialize all features with `torch.zeros`.

## Relevant Prs
Close #52 