### PR TITLE
Add Sentinal Node Id for Marking Invalid Neighbors

### DIFF
--- a/examples/linkproppred/TGB/tgat.py
+++ b/examples/linkproppred/TGB/tgat.py
@@ -11,6 +11,7 @@ from tgb.linkproppred.evaluate import Evaluator
 from tqdm import tqdm
 
 from tgm import DGBatch, DGData, DGraph
+from tgm.constants import INVALID_NODE_ID
 from tgm.hooks import (
     DGHook,
     NegativeEdgeSamplerHook,
@@ -126,7 +127,7 @@ class TGAT(nn.Module):
                 edge_feat=batch.nbr_feats[hop],
                 nbr_node_feat=nbr_feat,
                 nbr_time_feat=nbr_time_feat,
-                nbr_mask=nbr_mask,
+                invalid_nbr_mask=nbr_mask == INVALID_NODE_ID,
             )
             z[batch.global_to_local(seed_nodes)] = out
         return z

--- a/examples/linkproppred/TGB/tgn.py
+++ b/examples/linkproppred/TGB/tgn.py
@@ -12,6 +12,7 @@ from tgb.linkproppred.evaluate import Evaluator
 from tqdm import tqdm
 
 from tgm import DGBatch, DGData, DGraph
+from tgm.constants import INVALID_NODE_ID
 from tgm.hooks import (
     DGHook,
     NegativeEdgeSamplerHook,
@@ -317,7 +318,7 @@ class GraphAttentionEmbedding(nn.Module):
                 edge_feat=batch.nbr_feats[hop],
                 nbr_node_feat=nbr_feat,
                 nbr_time_feat=nbr_time_feat,
-                nbr_mask=nbr_mask,
+                invalid_nbr_mask=nbr_mask == INVALID_NODE_ID,
             )
             z[batch.global_to_local(seed_nodes)] = out
         return z

--- a/examples/linkproppred/tgat.py
+++ b/examples/linkproppred/tgat.py
@@ -10,6 +10,7 @@ from torchmetrics.classification import BinaryAUROC, BinaryAveragePrecision
 from tqdm import tqdm
 
 from tgm import DGBatch, DGData, DGraph
+from tgm.constants import INVALID_NODE_ID
 from tgm.hooks import (
     DGHook,
     NegativeEdgeSamplerHook,
@@ -123,7 +124,7 @@ class TGAT(nn.Module):
                 edge_feat=batch.nbr_feats[hop],
                 nbr_node_feat=nbr_feat,
                 nbr_time_feat=nbr_time_feat,
-                nbr_mask=nbr_mask,
+                invalid_nbr_mask=nbr_mask == INVALID_NODE_ID,
             )
             z[batch.global_to_local(seed_nodes)] = out
 

--- a/examples/linkproppred/tgn.py
+++ b/examples/linkproppred/tgn.py
@@ -12,6 +12,7 @@ from torchmetrics.classification import BinaryAUROC, BinaryAveragePrecision
 from tqdm import tqdm
 
 from tgm import DGBatch, DGData, DGraph
+from tgm.constants import INVALID_NODE_ID
 from tgm.hooks import (
     DGHook,
     NegativeEdgeSamplerHook,
@@ -314,7 +315,7 @@ class GraphAttentionEmbedding(nn.Module):
                 edge_feat=batch.nbr_feats[hop],
                 nbr_node_feat=nbr_feat,
                 nbr_time_feat=nbr_time_feat,
-                nbr_mask=nbr_mask,
+                invalid_nbr_mask=nbr_mask == INVALID_NODE_ID,
             )
             z[batch.global_to_local(seed_nodes)] = out
 

--- a/test/unit/test_data.py
+++ b/test/unit/test_data.py
@@ -150,6 +150,25 @@ def test_init_dg_data_sort_required():
     assert data.time_delta == TimeDeltaDG('r')
 
 
+def test_init_dg_data_bad_args_invalid_node_id():
+    edge_index = torch.LongTensor([[-1, 3], [10, 20]])
+    edge_timestamps = torch.LongTensor([1, 5])
+    with pytest.raises(ValueError):
+        _ = DGData.from_raw(edge_timestamps, edge_index)
+
+    edge_index = torch.LongTensor([[1, 3], [10, 20]])
+    edge_timestamps = torch.LongTensor([1, 5])
+    node_ids = torch.LongTensor([-1])
+    node_timestamps = torch.LongTensor([1])
+    with pytest.raises(ValueError):
+        _ = DGData.from_raw(
+            edge_timestamps,
+            edge_index,
+            node_ids=node_ids,
+            node_timestamps=node_timestamps,
+        )
+
+
 def test_init_dg_data_bad_args_empty_graph():
     # Empty graph not supported
     with pytest.raises(ValueError):

