### PR TITLE
Privatize DGStorage Construction

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras --dev --frozen
 
+      - name: Clean pytest caches
+        run: rm -rf .pytest_cache
+
       - name: Test non-gpu tests with pytest
         run: uv run pytest test -m "not gpu and not integration" --cov=tgm --cov-report=xml --cov-append -vvv
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -40,9 +40,6 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras --dev --frozen
 
-      - name: Clean pytest caches
-        run: rm -rf .pytest_cache
-
       - name: Test non-gpu tests with pytest
         run: uv run pytest test -m "not gpu and not integration" --cov=tgm --cov-report=xml --cov-append -vvv
 

--- a/test/unit/test_dataloader.py
+++ b/test/unit/test_dataloader.py
@@ -182,8 +182,8 @@ def test_iteration_non_ordered_dg_non_ordered_batch_unit_too_granular():
 def test_iteration_with_empty_batch():
     edge_index = torch.LongTensor([[2, 3], [2, 3]])
     edge_timestamps = torch.LongTensor([1, 5])
-    data = DGData.from_raw(edge_timestamps, edge_index)
-    dg = DGraph(data, time_delta='s')
+    data = DGData.from_raw(edge_timestamps, edge_index, time_delta='s')
+    dg = DGraph(data)
 
     loader = DGDataLoader(dg, batch_unit='s')
     assert len(loader) == 5  # Includes skipped batches
@@ -198,8 +198,8 @@ def test_iteration_with_empty_batch():
 def test_iteration_with_empty_batch_process_empty():
     edge_index = torch.LongTensor([[2, 3], [2, 3]])
     edge_timestamps = torch.LongTensor([1, 5])
-    data = DGData.from_raw(edge_timestamps, edge_index)
-    dg = DGraph(data, time_delta='s')
+    data = DGData.from_raw(edge_timestamps, edge_index, time_delta='s')
+    dg = DGraph(data)
 
     loader = DGDataLoader(dg, batch_unit='s', on_empty=None)
     assert len(loader) == 5  # Includes skipped batches
@@ -214,8 +214,8 @@ def test_iteration_with_empty_batch_process_empty():
 def test_iteration_with_empty_batch_raise():
     edge_index = torch.LongTensor([[2, 3], [2, 3]])
     edge_timestamps = torch.LongTensor([1, 5])
-    data = DGData.from_raw(edge_timestamps, edge_index)
-    dg = DGraph(data, time_delta='s')
+    data = DGData.from_raw(edge_timestamps, edge_index, time_delta='s')
+    dg = DGraph(data)
 
     loader = DGDataLoader(dg, batch_unit='s', on_empty='raise')
     assert len(loader) == 5  # Includes skipped batches

--- a/test/unit/test_dataloader.py
+++ b/test/unit/test_dataloader.py
@@ -60,8 +60,8 @@ def test_iteration_ordered(drop_last, time_delta):
         ]
     )
     edge_timestamps = torch.LongTensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-    data = DGData.from_raw(edge_timestamps, edge_index)
-    dg = DGraph(data, time_delta=time_delta)
+    data = DGData.from_raw(edge_timestamps, edge_index, time_delta=time_delta)
+    dg = DGraph(data)
     loader = DGDataLoader(dg, batch_size=3, batch_unit='r', drop_last=drop_last)
 
     src, dst, t = dg.edges
@@ -96,8 +96,8 @@ def test_iteration_by_time_equal_unit(drop_last):
         ]
     )
     edge_timestamps = torch.LongTensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
-    data = DGData.from_raw(edge_timestamps, edge_index)
-    dg = DGraph(data, time_delta='s')
+    data = DGData.from_raw(edge_timestamps, edge_index, time_delta='s')
+    dg = DGraph(data)
     loader = DGDataLoader(
         dg,
         batch_size=3,
@@ -136,8 +136,10 @@ def test_iteration_by_time_with_conversion_time_delta_value(drop_last):
         ]
     )
     edge_timestamps = torch.LongTensor([0, 0, 1, 1, 1, 12, 18, 24, 24])
