### PR TITLE
Set `torch-backend` for gpu drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,16 @@ pip install git+https://github.com/tgm-team/tgm.git
 python -c 'import tgm; print(tgm.__version__)'
 ```
 
+The steps above should work on Linux systems. We have not officially tested on other platforms, so expect additional steps may be required. If you encounter any issues on your system, please open an [issue](https://github.com/tgm-team/tgm/issues) and feel free [to discuss them with us](https://github.com/tgm-team/tgm/discussions).
+
+### Windows
+
+In order to enable GPU on non-linux platforms, you will need to manually install the appropriate torch wheels for your drivers. For instance, for *cuda:12.4*, follow the steps outlined above and then issue:
+
+```sh
+uv pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124
+```
+
 ## Quick Tour for New Users
 
 ![image](./docs/img/architecture-dark.svg#gh-dark-mode-only)

--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ pip install git+https://github.com/tgm-team/tgm.git
 python -c 'import tgm; print(tgm.__version__)'
 ```
 
-The steps above should work on Linux systems. We have not officially tested on other platforms, so expect additional steps may be required. If you encounter any issues on your system, please open an [issue](https://github.com/tgm-team/tgm/issues) and feel free [to discuss them with us](https://github.com/tgm-team/tgm/discussions).
+These steps should work on Linux systems. We have not officially tested on other platforms, so expect additional work may be required. If you encounter issues on your system, please open an [issue](https://github.com/tgm-team/tgm/issues) and feel free [to discuss them with us](https://github.com/tgm-team/tgm/discussions).
 
 ### Windows
 
-In order to enable GPU on non-linux platforms, you will need to manually install the appropriate torch wheels for your drivers. For instance, for *cuda:12.4*, follow the steps outlined above and then issue:
+To enable GPU on non-linux platforms, you will need to manually install the appropriate torch wheels for your drivers. For instance, for *cuda:12.4*, follow the steps above and then issue:
 
 ```sh
 uv pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu124

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 requires = ["flit_core >=3.2,<4"]
 build-backend = "flit_core.buildapi"
 
+[tool.uv.pip]
+torch-backend = "auto"
+
 [project]
 name = "tgm"
 version = "0.0.1-alpha"


### PR DESCRIPTION
# Purpose
The current `pyproject.toml` only specifies `torch >= 2.5.1` which defaults to cpu wheels. Nobody will care to run our library in CPU only mode, so the default should be to provide gpu support.


## Solution
The UV documentation suggests using the following (experimental) feature https://docs.astral.sh/uv/reference/settings/#pip_torch-backend, which:

> When set, uv will ignore the configured index URLs for packages in the PyTorch ecosystem, and will instead use the defined backend. For example, when set to cpu, uv will use the CPU-only PyTorch index; when set to cu126, uv will use the PyTorch index for CUDA 12.6.
> The auto mode will attempt to detect the appropriate PyTorch index based on the currently installed CUDA drivers.

I think this is reasonable
- If user has no gpu drivers configured, it should use cpu
- Otherwise, it should use the cuda wheel that matches your drivers

## Alternatives
- Explicitly force `torch == 2.5.1+cu121` so that all users have the same cuda-compatible version (needs care if their drivers are out of date, but completely reproducible with our code)
- Keep install cpu only, but add documentation that requires user to issue `uv pip install torch==2.5.1+cu121 --extra-index-url https://download.pytorch.org/whl/cu121`. Most generic but requires an extra command on the behalf of the user.
- Get people to just use our docker image and avoid these setup

**Note: Pypi only has cpu torch wheels, so when we publish there, we'll have to deal with this problem as well.**

## Relevant Prs
Fix #80 