--- a/test/unit/test_hooks/test_neighbor_sampler_hook.py
+++ b/test/unit/test_hooks/test_neighbor_sampler_hook.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 
 from tgm import DGBatch, DGraph
+from tgm.constants import INVALID_NODE_ID
 from tgm.data import DGData
 from tgm.hooks import NeighborSamplerHook
 from tgm.loader import DGDataLoader
@@ -25,7 +26,6 @@ def test_hook_dependancies():
         'nbr_nids',
         'nbr_times',
         'nbr_feats',
-        'nbr_mask',
     }
 
 
@@ -54,7 +54,6 @@ def test_neighbor_sampler_hook_link_pred(data):
     assert hasattr(batch, 'nbr_nids')
     assert hasattr(batch, 'nbr_times')
     assert hasattr(batch, 'nbr_feats')
-    assert hasattr(batch, 'nbr_mask')
 
 
 def test_neighbor_sampler_hook_node_pred(data):
@@ -66,10 +65,6 @@ def test_neighbor_sampler_hook_node_pred(data):
     assert hasattr(batch, 'nbr_nids')
     assert hasattr(batch, 'nbr_times')
     assert hasattr(batch, 'nbr_feats')
-    assert hasattr(batch, 'nbr_mask')
-
-
-EMPTY = -1  # use to indicate uninitialized vectors
 
 
 def _nbrs_2_np(batch: DGBatch) -> List[np.ndarray]:
@@ -79,14 +74,12 @@ def _nbrs_2_np(batch: DGBatch) -> List[np.ndarray]:
     assert hasattr(batch, 'nbr_nids')
     assert hasattr(batch, 'nbr_times')
     assert hasattr(batch, 'nbr_feats')
-    assert hasattr(batch, 'nbr_mask')
 
     nids = np.array(batch.nids)
     nbr_nids = np.array(batch.nbr_nids)
     nbr_times = np.array(batch.nbr_times)
     nbr_feats = np.array(batch.nbr_feats)
-    nbr_mask = np.array(batch.nbr_mask)
-    return [nids, nbr_nids, nbr_times, nbr_feats, nbr_mask]
+    return [nids, nbr_nids, nbr_times, nbr_feats]
 
 
 @pytest.fixture
@@ -136,54 +129,51 @@ def test_init_basic_sampled_graph_1_hop(basic_sample_graph):
 
     batch_iter = iter(loader)
     batch_1 = next(batch_iter)
-    nids, nbr_nids, nbr_times, nbr_feats, nbr_mask = _nbrs_2_np(batch_1)
+    nids, nbr_nids, nbr_times, nbr_feats = _nbrs_2_np(batch_1)
     assert nids.shape == (1, 2)
     assert nids[0][0] == 0
     assert nids[0][1] == 1
     assert nbr_nids.shape == (1, 2, 1)
-    assert nbr_nids[0][0][0] == EMPTY
-    assert nbr_nids[0][1][0] == EMPTY
+    assert nbr_nids[0][0][0] == INVALID_NODE_ID
+    assert nbr_nids[0][1][0] == INVALID_NODE_ID
     assert nbr_times.shape == (1, 2, 1)
-    assert nbr_times[0][0][0] == EMPTY
-    assert nbr_times[0][1][0] == EMPTY
+    assert nbr_times[0][0][0] == INVALID_NODE_ID
+    assert nbr_times[0][1][0] == INVALID_NODE_ID
     assert nbr_feats.shape == (1, 2, 1, 1)  # 1 feature per edge
-    assert nbr_feats[0][1][0][0] == nbr_feats[0][0][0][0] == EMPTY
-    assert nbr_mask.shape == (1, 2, 1)
+    assert nbr_feats[0][1][0][0] == nbr_feats[0][0][0][0] == INVALID_NODE_ID
 
     batch_2 = next(batch_iter)
-    nids, nbr_nids, nbr_times, nbr_feats, nbr_mask = _nbrs_2_np(batch_2)
+    nids, nbr_nids, nbr_times, nbr_feats = _nbrs_2_np(batch_2)
     assert nids.shape == (1, 2)
     assert nids[0][0] == 0
     assert nids[0][1] == 2
     assert nbr_nids.shape == (1, 2, 1)
     assert nbr_nids[0][0][0] == 1
