### PR TITLE
Update Temporal Attention

### DIFF
--- a/examples/linkproppred/TGB/tgat.py
+++ b/examples/linkproppred/TGB/tgat.py
@@ -74,7 +74,6 @@ class TGAT(nn.Module):
                     node_dim=embed_dim,
                     edge_dim=edge_dim,
                     time_dim=time_dim,
-                    out_dim=embed_dim,
                     dropout=dropout,
                 )
                 for _ in range(num_layers)

--- a/examples/linkproppred/TGB/tgn.py
+++ b/examples/linkproppred/TGB/tgn.py
@@ -263,7 +263,6 @@ class GraphAttentionEmbedding(nn.Module):
                     node_dim=embed_dim,
                     edge_dim=edge_dim,
                     time_dim=time_dim,
-                    out_dim=embed_dim,
                     dropout=dropout,
                 )
                 for _ in range(num_layers)

--- a/examples/linkproppred/tgat.py
+++ b/examples/linkproppred/tgat.py
@@ -72,7 +72,6 @@ class TGAT(nn.Module):
                     node_dim=embed_dim,
                     edge_dim=edge_dim,
                     time_dim=time_dim,
-                    out_dim=embed_dim,
                     dropout=dropout,
                 )
                 for _ in range(num_layers)

--- a/examples/linkproppred/tgn.py
+++ b/examples/linkproppred/tgn.py
@@ -263,7 +263,6 @@ class GraphAttentionEmbedding(nn.Module):
                     node_dim=embed_dim,
                     edge_dim=edge_dim,
                     time_dim=time_dim,
-                    out_dim=embed_dim,
                     dropout=dropout,
                 )
                 for _ in range(num_layers)

--- a/test/unit/test_model/test_temporal_attention.py
+++ b/test/unit/test_model/test_temporal_attention.py
@@ -5,25 +5,30 @@ from tgm.nn.attention import TemporalAttention
 
 
 def test_temporal_attention_bad_init_shape():
-    node_dim, edge_dim, time_dim = 2, 4, 5
-    n_heads, out_dim = 3, 5  # BAD: out_dim % n_heads == 0 must be true!
+    node_dim, edge_dim, time_dim, n_heads = 0, 4, 5, 3
     with pytest.raises(ValueError):
-        TemporalAttention(n_heads, node_dim, edge_dim, time_dim, out_dim)
+        TemporalAttention(n_heads, node_dim, edge_dim, time_dim)
 
-    node_dim = 0
-    n_heads, out_dim = 3, 6
+    node_dim, edge_dim, time_dim, n_heads = 4, 0, 5, 3
     with pytest.raises(ValueError):
-        TemporalAttention(n_heads, node_dim, edge_dim, time_dim, out_dim)
+        TemporalAttention(n_heads, node_dim, edge_dim, time_dim)
+
+    node_dim, edge_dim, time_dim, n_heads = 4, 5, 0, 3
+    with pytest.raises(ValueError):
+        TemporalAttention(n_heads, node_dim, edge_dim, time_dim)
+
+    node_dim, edge_dim, time_dim, n_heads = 4, 5, 3, 0
+    with pytest.raises(ValueError):
+        TemporalAttention(n_heads, node_dim, edge_dim, time_dim)
 
 
 def test_temporal_attention_forward():
-    node_dim, edge_dim, time_dim = 2, 4, 5
-    n_heads, out_dim = 3, 6
-    attn = TemporalAttention(n_heads, node_dim, edge_dim, time_dim, out_dim)
+    node_dim, edge_dim, time_dim, n_heads = 2, 4, 8, 5
+    attn = TemporalAttention(n_heads, node_dim, edge_dim, time_dim)
+    assert attn.pad_dim == 0
+    assert attn.out_dim == node_dim + time_dim + attn.pad_dim
 
     batch_size, num_nbr = 32, 7
-    num_nbr = 7
-
     node_feat = torch.rand(batch_size, node_dim)
     time_feat = torch.rand(batch_size, time_dim)
     edge_feat = torch.rand(batch_size, num_nbr, edge_dim)
@@ -33,4 +38,25 @@ def test_temporal_attention_forward():
 
     out = attn(node_feat, time_feat, edge_feat, nbr_node_feat, nbr_time_feat, nbr_mask)
     assert torch.is_tensor(out)
-    assert out.shape == (batch_size, out_dim)
+    assert out.shape == (batch_size, node_dim + time_dim)
+
+
+def test_temporal_attention_forward_with_padding():
+    node_dim, edge_dim, time_dim = 2, 4, 8
+    n_heads = 3  # out_dim = node_dim + time_dim = 10
+    attn = TemporalAttention(n_heads, node_dim, edge_dim, time_dim)
+
+    assert attn.pad_dim == 2  # n_heads - out_dim % n_heads
+    assert attn.out_dim == node_dim + time_dim + attn.pad_dim
+
+    batch_size, num_nbr = 32, 7
+    node_feat = torch.rand(batch_size, node_dim)
+    time_feat = torch.rand(batch_size, time_dim)
+    edge_feat = torch.rand(batch_size, num_nbr, edge_dim)
+    nbr_node_feat = torch.rand(batch_size, num_nbr, node_dim)
+    nbr_time_feat = torch.rand(batch_size, num_nbr, time_dim)
+    nbr_mask = torch.zeros(batch_size, num_nbr)
+
+    out = attn(node_feat, time_feat, edge_feat, nbr_node_feat, nbr_time_feat, nbr_mask)
+    assert torch.is_tensor(out)
+    assert out.shape == (batch_size, node_dim + time_dim + attn.pad_dim)