-    data = DGData.from_raw(edge_timestamps, edge_index)
-    dg = DGraph(data, time_delta=TimeDeltaDG('s', value=10))
+    data = DGData.from_raw(
+        edge_timestamps, edge_index, time_delta=TimeDeltaDG('s', value=10)
+    )
+    dg = DGraph(data)
     loader = DGDataLoader(dg, batch_size=2, batch_unit='m', drop_last=drop_last)
 
     src, _, _ = dg.edges
@@ -162,13 +164,16 @@ def test_iteration_by_time_with_conversion_time_delta_value(drop_last):
 def test_iteration_non_ordered_dg_non_ordered_batch_unit_too_granular():
     edge_index = torch.LongTensor([[2, 3]])
     edge_timestamps = torch.LongTensor([1])
-    data = DGData.from_raw(edge_timestamps, edge_index)
-    dg = DGraph(data, time_delta='m')
+    data = DGData.from_raw(edge_timestamps, edge_index, time_delta='m')
+    dg = DGraph(data)
     with pytest.raises(ValueError):
         # Seconds are too granular of an iteration unit for DG with minute time granularity
         _ = DGDataLoader(dg, batch_unit='s')
 
-    dg = DGraph(data, time_delta=TimeDeltaDG('s', value=30))
+    data = DGData.from_raw(
+        edge_timestamps, edge_index, time_delta=TimeDeltaDG('s', value=30)
+    )
+    dg = DGraph(data)
     with pytest.raises(ValueError):
         # Seconds are too granular of an iteration unit for DG with 'every 30 seconds' time granularity
         _ = DGDataLoader(dg, batch_unit='s')

--- a/test/unit/test_dgraph.py
+++ b/test/unit/test_dgraph.py
@@ -106,6 +106,11 @@ def test_str(data):
     assert isinstance(dg.__str__(), str)
 
 
+def test_init_bad_data():
+    with pytest.raises(TypeError):
+        DGraph('foo')
+
+
 def test_materialize(data):
     dg = DGraph(data)
     exp_src = torch.tensor([2, 2, 1], dtype=torch.int64)

--- a/test/unit/test_dgraph.py
+++ b/test/unit/test_dgraph.py
@@ -95,13 +95,10 @@ def test_init_gpu(data):
 
 def test_init_from_storage(data):
     dg_tmp = DGraph(data)
-    dg = DGraph(dg_tmp._storage, 'r')
+    dg = DGraph._from_storage(
+        dg_tmp._storage, dg_tmp.time_delta, dg_tmp.device, dg_tmp._slice
+    )
     assert id(dg_tmp._storage) == id(dg._storage)
-
-
-def test_init_bad_args(data):
-    with pytest.raises(ValueError):
-        _ = DGraph(data, time_delta='foo')
 
 
 def test_str(data):

--- a/tgm/graph.py
+++ b/tgm/graph.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Sized
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from functools import cached_property
 from typing import Any, Optional, Set, Tuple
 
@@ -16,28 +16,16 @@ from tgm.timedelta import TimeDeltaDG
 class DGraph:
     r"""Dynamic Graph Object provides a 'view' over a DGStorage backend."""
 
-    def __init__(
-        self,
-        data: DGStorage | DGData,
-        time_delta: TimeDeltaDG | str | None = None,
-        device: str | torch.device = 'cpu',
-    ) -> None:
-        if isinstance(time_delta, str):
-            time_delta = TimeDeltaDG(time_delta)
+    def __init__(self, data: DGData, device: str | torch.device = 'cpu') -> None:
+        if not isinstance(data, DGData):
+            raise TypeError(f'DGraph must be initialized with DGData, got {type(data)}')
 
-        if isinstance(data, DGData):
-            time_delta = time_delta or TimeDeltaDG('r')  # Default to ordered
-            data = DGStorage(data)
-        elif isinstance(data, DGStorage):
-            if time_delta is None:
-                raise RuntimeError(
-                    'Internally tried creating DGraph on existing storage without specifying a time_delta'
-                )
+        if isinstance(data.time_delta, str):
+            self._time_delta = TimeDeltaDG(data.time_delta)
         else:
-            raise ValueError(f'Unsupported dataset type: {type(data)}')
+            self._time_delta = data.time_delta
 
-        self._storage = data
-        self._time_delta = time_delta
+        self._storage = DGStorage(data)
         self._device = torch.device(device)
         self._slice = DGSliceTracker()
 