-    assert nbr_nids[0][1][0] == EMPTY
+    assert nbr_nids[0][1][0] == INVALID_NODE_ID
     assert nbr_times.shape == (1, 2, 1)
     assert nbr_times[0][0][0] == 1
-    assert nbr_times[0][1][0] == EMPTY
+    assert nbr_times[0][1][0] == INVALID_NODE_ID
     assert nbr_feats.shape == (1, 2, 1, 1)  # 1 feature per edge
     assert nbr_feats[0][0][0][0] == 1.0
-    assert nbr_feats[0][1][0][0] == EMPTY
-    assert nbr_mask.shape == (1, 2, 1)
+    assert nbr_feats[0][1][0][0] == INVALID_NODE_ID
 
     batch_3 = next(batch_iter)
-    nids, nbr_nids, nbr_times, nbr_feats, nbr_mask = _nbrs_2_np(batch_3)
+    nids, nbr_nids, nbr_times, nbr_feats = _nbrs_2_np(batch_3)
     assert nids.shape == (1, 2)
     assert nids[0][0] == 2
     assert nids[0][1] == 3
     assert nbr_nids.shape == (1, 2, 1)
     assert nbr_nids[0][0][0] == 0
-    assert nbr_nids[0][1][0] == EMPTY
+    assert nbr_nids[0][1][0] == INVALID_NODE_ID
     assert nbr_times.shape == (1, 2, 1)
     assert nbr_times[0][0][0] == 2
-    assert nbr_times[0][1][0] == EMPTY
+    assert nbr_times[0][1][0] == INVALID_NODE_ID
     assert nbr_feats.shape == (1, 2, 1, 1)  # 1 feature per edge
     assert nbr_feats[0][0][0][0] == 2.0
-    assert nbr_feats[0][1][0][0] == EMPTY
-    assert nbr_mask.shape == (1, 2, 1)
+    assert nbr_feats[0][1][0][0] == INVALID_NODE_ID
 
     batch_4 = next(batch_iter)
-    nids, nbr_nids, nbr_times, nbr_feats, nbr_mask = _nbrs_2_np(batch_4)
+    nids, nbr_nids, nbr_times, nbr_feats = _nbrs_2_np(batch_4)
     assert nids.shape == (1, 2)
     assert nids[0][0] == 2
     assert nids[0][1] == 0
@@ -196,4 +186,3 @@ def test_init_basic_sampled_graph_1_hop(basic_sample_graph):
     assert nbr_feats.shape == (1, 2, 1, 1)  # 1 feature per edge
     assert nbr_feats[0][0][0][0] == 5.0
     assert nbr_feats[0][1][0][0] == 2.0
-    assert nbr_mask.shape == (1, 2, 1)

--- a/test/unit/test_model/test_temporal_attention.py
+++ b/test/unit/test_model/test_temporal_attention.py
@@ -34,7 +34,7 @@ def test_temporal_attention_forward():
     edge_feat = torch.rand(batch_size, num_nbr, edge_dim)
     nbr_node_feat = torch.rand(batch_size, num_nbr, node_dim)
     nbr_time_feat = torch.rand(batch_size, num_nbr, time_dim)
-    nbr_mask = torch.zeros(batch_size, num_nbr)
+    nbr_mask = torch.zeros(batch_size, num_nbr, dtype=bool)
 
     out = attn(node_feat, time_feat, edge_feat, nbr_node_feat, nbr_time_feat, nbr_mask)
     assert torch.is_tensor(out)
@@ -55,7 +55,7 @@ def test_temporal_attention_forward_with_padding():
     edge_feat = torch.rand(batch_size, num_nbr, edge_dim)
     nbr_node_feat = torch.rand(batch_size, num_nbr, node_dim)
     nbr_time_feat = torch.rand(batch_size, num_nbr, time_dim)
-    nbr_mask = torch.zeros(batch_size, num_nbr)
+    nbr_mask = torch.zeros(batch_size, num_nbr, dtype=bool)
 
     out = attn(node_feat, time_feat, edge_feat, nbr_node_feat, nbr_time_feat, nbr_mask)
     assert torch.is_tensor(out)

--- a/tgm/_storage/backends/array_backend.py
+++ b/tgm/_storage/backends/array_backend.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional, Set, Tuple
 import torch
 from torch import Tensor
 
+from tgm.constants import INVALID_NODE_ID
 from tgm.data import DGData
 
 from ..base import DGSliceTracker, DGStorageBase