--- a/tgm/nn/attention.py
+++ b/tgm/nn/attention.py
@@ -45,30 +45,29 @@ class TemporalAttention(torch.nn.Module):
 
     def forward(
         self,
-        node_feat: torch.Tensor,  # (batch_size, node_dim)
-        time_feat: torch.Tensor,  # (batch_size, time_dim)
-        edge_feat: torch.Tensor,  # (batch_size, num_nbrs, edge_dim)
-        nbr_node_feat: torch.Tensor,  # (batch_size, num_nbrs, node_dim)
-        nbr_time_feat: torch.Tensor,  # (batch_size, num_nbrs, time_dim)
-        nbr_mask: torch.Tensor,  # (batch_size, num_nbrs)
-    ) -> torch.Tensor:  # (batch_size, out_dim)
+        node_feat: torch.Tensor,  # (B, node_dim)
+        time_feat: torch.Tensor,  # (B, time_dim)
+        edge_feat: torch.Tensor,  # (B, num_nbrs, edge_dim)
+        nbr_node_feat: torch.Tensor,  # (B, num_nbrs, node_dim)
+        nbr_time_feat: torch.Tensor,  # (B, num_nbrs, time_dim)
+        nbr_mask: torch.Tensor,  # (B, num_nbrs)
+    ) -> torch.Tensor:  # (B, out_dim)
         node_feat = F.pad(node_feat, (0, self.pad_dim)) if self.pad_dim else node_feat
-        node_feat = node_feat.unsqueeze(1)
 
-        Q = R = torch.cat([node_feat, time_feat], dim=2)  # (batch, 1, out_dim)
-        Q = self.W_Q(Q)  # (batch, out_dim)
+        Q = R = torch.cat([node_feat, time_feat], dim=1).unsqueeze(1)  # (B, 1, out_dim)
+        Q = self.W_Q(Q)  # (B, out_dim)
 
         Z = torch.cat([nbr_node_feat, edge_feat, nbr_time_feat], dim=-1)
         Z = self.W_KV(Z)
-        K = Z[:, :, : self.out_dim]  # (batch, num_nbrs, out_dim)
-        V = Z[:, :, self.out_dim :]  # (batch, num_nbrs, out_dim)
+        K = Z[:, :, : self.out_dim]  # (B, num_nbrs, out_dim)
+        V = Z[:, :, self.out_dim :]  # (B, num_nbrs, out_dim)
 
         Q = Q.reshape(Q.shape[0], -1, self.n_heads, self.head_dim).permute(0, 2, 1, 3)
         K = K.reshape(K.shape[0], -1, self.n_heads, self.head_dim).permute(0, 2, 1, 3)
         V = V.reshape(V.shape[0], -1, self.n_heads, self.head_dim).permute(0, 2, 1, 3)
         del Z
 
-        A = torch.einsum('bhld,bhnd->bhln', Q, K)  # (batch, n_heads, 1, num_nbrs)
+        A = torch.einsum('bhld,bhnd->bhln', Q, K)  # (B, n_heads, 1, num_nbrs)
         A *= self.head_dim**-0.5
         del Q, K
 
@@ -82,11 +81,11 @@ class TemporalAttention(torch.nn.Module):
         A = torch.softmax(A, dim=-1)
         A = self.dropout(A)
 
-        O = torch.einsum('bhln,bhnd->bhld', A, V)  # (batch, n_heads, 1, head_dim)
-        O = O.flatten(start_dim=1)  # (batch, out_dim)
+        O = torch.einsum('bhln,bhnd->bhld', A, V)  # (B, n_heads, 1, head_dim)
+        O = O.flatten(start_dim=1)  # (B, out_dim)
         del A
 
-        out = self.W_O(O)  # (batch, out_dim)
+        out = self.W_O(O)  # (B, out_dim)
         out = self.dropout(out)
         out = self.layer_norm(out + R.squeeze(1))
         return out


### PR DESCRIPTION
### Purpose
The purpose of this PR is to port over the isolated changes to `TemporalAttention` module that were discovered while debugging against dyglib (#138 )

### Changes

#### Implicit `out_dim`
https://github.com/tgm-team/tgm/blob/0265757eb6bead40bfbba633957ff8825802c4a1/tgm/nn/attention.py#L28
Instead of paramterizing `out_dim`, we hard code it to `node_dim + time_dim` as is standard in _temporal_ attention modules. This is not the case in general attention modules, but seems to be the case here.

#### Padding

https://github.com/tgm-team/tgm/blob/0265757eb6bead40bfbba633957ff8825802c4a1/tgm/nn/attention.py#L30-L32

If `out_dim % n_heads != 0`, we previously raised an error. Instead, we know apply zero-padding. Note, this also must happen at runtime to pad features if needed:

https://github.com/tgm-team/tgm/blob/0265757eb6bead40bfbba633957ff8825802c4a1/tgm/nn/attention.py#L55

#### Residual Connection

https://github.com/tgm-team/tgm/blob/0265757eb6bead40bfbba633957ff8825802c4a1/tgm/nn/attention.py#L90

I just forgot this

### Relevant Issues
Close #167 