### PR TITLE
Publish Workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,17 +1,22 @@
 name: Publish Python Package
 
 on: # yamllint disable-line rule:truthy
-  push:
-    tags:
-      - 'v*'  # Runs for tags like v0.1.0a0, v1.0.0
-
-permissions:
-  contents: read
+  workflow_dispatch:
+    inputs:
+      release:
+        description: "Set to 1 to publish to PyPI (leave blank for TestPyPI)"
+        required: false
+        default: "0"
 
 jobs:
   publish:
     name: Build and Publish
     runs-on: ubuntu-latest
+    # Require a v* tag and manual trigger
+    if: startsWith(github.ref, 'refs/tags/v') && github.ref_type == 'tag'
+    environment: pypi
+    permissions:
+      id-token: write  # Required for PyPI Trusted Publishing
 
     steps:
       - name: Checkout repository
@@ -27,8 +32,7 @@ jobs:
         run: curl -LsSf https://astral.sh/uv/${{ env.UV_VERSION }}/install.sh | sh
 
       - name: Check package metadata
-        run: |
-          uv version
+        run: uv version
 
       - name: Build the package
         run: uv build
@@ -38,15 +42,8 @@ jobs:
           echo "Verifying package installs and imports correctly..."
           uv run --with py-tgm --no-project -- python -c "import tgm; print(tgm.__version__)"
 