@@ -102,10 +103,11 @@ class DGStorageArrayBackend(DGStorageBase):
                 nbrs[d].append((i, s))
 
         B = len(seed_nodes)
-        nbr_nids = torch.full((B, num_nbrs), -1, dtype=torch.long, device=device)
+        nbr_nids = torch.full(
+            (B, num_nbrs), INVALID_NODE_ID, dtype=torch.long, device=device
+        )
         nbr_times = torch.zeros(B, num_nbrs, dtype=torch.long, device=device)
         nbr_feats = torch.zeros(B, num_nbrs, self.get_edge_feats_dim(), device=device)  # type: ignore
-        nbr_mask = torch.zeros(B, num_nbrs, dtype=torch.long, device=device)
 
         for i, node in enumerate(unique_nodes.tolist()):
             node_nbrs = nbrs[node]
@@ -129,9 +131,8 @@ class DGStorageArrayBackend(DGStorageBase):
             nbr_times[mask, :nn] = torch.tensor(times, dtype=torch.long, device=device)
             if self._data.edge_feats is not None:
                 nbr_feats[mask, :nn] = torch.stack(feats).to(device).float()
-            nbr_mask[mask, :nn] = 1
 
-        return nbr_nids, nbr_times, nbr_feats, nbr_mask
+        return nbr_nids, nbr_times, nbr_feats
 
     def get_static_node_feats(self) -> Optional[Tensor]:
         return self._data.static_node_feats

--- a/tgm/constants.py
+++ b/tgm/constants.py
@@ -1,0 +1,3 @@
+from typing import Final
+
+INVALID_NODE_ID: Final[int] = -1  # Sentinal id marking 'no valid neighbors'

--- a/tgm/data.py
+++ b/tgm/data.py
@@ -10,6 +10,7 @@ import numpy as np
 import torch
 from torch import Tensor
 
+from tgm.constants import INVALID_NODE_ID
 from tgm.split import SplitStrategy, TemporalRatioSplit, TGBSplit
 from tgm.timedelta import TGB_TIME_DELTAS, TimeDeltaDG
 
@@ -52,6 +53,10 @@ class DGData:
         if self.edge_index.ndim != 2 or self.edge_index.shape[1] != 2:
             raise ValueError(
                 f'edge_index must have shape [num_edges, 2], got: {self.edge_index.shape}',
+            )
+        if torch.any(self.edge_index == INVALID_NODE_ID):
+            raise ValueError(
+                f'Edge events contains node ids matching INVALID_NODE_ID: {INVALID_NODE_ID}, which is used to mark invalid neighbors. Try remapping all node ids to positive integers.'
             )
 
         num_edges = self.edge_index.shape[0]
@@ -99,6 +104,10 @@ class DGData:
                 raise ValueError(
                     'node_ids must have shape [num_node_events], ',
                     f'got {num_node_events} node events and shape {self.node_ids.shape}',  # type: ignore
+                )
+            if torch.any(self.node_ids == INVALID_NODE_ID):  # type: ignore
+                raise ValueError(
+                    f'Node events contains node ids matching INVALID_NODE_ID: {INVALID_NODE_ID}, which is used to mark invalid neighbors. Try remapping all node ids to positive integers.'
                 )
 
             # Validate dynamic node features (could be None)


### PR DESCRIPTION
### Purpose
The purpose of this PR is to add a global `tgm` library constant `INVALID_NODE_ID` which denotes the node id that we use for marking _invalid neighors_ during sampling. Currently, we chose `-1`. It will be annoyuing to users who have negative node ids, but we don't see this as the common situation.

### Changes

#### Added `INVALID_NODE_ID`
A global constant available in `tgm/constants.py`.

#### Removed `nbr_mask` from the sampler API
The `nbr_mask` is not used to recursively prune neighborhood info. Instead, our nbr_mask can _always_ be computed at any stage by doing `batch.nbr_nids[i] == INVALID_NODE_ID`. Therefore, I think there is no need to return this mask explicitly, as it's sort of redundant.

#### Samplers
Samplers just use the placehodlers constant `INVALID_NODE_ID` instead of hardcoding `-1` for makring incomplete neighborhood searches.

#### Data Loading
I am now throwing an exception if either the edge events or node events contains node ids that match the `INVALID_NODE_ID` sentinal value.

#### Attention
This one we can think about. I decided to rename `nbr_mask` to `invalid_nbr_mask` to make it more clear that this should be a boolearn tensor marking _invalid_ node positions, rather than valid ones (this is what we used for masked softmax).

### Relevant Issues
Close #177 