### PR TITLE
Upgrade Decoders

### DIFF
--- a/examples/linkproppred/TGB/gcn.py
+++ b/examples/linkproppred/TGB/gcn.py
@@ -127,7 +127,7 @@ class LinkPredictor(nn.Module):
     def forward(self, z_src: torch.Tensor, z_dst: torch.Tensor) -> torch.Tensor:
         h = self.fc1(torch.cat([z_src, z_dst], dim=1))
         h = h.relu()
-        return self.fc2(h)
+        return self.fc2(h).sigmoid().view(-1)
 
 
 def train_in_batches(

--- a/examples/linkproppred/TGB/gcn.py
+++ b/examples/linkproppred/TGB/gcn.py
@@ -119,16 +119,15 @@ class GCNEncoder(torch.nn.Module):
 
 
 class LinkPredictor(nn.Module):
-    def __init__(self, in_channels):
+    def __init__(self, dim: int) -> None:
         super().__init__()
-        self.lin_src = nn.Linear(in_channels, in_channels)
-        self.lin_dst = nn.Linear(in_channels, in_channels)
-        self.lin_final = nn.Linear(in_channels, 1)
+        self.fc1 = nn.Linear(2 * dim, dim)
+        self.fc2 = nn.Linear(dim, 1)
 
-    def forward(self, z_src, z_dst):
-        h = self.lin_src(z_src) + self.lin_dst(z_dst)
+    def forward(self, z_src: torch.Tensor, z_dst: torch.Tensor) -> torch.Tensor:
+        h = self.fc1(torch.cat([z_src, z_dst], dim=1))
         h = h.relu()
-        return self.lin_final(h).sigmoid().view(-1)  # Ensure output is a 1D tensor
+        return self.fc2(h)
 
 
 def train_in_batches(

--- a/examples/linkproppred/TGB/tgat.py
+++ b/examples/linkproppred/TGB/tgat.py
@@ -123,14 +123,13 @@ class TGAT(nn.Module):
 class LinkPredictor(nn.Module):
     def __init__(self, dim: int) -> None:
         super().__init__()
-        self.lin_src = nn.Linear(dim, dim)
-        self.lin_dst = nn.Linear(dim, dim)
-        self.lin_out = nn.Linear(dim, 1)
+        self.fc1 = nn.Linear(2 * dim, dim)
+        self.fc2 = nn.Linear(dim, 1)
 
     def forward(self, z_src: torch.Tensor, z_dst: torch.Tensor) -> torch.Tensor:
-        h = self.lin_src(z_src) + self.lin_dst(z_dst)
+        h = self.fc1(torch.cat([z_src, z_dst], dim=1))
         h = h.relu()
-        return self.lin_out(h).sigmoid().view(-1)
+        return self.fc2(h)
 
 
 def train(

--- a/examples/linkproppred/TGB/tgat.py
+++ b/examples/linkproppred/TGB/tgat.py
@@ -52,6 +52,18 @@ parser.add_argument(
 )
 
 
+class MergeLayer(nn.Module):
+    def __init__(self, in_dim1: int, in_dim2: int, hidden_dim: int, output_dim: int):
+        super().__init__()
+        self.fc1 = nn.Linear(in_dim1 + in_dim2, hidden_dim)
+        self.fc2 = nn.Linear(hidden_dim, output_dim)
+
+    def forward(self, x1: torch.Tensor, x2: torch.Tensor):
+        h = self.fc1(torch.cat([x1, x2], dim=1))
+        h = h.relu()
+        return self.fc2(h)
+
+
 class TGAT(nn.Module):
     def __init__(
         self,
@@ -129,7 +141,7 @@ class LinkPredictor(nn.Module):
     def forward(self, z_src: torch.Tensor, z_dst: torch.Tensor) -> torch.Tensor:
         h = self.fc1(torch.cat([z_src, z_dst], dim=1))
         h = h.relu()
-        return self.fc2(h)
+        return self.fc2(h).sigmoid().view(-1)
 
 
 def train(

--- a/examples/linkproppred/TGB/tgn.py
+++ b/examples/linkproppred/TGB/tgn.py
@@ -314,14 +314,13 @@ class GraphAttentionEmbedding(nn.Module):
 class LinkPredictor(nn.Module):
     def __init__(self, dim: int) -> None:
         super().__init__()
-        self.lin_src = nn.Linear(dim, dim)
-        self.lin_dst = nn.Linear(dim, dim)
-        self.lin_out = nn.Linear(dim, 1)
+        self.fc1 = nn.Linear(2 * dim, dim)
+        self.fc2 = nn.Linear(dim, 1)
 
     def forward(self, z_src: torch.Tensor, z_dst: torch.Tensor) -> torch.Tensor:
-        h = self.lin_src(z_src) + self.lin_dst(z_dst)
+        h = self.fc1(torch.cat([z_src, z_dst], dim=1))
         h = h.relu()
-        return self.lin_out(h).sigmoid().view(-1)
+        return self.fc2(h)
 
 
 def train(

--- a/examples/linkproppred/TGB/tgn.py
+++ b/examples/linkproppred/TGB/tgn.py
@@ -53,6 +53,18 @@ parser.add_argument(
 )
 
 
+class MergeLayer(nn.Module):
+    def __init__(self, in_dim1: int, in_dim2: int, hidden_dim: int, output_dim: int):
+        super().__init__()
+        self.fc1 = nn.Linear(in_dim1 + in_dim2, hidden_dim)
+        self.fc2 = nn.Linear(hidden_dim, output_dim)
+
+    def forward(self, x1: torch.Tensor, x2: torch.Tensor):
+        h = self.fc1(torch.cat([x1, x2], dim=1))
+        h = h.relu()
+        return self.fc2(h)
+
+
 class TGN(torch.nn.Module):
     def __init__(
         self,
@@ -320,7 +332,7 @@ class LinkPredictor(nn.Module):
     def forward(self, z_src: torch.Tensor, z_dst: torch.Tensor) -> torch.Tensor:
         h = self.fc1(torch.cat([z_src, z_dst], dim=1))
         h = h.relu()
-        return self.fc2(h)
+        return self.fc2(h).sigmoid().view(-1)
 
 
 def train(

--- a/examples/linkproppred/gclstm.py
+++ b/examples/linkproppred/gclstm.py
@@ -95,7 +95,7 @@ class LinkPredictor(nn.Module):
     def forward(self, z_src: torch.Tensor, z_dst: torch.Tensor) -> torch.Tensor:
         h = self.fc1(torch.cat([z_src, z_dst], dim=1))
         h = h.relu()
-        return self.fc2(h)
+        return self.fc2(h).sigmoid().view(-1)
 
 
 def train(

--- a/examples/linkproppred/gclstm.py
+++ b/examples/linkproppred/gclstm.py
@@ -89,14 +89,13 @@ class RecurrentGCN(torch.nn.Module):
 class LinkPredictor(nn.Module):
     def __init__(self, dim: int) -> None:
         super().__init__()
-        self.lin_src = nn.Linear(dim, dim)
-        self.lin_dst = nn.Linear(dim, dim)
-        self.lin_out = nn.Linear(dim, 1)
+        self.fc1 = nn.Linear(2 * dim, dim)
+        self.fc2 = nn.Linear(dim, 1)
 
     def forward(self, z_src: torch.Tensor, z_dst: torch.Tensor) -> torch.Tensor:
-        h = self.lin_src(z_src) + self.lin_dst(z_dst)
+        h = self.fc1(torch.cat([z_src, z_dst], dim=1))
         h = h.relu()
-        return self.lin_out(h).sigmoid().view(-1)
+        return self.fc2(h)
 
 
 def train(

--- a/examples/linkproppred/gcn.py
+++ b/examples/linkproppred/gcn.py
@@ -124,7 +124,7 @@ class LinkPredictor(nn.Module):
     def forward(self, z_src: torch.Tensor, z_dst: torch.Tensor) -> torch.Tensor:
         h = self.fc1(torch.cat([z_src, z_dst], dim=1))
         h = h.relu()
-        return self.fc2(h)
+        return self.fc2(h).sigmoid().view(-1)
 
 
 def train(

--- a/examples/linkproppred/gcn.py
+++ b/examples/linkproppred/gcn.py
@@ -118,14 +118,13 @@ class GCNEncoder(torch.nn.Module):
 class LinkPredictor(nn.Module):
     def __init__(self, dim: int) -> None:
         super().__init__()
-        self.lin_src = nn.Linear(dim, dim)
-        self.lin_dst = nn.Linear(dim, dim)
-        self.lin_out = nn.Linear(dim, 1)
+        self.fc1 = nn.Linear(2 * dim, dim)
+        self.fc2 = nn.Linear(dim, 1)
 
     def forward(self, z_src: torch.Tensor, z_dst: torch.Tensor) -> torch.Tensor:
-        h = self.lin_src(z_src) + self.lin_dst(z_dst)
+        h = self.fc1(torch.cat([z_src, z_dst], dim=1))
         h = h.relu()
-        return self.lin_out(h).sigmoid().view(-1)
+        return self.fc2(h)
 
 
 def train(

--- a/examples/linkproppred/graphmixer.py
+++ b/examples/linkproppred/graphmixer.py
@@ -188,14 +188,13 @@ class MLPMixer(nn.Module):
 class LinkPredictor(nn.Module):
     def __init__(self, dim: int) -> None:
         super().__init__()
-        self.lin_src = nn.Linear(dim, dim)
-        self.lin_dst = nn.Linear(dim, dim)
-        self.lin_out = nn.Linear(dim, 1)
+        self.fc1 = nn.Linear(2 * dim, dim)
+        self.fc2 = nn.Linear(dim, 1)
 
     def forward(self, z_src: torch.Tensor, z_dst: torch.Tensor) -> torch.Tensor:
-        h = self.lin_src(z_src) + self.lin_dst(z_dst)
+        h = self.fc1(torch.cat([z_src, z_dst], dim=1))
         h = h.relu()
-        return self.lin_out(h).sigmoid().view(-1)
+        return self.fc2(h)
 
 
 def train(

--- a/examples/linkproppred/graphmixer.py
+++ b/examples/linkproppred/graphmixer.py
@@ -194,7 +194,7 @@ class LinkPredictor(nn.Module):
     def forward(self, z_src: torch.Tensor, z_dst: torch.Tensor) -> torch.Tensor:
         h = self.fc1(torch.cat([z_src, z_dst], dim=1))
         h = h.relu()
-        return self.fc2(h)
+        return self.fc2(h).sigmoid().view(-1)
 
 
 def train(

--- a/examples/linkproppred/tgat.py
+++ b/examples/linkproppred/tgat.py
@@ -50,6 +50,18 @@ parser.add_argument(
 )
 
 
+class MergeLayer(nn.Module):
+    def __init__(self, in_dim1: int, in_dim2: int, hidden_dim: int, output_dim: int):
+        super().__init__()
+        self.fc1 = nn.Linear(in_dim1 + in_dim2, hidden_dim)
+        self.fc2 = nn.Linear(hidden_dim, output_dim)
+
+    def forward(self, x1: torch.Tensor, x2: torch.Tensor):
+        h = self.fc1(torch.cat([x1, x2], dim=1))
+        h = h.relu()
+        return self.fc2(h)
+
+
 class TGAT(nn.Module):
     def __init__(
         self,
@@ -133,7 +145,7 @@ class LinkPredictor(nn.Module):
     def forward(self, z_src: torch.Tensor, z_dst: torch.Tensor) -> torch.Tensor:
         h = self.fc1(torch.cat([z_src, z_dst], dim=1))
         h = h.relu()
-        return self.fc2(h)
+        return self.fc2(h).sigmoid().view(-1)
 
 
 def train(

--- a/examples/linkproppred/tgat.py
+++ b/examples/linkproppred/tgat.py
@@ -127,14 +127,13 @@ class TGAT(nn.Module):
 class LinkPredictor(nn.Module):
     def __init__(self, dim: int) -> None:
         super().__init__()
-        self.lin_src = nn.Linear(dim, dim)
-        self.lin_dst = nn.Linear(dim, dim)
-        self.lin_out = nn.Linear(dim, 1)
+        self.fc1 = nn.Linear(2 * dim, dim)
+        self.fc2 = nn.Linear(dim, 1)
 
     def forward(self, z_src: torch.Tensor, z_dst: torch.Tensor) -> torch.Tensor:
-        h = self.lin_src(z_src) + self.lin_dst(z_dst)
+        h = self.fc1(torch.cat([z_src, z_dst], dim=1))
         h = h.relu()
-        return self.lin_out(h).sigmoid().view(-1)
+        return self.fc2(h)
 
 
 def train(

--- a/examples/linkproppred/tgn.py
+++ b/examples/linkproppred/tgn.py
@@ -318,14 +318,13 @@ class GraphAttentionEmbedding(nn.Module):
 class LinkPredictor(nn.Module):
     def __init__(self, dim: int) -> None:
         super().__init__()
-        self.lin_src = nn.Linear(dim, dim)
-        self.lin_dst = nn.Linear(dim, dim)
-        self.lin_out = nn.Linear(dim, 1)
+        self.fc1 = nn.Linear(2 * dim, dim)
+        self.fc2 = nn.Linear(dim, 1)
 
     def forward(self, z_src: torch.Tensor, z_dst: torch.Tensor) -> torch.Tensor:
-        h = self.lin_src(z_src) + self.lin_dst(z_dst)
+        h = self.fc1(torch.cat([z_src, z_dst], dim=1))
         h = h.relu()
-        return self.lin_out(h).sigmoid().view(-1)
+        return self.fc2(h)
 
 
 def train(

--- a/examples/linkproppred/tgn.py
+++ b/examples/linkproppred/tgn.py
@@ -52,6 +52,18 @@ parser.add_argument(
 )
 
 
+class MergeLayer(nn.Module):
+    def __init__(self, in_dim1: int, in_dim2: int, hidden_dim: int, output_dim: int):
+        super().__init__()
+        self.fc1 = nn.Linear(in_dim1 + in_dim2, hidden_dim)
+        self.fc2 = nn.Linear(hidden_dim, output_dim)
+
+    def forward(self, x1: torch.Tensor, x2: torch.Tensor):
+        h = self.fc1(torch.cat([x1, x2], dim=1))
+        h = h.relu()
+        return self.fc2(h)
+
+
 class TGN(torch.nn.Module):
     def __init__(
         self,
@@ -324,7 +336,7 @@ class LinkPredictor(nn.Module):
     def forward(self, z_src: torch.Tensor, z_dst: torch.Tensor) -> torch.Tensor:
         h = self.fc1(torch.cat([z_src, z_dst], dim=1))
         h = h.relu()
-        return self.fc2(h)
+        return self.fc2(h).sigmoid().view(-1)
 
 
 def train(


### PR DESCRIPTION
### Purpose
The purpose of this PR is to port over the isolated changes to `LinkPredictor` modules that were discovered while debugging against dyglib (#138 )

### Changes

#### `torch.cat` the `src` and `dst` embeddings
https://github.com/tgm-team/tgm/blob/901d24088890d63f62025dc7fbff93c725e66838/examples/linkproppred/TGB/tgat.py#L142

#### MergeLayer Modules

I'm just adding these in the relevant example files. But leaving the integration into the forward pass for #138. This will just reduce the noise in the diff of the other PR.

### Relevant Issues
Close #169 