### PR TITLE
Change module scope

### DIFF
--- a/examples/linkproppred/TGB/edgebank.py
+++ b/examples/linkproppred/TGB/edgebank.py
@@ -6,7 +6,7 @@ from tgb.linkproppred.dataset_pyg import PyGLinkPropPredDataset
 from tgb.linkproppred.evaluate import Evaluator
 from tqdm import tqdm
 
-from tgm.graph import DGraph
+from tgm import DGraph
 from tgm.hooks import TGBNegativeEdgeSamplerHook
 from tgm.loader import DGDataLoader
 from tgm.nn import EdgeBankPredictor

--- a/examples/linkproppred/edgebank.py
+++ b/examples/linkproppred/edgebank.py
@@ -5,7 +5,7 @@ from torchmetrics import Metric, MetricCollection
 from torchmetrics.classification import BinaryAUROC, BinaryAveragePrecision
 from tqdm import tqdm
 
-from tgm.graph import DGraph
+from tgm import DGraph
 from tgm.hooks import NegativeEdgeSamplerHook
 from tgm.loader import DGDataLoader
 from tgm.nn import EdgeBankPredictor

--- a/examples/linkproppred/gclstm.py
+++ b/examples/linkproppred/gclstm.py
@@ -9,7 +9,7 @@ from torchmetrics import Metric, MetricCollection
 from torchmetrics.classification import BinaryAUROC, BinaryAveragePrecision
 from tqdm import tqdm
 
-from tgm.graph import DGBatch, DGraph
+from tgm import DGBatch, DGraph
 from tgm.hooks import NegativeEdgeSamplerHook
 from tgm.loader import DGDataLoader
 from tgm.nn.recurrent import GCLSTM

--- a/examples/linkproppred/gcn.py
+++ b/examples/linkproppred/gcn.py
@@ -10,7 +10,7 @@ from torchmetrics import Metric, MetricCollection
 from torchmetrics.classification import BinaryAUROC, BinaryAveragePrecision
 from tqdm import tqdm
 
-from tgm.graph import DGBatch, DGraph
+from tgm import DGBatch, DGraph
 from tgm.hooks import NegativeEdgeSamplerHook
 from tgm.loader import DGDataLoader
 from tgm.timedelta import TimeDeltaDG

--- a/examples/linkproppred/graphmixer.py
+++ b/examples/linkproppred/graphmixer.py
@@ -10,7 +10,7 @@ from torchmetrics import Metric, MetricCollection
 from torchmetrics.classification import BinaryAUROC, BinaryAveragePrecision
 from tqdm import tqdm
 
-from tgm.graph import DGBatch, DGraph
+from tgm import DGBatch, DGraph
 from tgm.hooks import DGHook, NegativeEdgeSamplerHook, RecencyNeighborHook
 from tgm.loader import DGDataLoader
 from tgm.nn import Time2Vec

--- a/examples/linkproppred/tgat.py
+++ b/examples/linkproppred/tgat.py
@@ -9,7 +9,7 @@ from torchmetrics import Metric, MetricCollection
 from torchmetrics.classification import BinaryAUROC, BinaryAveragePrecision
 from tqdm import tqdm
 
