### PR TITLE
Hook State API Change

### DIFF
--- a/test/unit/test_hooks/test_deduplication_hook.py
+++ b/test/unit/test_hooks/test_deduplication_hook.py
@@ -19,6 +19,10 @@ def test_hook_dependancies():
     assert DeduplicationHook.produces == {'unique_nids', 'global_to_local'}
 
 
+def test_hook_reset_state():
+    assert DeduplicationHook.has_state == False
+
+
 def test_dedup(dg):
     hook = DeduplicationHook()
     batch = dg.materialize()

--- a/test/unit/test_hooks/test_device_transfer_hook.py
+++ b/test/unit/test_hooks/test_device_transfer_hook.py
@@ -19,6 +19,10 @@ def test_hook_dependancies():
     assert DeviceTransferHook.produces == set()
 
 
+def test_hook_reset_state():
+    assert DeviceTransferHook.has_state == False
+
+
 def test_device_transfer_hook_cpu_cpu(dg):
     hook = DeviceTransferHook('cpu')
     batch = dg.materialize()

--- a/test/unit/test_hooks/test_negative_edge_sampler_hook.py
+++ b/test/unit/test_hooks/test_negative_edge_sampler_hook.py
@@ -18,6 +18,10 @@ def test_hook_dependancies():
     assert NegativeEdgeSamplerHook.produces == {'neg', 'neg_time'}
 
 
+def test_hook_reset_state():
+    assert NegativeEdgeSamplerHook.has_state == False
+
+
 def test_bad_negative_edge_sampler_init():
     with pytest.raises(ValueError):
         NegativeEdgeSamplerHook(low=0, high=0)

--- a/test/unit/test_hooks/test_neighbor_sampler_hook.py
+++ b/test/unit/test_hooks/test_neighbor_sampler_hook.py
@@ -25,6 +25,10 @@ def test_hook_dependancies():
     }
 
 
+def test_hook_reset_state():
+    assert NeighborSamplerHook.has_state == False
+
+
 def test_bad_neighbor_sampler_init():
     with pytest.raises(ValueError):
         NeighborSamplerHook(num_nbrs=[])

--- a/test/unit/test_hooks/test_pin_memory_hook.py
+++ b/test/unit/test_hooks/test_pin_memory_hook.py
@@ -19,6 +19,10 @@ def test_hook_dependancies():
     assert PinMemoryHook.produces == set()
 
 
+def test_hook_reset_state():
+    assert PinMemoryHook.has_state == False
+
+
 @pytest.mark.gpu
 def test_pin_memory_hook_cpu(dg):
     # Note: The gpu is not actually used, but torch complains when calling .pin_memory()

--- a/test/unit/test_hooks/test_recency_nbr_hook.py
+++ b/test/unit/test_hooks/test_recency_nbr_hook.py
@@ -18,6 +18,11 @@ def test_hook_dependancies():
     }
 
 
+@pytest.mark.skip('TODO: Add recency nbr tests')
+def test_hook_reset_state():
+    assert RecencyNeighborHook.has_state == True
+
+
 def test_bad_neighbor_sampler_init():
     with pytest.raises(ValueError):
         RecencyNeighborHook(num_nbrs=[0], num_nodes=2, edge_feats_dim=1)

--- a/test/unit/test_hooks/test_tgb_negative_sampling_hook.py
+++ b/test/unit/test_hooks/test_tgb_negative_sampling_hook.py
@@ -20,6 +20,10 @@ def test_hook_dependancies():
     assert TGBNegativeEdgeSamplerHook.produces == {'neg', 'neg_batch_list', 'neg_time'}
 
 
+def test_hook_reset_state():
+    assert TGBNegativeEdgeSamplerHook.has_state == False
+
+
 class FakeNegSampler:
     def query_batch(self, src, dst, time, split_mode='val'):
         return []


### PR DESCRIPTION
### Purpose
The purpose of this PR is to add the minimal API change required to satisfy the hook state management planned for beta release.
Namely, the ability to reset state on all hooks.

### Changes
- hook manager has `reset_state()` api, which resets all hooks.
- `DGHook` protocol enforces that each hook now implements `has_state: bool` property, and `reset_state()` method. For stateless hooks, these are no-ops.
- To reduce boilerplate, I created a `StatelessHook` protocol which has these as no-ops.

### Out of scope
Going to modify the examples in subsequent PR. This also requires thining about our dataloading API which I wrote to implicitly allow `HookManager` construction: https://github.com/tgm-team/tgm/blob/5bec4b724b62cd0a40c7b6ca519071edfeb54826/tgm/loader.py#L72

If the user is to completely manage state via hook manager, it makes sense from an API perspective to expose direct hook manager injection instead. This will require more changes to loader, hence, why I am splitting things up.

### Relevant Issues
Close #160 