### PR TITLE
Handle Empty Batches

### DIFF
--- a/examples/linkproppred/gclstm.py
+++ b/examples/linkproppred/gclstm.py
@@ -106,10 +106,6 @@ def train(
     total_loss = 0
     h_0, c_0 = None, None
     for batch in tqdm(loader):
-        # TODO: Consider skipping empty batches natively, when iterating by time (instead of events)
-        if not len(batch.src):
-            continue
-
         opt.zero_grad()
         pos_out, neg_out, h_0, c_0 = model(batch, node_feat, h_0, c_0)
         loss = F.mse_loss(pos_out, torch.ones_like(pos_out))
@@ -132,10 +128,6 @@ def eval(
 ) -> Tuple[dict, torch.Tensor, torch.Tensor]:
     model.eval()
     for batch in tqdm(loader):
-        # TODO: Consider skipping empty batches natively, when iterating by time (instead of events)
-        if not len(batch.src):
-            continue
-
         pos_out, neg_out, h_0, c_0 = model(batch, node_feat, h_0, c_0)
         y_pred = torch.cat([pos_out, neg_out], dim=0).float()
         y_true = (

--- a/examples/linkproppred/gcn.py
+++ b/examples/linkproppred/gcn.py
@@ -134,10 +134,6 @@ def train(
     model.train()
     total_loss = 0
     for batch in tqdm(loader):
-        # TODO: Consider skipping empty batches natively, when iterating by time (instead of events)
-        if not len(batch.src):
-            continue
-
         opt.zero_grad()
         pos_out, neg_out = model(batch, node_feat)
         loss = F.mse_loss(pos_out, torch.ones_like(pos_out))
@@ -157,10 +153,6 @@ def eval(
 ) -> dict:
     model.eval()
     for batch in tqdm(loader):
-        # TODO: Consider skipping empty batches natively, when iterating by time (instead of events)
-        if not len(batch.src):
-            continue
-
         pos_out, neg_out = model(batch, node_feat)
         y_pred = torch.cat([pos_out, neg_out], dim=0).float()
         y_true = (

--- a/examples/nodeproppred/gclstm.py
+++ b/examples/nodeproppred/gclstm.py
@@ -108,10 +108,6 @@ def train(
     h_0, c_0 = None, None
     criterion = torch.nn.CrossEntropyLoss()
     for batch in tqdm(loader):
-        # TODO: Consider skipping empty batches natively, when iterating by time (instead of events)
-        if not len(batch.src):
-            continue
-
         opt.zero_grad()
         label = batch.dynamic_node_feats
         if label is None:
@@ -137,9 +133,6 @@ def eval(
     eval_metric = 'ndcg'
     total_score = 0
     for batch in tqdm(loader):
-        # TODO: Consider skipping empty batches natively, when iterating by time (instead of events)
-        if not len(batch.src):
-            continue
         label = batch.dynamic_node_feats
         if label is None:
             continue

--- a/examples/nodeproppred/gcn.py
+++ b/examples/nodeproppred/gcn.py
@@ -136,9 +136,6 @@ def train(
     total_loss = 0
     criterion = torch.nn.CrossEntropyLoss()
     for batch in tqdm(loader):
-        # TODO: Consider skipping empty batches natively, when iterating by time (instead of events)
-        if not len(batch.src):
-            continue
         opt.zero_grad()
         label = batch.dynamic_node_feats
         if label is None:
@@ -162,9 +159,6 @@ def eval(
     eval_metric = 'ndcg'
     total_score = 0
     for batch in tqdm(loader):
-        # TODO: Consider skipping empty batches natively, when iterating by time (instead of events)
-        if not len(batch.src):
-            continue
         label = batch.dynamic_node_feats
         if label is None:
             continue

--- a/examples/nodeproppred/tgcn.py
+++ b/examples/nodeproppred/tgcn.py
@@ -106,10 +106,6 @@ def train(
     h_0 = None
     criterion = torch.nn.CrossEntropyLoss()
     for batch in tqdm(loader):
-        # TODO: Consider skipping empty batches natively, when iterating by time (instead of events)
-        if not len(batch.src):
-            continue
-
         opt.zero_grad()
         label = batch.dynamic_node_feats
         if label is None:
@@ -134,9 +130,6 @@ def eval(
     eval_metric = 'ndcg'
     total_score = 0
     for batch in tqdm(loader):
-        # TODO: Consider skipping empty batches natively, when iterating by time (instead of events)
-        if not len(batch.src):
-            continue
         label = batch.dynamic_node_feats
         if label is None:
             continue

--- a/tgm/loader.py
+++ b/tgm/loader.py
@@ -63,7 +63,7 @@ class DGDataLoader(_SkippableDataLoaderMixin, torch.utils.data.DataLoader):  # t
         dg: DGraph,
         batch_size: int = 1,
         batch_unit: str = 'r',
-        on_empty: Literal['skip', 'raise', None] = None,
+        on_empty: Literal['skip', 'raise', None] = 'skip',
         hook: HookManager | DGHook | List[DGHook] | None = None,
         **kwargs: Any,
     ) -> None:

--- a/tgm/loader.py
+++ b/tgm/loader.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, List
+from abc import ABC, abstractmethod
+from typing import Any, Iterator, List, Literal
 
 import torch
 
@@ -9,19 +10,52 @@ from tgm.hooks import DGHook, HookManager
 from tgm.timedelta import TimeDeltaDG
 
 
-class DGDataLoader(torch.utils.data.DataLoader):
+class _SkippableDataLoaderMixin(ABC):
+    r"""Mixin to optionally skip or raise on empty batches."""
+
+    def __init__(
+        self,
+        *args: Any,
+        on_empty: Literal['skip', 'raise', None] = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+
+        valid_on_empty = ['skip', 'raise', None]
+        if on_empty not in valid_on_empty:
+            raise ValueError(
+                f'Invalid on_empty={on_empty}, expected one of: {valid_on_empty}'
+            )
+        self._on_empty = on_empty
+
+    @abstractmethod
+    def is_batch_empty(self, batch: Any) -> bool: ...
+
+    def __iter__(self) -> Iterator[Any]:
+        for batch in super().__iter__():  # type: ignore
+            if self.is_batch_empty(batch):
+                if self._on_empty == 'raise':
+                    raise ValueError('Empty batch encountered')
+                elif self._on_empty == 'skip':
+                    continue
+            yield batch
+
+
+class DGDataLoader(_SkippableDataLoaderMixin, torch.utils.data.DataLoader):  # type: ignore
     r"""Iterate and materialize from a DGraph.
 
     Args:
         dg (DGraph): The dynamic graph to iterate.
         batch_size (int): The batch size to yield at each iteration.
         batch_unit (str): The unit corresponding to the batch_size.
+        on_empty (Literal['skip', 'raise', None]): Action for empty batches.
         hook (HookManager | Hook | List[Hook] | None): Arbitrary transform behaviour to execute before materializing a batch.
         **kwargs (Any): Additional arguments to torch.utils.data.DataLoader.
 
     Raises:
         ValueError: If the batch_unit and dg time unit are not both ordered or both not ordered.
         ValueError: If the batch_unit and dg time unit are both ordered but the graph is coarser than the batch.
+        ValueError: If an empty batch was encountered an on_empty='raise'.
     """
 
     def __init__(
@@ -29,6 +63,7 @@ class DGDataLoader(torch.utils.data.DataLoader):
         dg: DGraph,
         batch_size: int = 1,
         batch_unit: str = 'r',
+        on_empty: Literal['skip', 'raise', None] = None,
         hook: HookManager | DGHook | List[DGHook] | None = None,
         **kwargs: Any,
     ) -> None:
@@ -52,8 +87,7 @@ class DGDataLoader(torch.utils.data.DataLoader):
             batch_size = int(batch_time_delta.convert(dg.time_delta))
 
         # Warning: Cache miss
-        assert dg.start_time is not None
-        assert dg.end_time is not None
+        assert dg.start_time is not None and dg.end_time is not None
 
         self._dg = dg
         self._batch_size = batch_size
@@ -67,9 +101,15 @@ class DGDataLoader(torch.utils.data.DataLoader):
             slice_start = range(start_idx, stop_idx - batch_size, batch_size)
         else:
             slice_start = range(start_idx, stop_idx, batch_size)
-        super().__init__(slice_start, 1, shuffle=False, collate_fn=self, **kwargs)  # type: ignore
+
+        super().__init__(
+            slice_start, 1, shuffle=False, collate_fn=self, on_empty=on_empty, **kwargs
+        )
 
     def __call__(self, slice_start: List[int]) -> DGBatch:
         slice_end = slice_start[0] + self._batch_size
         batch = self._slice_op(slice_start[0], slice_end)
         return self._hook(batch)
+
+    def is_batch_empty(self, batch: DGBatch) -> bool:
+        return batch.src.numel() == 0

--- a/tgm/loader.py
+++ b/tgm/loader.py
@@ -56,6 +56,11 @@ class DGDataLoader(_SkippableDataLoaderMixin, torch.utils.data.DataLoader):  # t
         ValueError: If the batch_unit and dg time unit are not both ordered or both not ordered.
         ValueError: If the batch_unit and dg time unit are both ordered but the graph is coarser than the batch.
         ValueError: If an empty batch was encountered an on_empty='raise'.
+
+    Note:
+        The length returned by `len(DGDataLoader)` may be inaccurate when using a non-ordered
+        `batch_unit` with `on_empty='skip'`. The reported length counts all batches, including
+        those that would be skipped due to being empty.
     """
 
     def __init__(


### PR DESCRIPTION
# Purpose
The purpose of this PR is to add support to handle empty batches (num_events = 0) during iteration. We currently support the following policies:
- `on_empty='skip'`: (default) continues the iteration, skipping the empty batch
- `on_empty='raise'`: Raises a ValueError when an empty batch is encoutered
- `on_empty=None`: Yields the empty batch normally (what we currently have implemented in master).

## Design Tradeoffs
There are several obvious implementations that I did _not_ go with, and for good reason. The main difficulty is that why don't know _which_ batches will be empty ahead of time. This means we cannot do online iteration since the `torch.DataLoader` would not now anything about the batches we want to skip, and would re-yield them to the user.

### Option 1: Pre-compute the batches that are empty
This is possible. I didn't try it, because it's not ideal to have to iterate the entire graph at construction time. Not to mention each query requires materializing the batch (or a call to the storage backend) to actually see if our view is empty. (recall, our notion of empty is not that the start/end time have no overlap, but it's that no _events_ occured in an interval). Also, this would require storing an extra array, whereas loader should be lightweight.

### Option 2: Subclass `torch.IterableDataset` instead of `torch.DataLoader`
This is more akin to the behaviour we expect, we read from a data stream and don't know exactly which batch will be yielded ahead of time. This change has several downsides, mostly related to the API. Iterable loaders don't have `len()` and must be _reset_ after use manually, making them cumbersome for the user. Also, it's silly to use this when we have all our data up front.

### Option 3: Wrap an instance of the dataloder
This is the most straightforward. Idea would be to have the internal loader (with the main logic) wrapped in a user-facing class. The main downside here is that our DGDataloader would no longer subclass `torch.DataLoader`. And so, we would have to right a bit of boilerplate if we wanted it to be a drop in replacemement for torch loader.

### Option 4: Mixin Class
This is what I went with. We maintain subclassing `torch.DataLoader`, to get all their benefits out of the box. We define a private generic utility class (`SkippableDataLoaderMixin`) which holds all the logic for skipping batches. There is some finnacky multiple inheritence things that come up, but I don't think it's too bad. If this comes to bite us, we can go back to option 3 and keep the same API.

## Performance
There is obviously a runtime check that would only be avoided if we went with option 1 and pre-computed the batches that are empty. But this would make our end-to-end latency a bit worse, and seems not ideal. That being said, our  empty check does not come for free either, and we pay the cost on every batch.

It is important to realize that we cannot (currently) check if a graph is empty in `O(1)`. This is because we need to call the backend and see how many events actually exist in a time interval. If we have a cache miss, this requires binary searching the time stamps to get the interval range. Therefore, I this implementation **materializes the graph internally**. It calls all the hooks, and then skips the batch if it's empty. Technically, this might not be any better since materialization (even on an empty graph) requires the exact same binary search (plus other things).

If we find that this is not acceptable, then we can do a few things
- Mess around with method resolution order so that the `is_batch_empty` check happens on the unmaterialized graph. 
- Materialize the graph internally (without running all the hooks) and then do the check


Currently, the perforamnce will be exactly the same as what we have, since our current logic of materializing and going through all the hooks (and then in the example files skipping empty batches) is close to what's happening internally. Empty batches probably don't come up often (?) and it only dould occurs when iterating by time. 


## Relevant Prs
Close #14 