-from tgm.graph import DGBatch, DGraph
+from tgm import DGBatch, DGraph
 from tgm.hooks import (
     DGHook,
     NegativeEdgeSamplerHook,

--- a/examples/linkproppred/tgn.py
+++ b/examples/linkproppred/tgn.py
@@ -11,7 +11,7 @@ from torchmetrics import Metric, MetricCollection
 from torchmetrics.classification import BinaryAUROC, BinaryAveragePrecision
 from tqdm import tqdm
 
-from tgm.graph import DGBatch, DGraph
+from tgm import DGBatch, DGraph
 from tgm.hooks import (
     DGHook,
     NegativeEdgeSamplerHook,

--- a/examples/nodeproppred/gclstm.py
+++ b/examples/nodeproppred/gclstm.py
@@ -13,7 +13,7 @@ import torch.nn.functional as F
 from tgb.nodeproppred.evaluate import Evaluator
 from tqdm import tqdm
 
-from tgm.graph import DGBatch, DGraph
+from tgm import DGBatch, DGraph
 from tgm.loader import DGDataLoader
 from tgm.nn.recurrent import GCLSTM
 from tgm.timedelta import TimeDeltaDG

--- a/examples/nodeproppred/gcn.py
+++ b/examples/nodeproppred/gcn.py
@@ -14,7 +14,7 @@ from tgb.nodeproppred.evaluate import Evaluator
 from torch_geometric.nn import GCNConv
 from tqdm import tqdm
 
-from tgm.graph import DGBatch, DGraph
+from tgm import DGBatch, DGraph
 from tgm.loader import DGDataLoader
 from tgm.timedelta import TimeDeltaDG
 from tgm.util.seed import seed_everything

--- a/test/test_dataloader.py
+++ b/test/test_dataloader.py
@@ -1,8 +1,8 @@
 import pytest
 import torch
 
+from tgm import DGBatch, DGraph
 from tgm.data import DGData
-from tgm.graph import DGBatch, DGraph
 from tgm.loader import DGDataLoader
 from tgm.timedelta import TimeDeltaDG
 from tgm.util.seed import seed_everything

--- a/test/test_dgraph.py
+++ b/test/test_dgraph.py
@@ -4,8 +4,8 @@ from unittest.mock import patch
 import pytest
 import torch
 
+from tgm import DGBatch, DGraph
 from tgm.data import DGData
-from tgm.graph import DGBatch, DGraph
 
 
 @pytest.fixture

--- a/test/test_hooks/test_deduplication_hook.py
+++ b/test/test_hooks/test_deduplication_hook.py
@@ -1,8 +1,8 @@
 import pytest
 import torch
 
+from tgm import DGraph
 from tgm.data import DGData
-from tgm.graph import DGraph
 from tgm.hooks import DeduplicationHook
 
 

--- a/test/test_hooks/test_device_transfer_hook.py
+++ b/test/test_hooks/test_device_transfer_hook.py
@@ -1,8 +1,8 @@
 import pytest
 import torch
 
+from tgm import DGraph
 from tgm.data import DGData
-from tgm.graph import DGraph
 from tgm.hooks import DeviceTransferHook
 
 

--- a/test/test_hooks/test_hook_manager.py
+++ b/test/test_hooks/test_hook_manager.py
@@ -3,8 +3,8 @@ from typing import Set
 import pytest
 import torch
 
+from tgm import DGBatch, DGraph
 from tgm.data import DGData
-from tgm.graph import DGBatch, DGraph
 from tgm.hooks import DeduplicationHook, HookManager
 
 

--- a/test/test_hooks/test_negative_edge_sampler_hook.py
+++ b/test/test_hooks/test_negative_edge_sampler_hook.py
@@ -1,8 +1,8 @@
 import pytest
 import torch
 
+from tgm import DGBatch, DGraph
 from tgm.data import DGData
-from tgm.graph import DGBatch, DGraph
 from tgm.hooks import NegativeEdgeSamplerHook
 
 

--- a/test/test_hooks/test_neighbor_sampler_hook.py
+++ b/test/test_hooks/test_neighbor_sampler_hook.py
@@ -1,8 +1,8 @@
 import pytest
 import torch
 
+from tgm import DGBatch, DGraph
 from tgm.data import DGData
-from tgm.graph import DGBatch, DGraph
 from tgm.hooks import NeighborSamplerHook
 
 

--- a/test/test_hooks/test_pin_memory_hook.py
+++ b/test/test_hooks/test_pin_memory_hook.py
@@ -1,8 +1,8 @@
 import pytest
 import torch
 
+from tgm import DGraph
 from tgm.data import DGData
-from tgm.graph import DGraph
 from tgm.hooks import PinMemoryHook
 
 

--- a/test/test_hooks/test_recency_nbr_hook.py
+++ b/test/test_hooks/test_recency_nbr_hook.py
@@ -1,8 +1,8 @@
 import pytest
 import torch
 
+from tgm import DGBatch, DGraph
 from tgm.data import DGData
-from tgm.graph import DGBatch, DGraph
 from tgm.hooks import RecencyNeighborHook
 
 

--- a/test/test_hooks/test_tgb_negative_sampling_hook.py
+++ b/test/test_hooks/test_tgb_negative_sampling_hook.py
@@ -3,8 +3,8 @@ from unittest.mock import Mock
 import pytest
 import torch
 
+from tgm import DGBatch, DGraph
 from tgm.data import DGData
-from tgm.graph import DGBatch, DGraph
 from tgm.hooks import TGBNegativeEdgeSamplerHook
 
 

--- a/tgm/__init__.py
+++ b/tgm/__init__.py
@@ -1,7 +1,11 @@
 """TGM: Efficient and Modular ML on Dynamic Graphs."""
 
+from .graph import DGraph, DGBatch
+
 __version__ = '0.0.1-alpha'
 
 __all__ = [
     '__version__',
+    'DGraph',
+    'DGBatch',
 ]

--- a/tgm/hooks.py
+++ b/tgm/hooks.py
@@ -6,8 +6,8 @@ from typing import Any, Deque, Dict, List, Protocol, Set, runtime_checkable
 import numpy as np
 import torch
 
+from tgm import DGBatch, DGraph
 from tgm._storage import DGSliceTracker
-from tgm.graph import DGBatch, DGraph
 
 
 @runtime_checkable

--- a/tgm/loader.py
+++ b/tgm/loader.py
@@ -4,7 +4,7 @@ from typing import Any, List
 
 import torch
 
-from tgm.graph import DGBatch, DGraph
+from tgm import DGBatch, DGraph
 from tgm.hooks import DGHook, HookManager
 from tgm.timedelta import TimeDeltaDG
 


### PR DESCRIPTION
# Purpose
The purpose of this PR is to move `DGraph` and `DGBatch` into top level scope. This enables imports like:

```
from tgm import DGraph, DGBatch
```
which seems better (in the same was DataFrame and tensors are in top level pandas and pytorch scope, for instance).


## Key Changes
- Move `DGraph` and `DGBatch` into top level scope
- Changed all examples to use the new imports

### Things to keep in mind
- Kept hooks in their own module as they will likely soon be split into separate files
- Kept `DGDataLoader` in separate module similar to torch
- `DGData` is left as is since its mostly private (users can just construct DGraphs, not worry about internal IO)
- `TimeDeltaDG` is on the fence, but I will likely change `DGraph` constructor to take a string so that user never has to explicitly construct a time delta:

```python
DGraph('tgbl-wiki', 's') # instead of `DGraph('tgbl-wiki', TimeDeltaDG('s'))
```

## Relevant Prs
Close #40 