@@ -58,12 +46,10 @@ class DGraph:
         if start_idx is not None and end_idx is not None and start_idx > end_idx:
             raise ValueError(f'start_idx ({start_idx}) must be <= end_idx ({end_idx})')
 
-        dg = DGraph(data=self._storage, time_delta=self.time_delta, device=self.device)
-        dg._slice.start_time = self._slice.start_time
-        dg._slice.end_time = self._slice.end_time
-        dg._slice.start_idx = self._maybe_max(start_idx, self._slice.start_idx)
-        dg._slice.end_idx = self._maybe_min(end_idx, self._slice.end_idx)
-        return dg
+        slice = replace(self._slice)
+        slice.start_idx = self._maybe_max(start_idx, slice.start_idx)
+        slice.end_idx = self._maybe_min(end_idx, slice.end_idx)
+        return DGraph._from_storage(self._storage, self.time_delta, self.device, slice)
 
     def slice_time(
         self, start_time: Optional[int] = None, end_time: Optional[int] = None
@@ -76,12 +62,10 @@ class DGraph:
         if end_time is not None:
             end_time -= 1
 
-        dg = DGraph(data=self._storage, time_delta=self.time_delta, device=self.device)
-        dg._slice.start_time = self._maybe_max(start_time, self.start_time)
-        dg._slice.end_time = self._maybe_min(end_time, self.end_time)
-        dg._slice.start_idx = self._slice.start_idx
-        dg._slice.end_idx = self._slice.end_idx
-        return dg
+        slice = replace(self._slice)
+        slice.start_time = self._maybe_max(start_time, slice.start_time)
+        slice.end_time = self._maybe_min(end_time, slice.end_time)
+        return DGraph._from_storage(self._storage, self.time_delta, self.device, slice)
 
     def __len__(self) -> int:
         r"""The number of timestamps in the dynamic graph."""
@@ -99,7 +83,9 @@ class DGraph:
         return self._time_delta
 
     def to(self, device: str | torch.device) -> DGraph:
-        return DGraph(data=self._storage, time_delta=self.time_delta, device=device)
+        device = torch.device(device)
+        slice = replace(self._slice)
+        return DGraph._from_storage(self._storage, self.time_delta, device, slice)
 
     @cached_property
     def start_time(self) -> Optional[int]:
@@ -205,6 +191,21 @@ class DGraph:
         if a is not None and b is not None:
             return min(a, b)
         return a if b is None else b if a is None else None
+
+    @classmethod
+    def _from_storage(
+        cls,
+        storage: DGStorage,
+        time_delta: TimeDeltaDG,
+        device: torch.device,
+        slice: DGSliceTracker,
+    ) -> DGraph:
+        obj = cls.__new__(cls)
+        obj._storage = storage
+        obj._time_delta = time_delta
+        obj._device = device
+        obj._slice = slice
+        return obj
 
 
 @dataclass

--- a/tgm/graph.py
+++ b/tgm/graph.py
@@ -20,11 +20,7 @@ class DGraph:
         if not isinstance(data, DGData):
             raise TypeError(f'DGraph must be initialized with DGData, got {type(data)}')
 
-        if isinstance(data.time_delta, str):
-            self._time_delta = TimeDeltaDG(data.time_delta)
-        else:
-            self._time_delta = data.time_delta
-
+        self._time_delta = data.time_delta
         self._storage = DGStorage(data)
         self._device = torch.device(device)
         self._slice = DGSliceTracker()
@@ -80,7 +76,7 @@ class DGraph:
 
     @property
     def time_delta(self) -> TimeDeltaDG:
-        return self._time_delta
+        return self._time_delta  # type: ignore
 
     def to(self, device: str | torch.device) -> DGraph:
         device = torch.device(device)


### PR DESCRIPTION
# Purpose
The purpose of this PR is to simplify the `DGraph` constuctor by moving the _internal_ `DGStorage` based construction into a private class method.

This makes the API extremely clear to the user:
```python
dg = DGraph(data: DGData, device: str | torch.device)
```

The time delta is now fully manged by `DGData`, and we avoid confusion for passing `time_delta` itno DGraph (which is now only possible via view_creation.

## Changes
New private class method `from_storage` which we use internally to create our `DGraph` views. Public constructor is only for initial graph construction (from `DGData` by the user).
 
## Relevant Issues
Close #155 