-      - name: Publish to TestPyPI (default)
-        if: ${{ !env.RELEASE }}
+      - name: Publish to PyPI or TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository-url: https://test.pypi.org/legacy/
-          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-
-      - name: Publish to PyPI
-        if: ${{ env.RELEASE }}
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
+          repository_url: >-
+            ${{ github.event.inputs.release == '1' && 'https://upload.pypi.org/legacy/' || 'https://test.pypi.org/legacy/' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,52 @@
+name: Publish Python Package
+
+on: # yamllint disable-line rule:truthy
+  push:
+    tags:
+      - 'v*'  # Runs for tags like v0.1.0a0, v1.0.0
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Build and Publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up python
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: ".python-version"
+
+      - name: Set up uv
+        run: curl -LsSf https://astral.sh/uv/${{ env.UV_VERSION }}/install.sh | sh
+
+      - name: Check package metadata
+        run: |
+          uv version
+
+      - name: Build the package
+        run: uv build
+
+      - name: Sanity check that package installs and imports
+        run: |
+          echo "Verifying package installs and imports correctly..."
+          uv run --with py-tgm --no-project -- python -c "import tgm; print(tgm.__version__)"
+
+      - name: Publish to TestPyPI (default)
+        if: ${{ !env.RELEASE }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+
+      - name: Publish to PyPI
+        if: ${{ env.RELEASE }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,8 +3,8 @@ name: Publish Python Package
 on: # yamllint disable-line rule:truthy
   push:
     tags:
-      - "v*" # Trigger only when a tag like v* is pushed
-  workflow_dispatch: # TODO: Remove this once TEST-PYPI publish is verified
+      - "v*" # Trigger on tags like v0.1.0 (PyPI)
+      - "test-v*" # Trigger ont ags like test-v0.1.0 (Test-PyPI)
 
 jobs:
   publish:
@@ -41,6 +41,5 @@ jobs:
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          # TODO: Switch this once TEST-PYPI publish is verified
-          repository-url: https://test.pypi.org/legacy/ # <-- TESTPYPI for testing
-          # Switch to https://upload.pypi.org/legacy/ when ready for PyPI
+          repository-url: >-
+            ${{ startsWith(github.ref_name, 'test-v') && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,19 +1,14 @@
 name: Publish Python Package
 
 on: # yamllint disable-line rule:truthy
-  workflow_dispatch:
-    inputs:
-      release:
-        description: "Set to 1 to publish to PyPI (leave blank for TestPyPI)"
-        required: false
-        default: "0"
+  push:
+    tags:
+      - "v*" # Trigger only when a tag like v* is pushed
 
 jobs:
   publish:
     name: Build and Publish
     runs-on: ubuntu-latest
-    # Require a v* tag and manual trigger
-    if: startsWith(github.ref, 'refs/tags/v') && github.ref_type == 'tag'
     environment: pypi
     permissions:
       id-token: write  # Required for PyPI Trusted Publishing
@@ -42,8 +37,8 @@ jobs:
           echo "Verifying package installs and imports correctly..."
           uv run --with tgm-lib --no-project -- python -c "import tgm; print(tgm.__version__)"
 
-      - name: Publish to PyPI or TestPyPI
+      - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository_url: >-
-            ${{ github.event.inputs.release == '1' && 'https://upload.pypi.org/legacy/' || 'https://test.pypi.org/legacy/' }}
+          repository-url: https://test.pypi.org/legacy/ # <-- TESTPYPI for testing
+          # Switch to https://upload.pypi.org/legacy/ when ready for PyPI

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Sanity check that package installs and imports
         run: |
           echo "Verifying package installs and imports correctly..."
-          uv run --with py-tgm --no-project -- python -c "import tgm; print(tgm.__version__)"
+          uv run --with tgm-lib --no-project -- python -c "import tgm; print(tgm.__version__)"
 
       - name: Publish to PyPI or TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on: # yamllint disable-line rule:truthy
   push:
     tags:
       - "v*" # Trigger only when a tag like v* is pushed
+  workflow_dispatch: # TODO: Remove this once TEST-PYPI publish is verified
 
 jobs:
   publish:
@@ -40,5 +41,6 @@ jobs:
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          # TODO: Switch this once TEST-PYPI publish is verified
           repository-url: https://test.pypi.org/legacy/ # <-- TESTPYPI for testing
           # Switch to https://upload.pypi.org/legacy/ when ready for PyPI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "py-tgm"
+name = "tgm-lib"
 version = "0.1.0a0"
 description = "Efficient and Modular ML on Temporal Graphs"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,6 @@ build-backend = "flit_core.buildapi"
 [tool.uv.pip]
 torch-backend = "auto"
 
-[tool.uv.project]
-root-package = "tgm"
-
 [tool.flit.module]
 name = "tgm"
 

--- a/uv.lock
+++ b/uv.lock
@@ -1303,67 +1303,6 @@ wheels = [
 ]
 
 [[package]]
-name = "py-tgm"
-version = "0.1.0a0"
-source = { editable = "." }
-dependencies = [
-    { name = "numpy" },
-    { name = "torch" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "isort" },
-    { name = "mypy" },
-    { name = "pandas" },
-    { name = "pre-commit" },
-    { name = "py-tgb" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
-    { name = "pytest-xdist" },
-    { name = "ruff" },
-]
-docs = [
-    { name = "mkdocs" },
-    { name = "mkdocs-material" },
-    { name = "mkdocstrings", extra = ["python"] },
-]
-examples = [
-    { name = "py-tgb" },
-    { name = "torchmetrics" },
-    { name = "tqdm" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "numpy", specifier = ">=2.2.6" },
-    { name = "torch", specifier = ">=2.5.1" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "isort", specifier = ">=5.13.2" },
-    { name = "mypy", specifier = ">=1.13.0" },
-    { name = "pandas", specifier = ">=1.5.3" },
-    { name = "pre-commit", specifier = ">=4.0.1" },
-    { name = "py-tgb", specifier = ">=2.1.0" },
-    { name = "pytest", specifier = ">=8.3.3" },
-    { name = "pytest-cov", specifier = ">=6.0.0" },
-    { name = "pytest-xdist", specifier = ">=3.7.0" },
-    { name = "ruff", specifier = "==0.11.1" },
-]
-docs = [
-    { name = "mkdocs", specifier = ">=1.6.1" },
-    { name = "mkdocs-material", specifier = ">=9.6.9" },
-    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.29.0" },
-]
-examples = [
-    { name = "py-tgb", specifier = ">=2.1.0" },
-    { name = "torchmetrics", specifier = ">=1.7.0" },
-    { name = "tqdm", specifier = ">=4.67.1" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1676,6 +1615,67 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ca/99/5a5b6f19ff9f083671ddf7b9632028436167cd3d33e11015754e41b249a4/sympy-1.13.1.tar.gz", hash = "sha256:9cebf7e04ff162015ce31c9c6c9144daa34a93bd082f54fd8f12deca4f47515f", size = 7533040, upload-time = "2024-07-19T09:26:51.238Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/fe/81695a1aa331a842b582453b605175f419fe8540355886031328089d840a/sympy-1.13.1-py3-none-any.whl", hash = "sha256:db36cdc64bf61b9b24578b6f7bab1ecdd2452cf008f34faa33776680c26d66f8", size = 6189177, upload-time = "2024-07-19T09:26:48.863Z" },
+]
+
+[[package]]
+name = "tgm-lib"
+version = "0.1.0a0"
+source = { editable = "." }
+dependencies = [
+    { name = "numpy" },
+    { name = "torch" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "isort" },
+    { name = "mypy" },
+    { name = "pandas" },
+    { name = "pre-commit" },
+    { name = "py-tgb" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-xdist" },
+    { name = "ruff" },
+]
+docs = [
+    { name = "mkdocs" },
+    { name = "mkdocs-material" },
+    { name = "mkdocstrings", extra = ["python"] },
+]
+examples = [
+    { name = "py-tgb" },
+    { name = "torchmetrics" },
+    { name = "tqdm" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "numpy", specifier = ">=2.2.6" },
+    { name = "torch", specifier = ">=2.5.1" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "isort", specifier = ">=5.13.2" },
+    { name = "mypy", specifier = ">=1.13.0" },
+    { name = "pandas", specifier = ">=1.5.3" },
+    { name = "pre-commit", specifier = ">=4.0.1" },
+    { name = "py-tgb", specifier = ">=2.1.0" },
+    { name = "pytest", specifier = ">=8.3.3" },
+    { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "pytest-xdist", specifier = ">=3.7.0" },
+    { name = "ruff", specifier = "==0.11.1" },
+]
+docs = [
+    { name = "mkdocs", specifier = ">=1.6.1" },
+    { name = "mkdocs-material", specifier = ">=9.6.9" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.29.0" },
+]
+examples = [
+    { name = "py-tgb", specifier = ">=2.1.0" },
+    { name = "torchmetrics", specifier = ">=1.7.0" },
+    { name = "tqdm", specifier = ">=4.67.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Purpose
The purpose of this PR is to add a workflow for publish releases of `py-tgm`. The new workflow will build wheels, verify package data, and then publish a release onto [test-pypi](https://packaging.python.org/en/latest/guides/using-testpypi/). The dry-run is default.

After this succeeds, a repository owner can navigate to the github action, and set the environment variable `RELEASE=True`. Re-running the job will then publish artifact onto [pypi](https://pypi.org/)

## Release Workflow
```sh
#1. Bump version in pyproject.toml and __init__
#2. git tag v0.1.0a0
#3. git push origin v0.1.0a0 (triggers dry-run)
#4. If dry-run succeeds navigate to github ui and re-trigger action with `RELEASE` flag
#5. Create a changelog on github tag
```
## Key Changes
- new action `publish.yml`

## Relevant Prs
Fix #99

## TODO
Setup `pypi` token