### PR TITLE
Hook Management Registry

### DIFF
--- a/examples/linkproppred/TGB/edgebank.py
+++ b/examples/linkproppred/TGB/edgebank.py
@@ -78,7 +78,7 @@ train_data = train_dg.materialize(materialize_features=False)
 val_neg_hook = TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='val')
 test_neg_hook = TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='test')
 
-hm = HookManager()
+hm = HookManager(keys=['val', 'test'])
 hm.register('val', val_neg_hook)
 hm.register('test', test_neg_hook)
 

--- a/examples/linkproppred/TGB/gcn.py
+++ b/examples/linkproppred/TGB/gcn.py
@@ -254,7 +254,7 @@ train_neg_hook = NegativeEdgeSamplerHook(low=int(dst.min()), high=int(dst.max())
 val_neg_hook = TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='val')
 test_neg_hook = TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='test')
 
-hm = HookManager(args.device)
+hm = HookManager(keys=['train', 'val', 'test'])
 hm.register('train', train_neg_hook)
 hm.register('val', val_neg_hook)
 hm.register('test', test_neg_hook)

--- a/examples/linkproppred/TGB/tgat.py
+++ b/examples/linkproppred/TGB/tgat.py
@@ -256,9 +256,9 @@ hm.register('val', val_neg_hook)
 hm.register('test', test_neg_hook)
 hm.register_shared(nbr_hook)
 
-train_loader = DGDataLoader(train_dg, args.bsize, hm=hm)
-val_loader = DGDataLoader(val_dg, args.bsize, hm=hm)
-test_loader = DGDataLoader(test_dg, args.bsize, hm=hm)
+train_loader = DGDataLoader(train_dg, args.bsize, hook_manager=hm)
+val_loader = DGDataLoader(val_dg, args.bsize, hook_manager=hm)
+test_loader = DGDataLoader(test_dg, args.bsize, hook_manager=hm)
 
 encoder = TGAT(
     edge_dim=train_dg.edge_feats_dim or args.embed_dim,
@@ -297,4 +297,4 @@ with hm.activate('test'):
     test_results = eval(
         test_loader, static_node_feats, encoder, decoder, eval_metric, evaluator
     )
-print(' '.join(f'{k}={v:.4f}' for k, v in test_results.items()))
+    print(' '.join(f'{k}={v:.4f}' for k, v in test_results.items()))

--- a/examples/linkproppred/TGB/tgat.py
+++ b/examples/linkproppred/TGB/tgat.py
@@ -13,13 +13,13 @@ from tqdm import tqdm
 from tgm import DGBatch, DGData, DGraph
 from tgm.constants import PADDED_NODE_ID
 from tgm.hooks import (
+    DeviceTransferHook,
     HookManager,
     NegativeEdgeSamplerHook,
     NeighborSamplerHook,
     RecencyNeighborHook,
     TGBNegativeEdgeSamplerHook,
 )
-from tgm.hooks.hooks import DeviceTransferHook
 from tgm.loader import DGDataLoader
 from tgm.nn import TemporalAttention, Time2Vec
 from tgm.util.seed import seed_everything

--- a/examples/linkproppred/TGB/tgat.py
+++ b/examples/linkproppred/TGB/tgat.py
@@ -13,6 +13,7 @@ from tqdm import tqdm
 from tgm import DGBatch, DGData, DGraph
 from tgm.constants import PADDED_NODE_ID
 from tgm.hooks import (
+    HookManager,
     NegativeEdgeSamplerHook,
     NeighborSamplerHook,
     RecencyNeighborHook,
@@ -243,14 +244,21 @@ elif args.sampling_type == 'recency':
 else:
     raise ValueError(f'Unknown sampling type: {args.sampling}')
 
+
 _, dst, _ = train_dg.edges
 train_neg_hook = NegativeEdgeSamplerHook(low=int(dst.min()), high=int(dst.max()))
 val_neg_hook = TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='val')
 test_neg_hook = TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='test')
 
-train_loader = DGDataLoader(train_dg, args.bsize, hooks=[nbr_hook, train_neg_hook])
-val_loader = DGDataLoader(val_dg, args.bsize, hooks=[nbr_hook, val_neg_hook])
-test_loader = DGDataLoader(test_dg, args.bsize, hooks=[nbr_hook, test_neg_hook])
+hook_manager = HookManager()
+hook_manager.register('train', train_neg_hook)
+hook_manager.register('val', val_neg_hook)
+hook_manager.register('test', test_neg_hook)
+hook_manager.register_shared(nbr_hook)
+
+train_loader = DGDataLoader(train_dg, args.bsize, hook_manager=hook_manager)
+val_loader = DGDataLoader(val_dg, args.bsize, hook_manager=hook_manager)
+test_loader = DGDataLoader(test_dg, args.bsize, hook_manager=hook_manager)
 
 encoder = TGAT(
     edge_dim=train_dg.edge_feats_dim or args.embed_dim,
@@ -266,14 +274,16 @@ opt = torch.optim.Adam(
 )
 
 for epoch in range(1, args.epochs + 1):
-    start_time = time.perf_counter()
-    loss = train(train_loader, static_node_feats, encoder, decoder, opt)
-    end_time = time.perf_counter()
-    latency = end_time - start_time
+    with hook_manager.activate('train'):
+        start_time = time.perf_counter()
+        loss = train(train_loader, static_node_feats, encoder, decoder, opt)
+        end_time = time.perf_counter()
+        latency = end_time - start_time
 
-    val_results = eval(
-        val_loader, static_node_feats, encoder, decoder, eval_metric, evaluator
-    )
+    with hook_manager.activate('val'):
+        val_results = eval(
+            val_loader, static_node_feats, encoder, decoder, eval_metric, evaluator
+        )
 
     print(
         f'Epoch={epoch:02d} Latency={latency:.4f} Loss={loss:.4f} '
@@ -281,10 +291,10 @@ for epoch in range(1, args.epochs + 1):
     )
 
     if epoch < args.epochs:  # Reset hooks after each epoch, except last epoch
-        train_loader._hook.reset_state()
-        val_loader._hook.reset_state()  # This is technically redundant
+        hook_manager.reset_state()
 
-test_results = eval(
-    test_loader, static_node_feats, encoder, decoder, eval_metric, evaluator
-)
+with hook_manager.activate('test'):
+    test_results = eval(
+        test_loader, static_node_feats, encoder, decoder, eval_metric, evaluator
+    )
 print(' '.join(f'{k}={v:.4f}' for k, v in test_results.items()))

--- a/examples/linkproppred/TGB/tgat.py
+++ b/examples/linkproppred/TGB/tgat.py
@@ -13,7 +13,6 @@ from tqdm import tqdm
 from tgm import DGBatch, DGData, DGraph
 from tgm.constants import PADDED_NODE_ID
 from tgm.hooks import (
-    DeviceTransferHook,
     HookManager,
     NegativeEdgeSamplerHook,
     NeighborSamplerHook,
@@ -251,12 +250,11 @@ train_neg_hook = NegativeEdgeSamplerHook(low=int(dst.min()), high=int(dst.max())
 val_neg_hook = TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='val')
 test_neg_hook = TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='test')
 
-hm = HookManager()
+hm = HookManager(args.device)
 hm.register('train', train_neg_hook)
 hm.register('val', val_neg_hook)
 hm.register('test', test_neg_hook)
 hm.register_shared(nbr_hook)
-hm.register_shared(DeviceTransferHook(args.device))
 
 train_loader = DGDataLoader(train_dg, args.bsize, hm=hm)
 val_loader = DGDataLoader(val_dg, args.bsize, hm=hm)

--- a/examples/linkproppred/TGB/tgat.py
+++ b/examples/linkproppred/TGB/tgat.py
@@ -250,7 +250,7 @@ train_neg_hook = NegativeEdgeSamplerHook(low=int(dst.min()), high=int(dst.max())
 val_neg_hook = TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='val')
 test_neg_hook = TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='test')
 
-hm = HookManager(args.device)
+hm = HookManager(keys=['train', 'val', 'test'])
 hm.register('train', train_neg_hook)
 hm.register('val', val_neg_hook)
 hm.register('test', test_neg_hook)

--- a/examples/linkproppred/TGB/tgn.py
+++ b/examples/linkproppred/TGB/tgn.py
@@ -480,7 +480,7 @@ for epoch in range(1, args.epochs + 1):
         end_time = time.perf_counter()
         latency = end_time - start_time
 
-        with hm.activaet('val'):
+        with hm.activate('val'):
             val_results = eval(
                 val_loader, static_node_feats, encoder, decoder, eval_metric, evaluator
             )

--- a/examples/linkproppred/TGB/tgn.py
+++ b/examples/linkproppred/TGB/tgn.py
@@ -447,7 +447,7 @@ train_neg_hook = NegativeEdgeSamplerHook(low=int(dst.min()), high=int(dst.max())
 val_neg_hook = TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='val')
 test_neg_hook = TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='test')
 
-hm = HookManager(args.device)
+hm = HookManager(keys=['train', 'val', 'test'])
 hm.register('train', train_neg_hook)
 hm.register('val', val_neg_hook)
 hm.register('test', test_neg_hook)

--- a/examples/linkproppred/TGB/tgn.py
+++ b/examples/linkproppred/TGB/tgn.py
@@ -1,7 +1,7 @@
 import argparse
 import time
 from collections import defaultdict
-from typing import Dict, List, Tuple
+from typing import Dict, Tuple
 
 import numpy as np
 import torch
@@ -14,7 +14,7 @@ from tqdm import tqdm
 from tgm import DGBatch, DGData, DGraph
 from tgm.constants import PADDED_NODE_ID
 from tgm.hooks import (
-    DGHook,
+    HookManager,
     NegativeEdgeSamplerHook,
     NeighborSamplerHook,
     RecencyNeighborHook,
@@ -429,36 +429,33 @@ else:
     )
 
 
-def _init_hooks(
-    dg: DGraph, sampling_type: str, neg_sampler: object, split_mode: str
-) -> List[DGHook]:
-    if sampling_type == 'uniform':
-        nbr_hook = NeighborSamplerHook(num_nbrs=args.n_nbrs)
-    elif sampling_type == 'recency':
-        nbr_hook = RecencyNeighborHook(
-            num_nbrs=args.n_nbrs,
-            num_nodes=dg.num_nodes,
-            edge_feats_dim=dg.edge_feats_dim,
-        )
-    else:
-        raise ValueError(f'Unknown sampling type: {args.sampling}')
-
-    # Always produce negative edge prior to neighbor sampling for link prediction
-    if split_mode in ['val', 'test']:
-        neg_hook = TGBNegativeEdgeSamplerHook(neg_sampler, split_mode=split_mode)
-    else:
-        _, dst, _ = dg.edges
-        min_dst, max_dst = int(dst.min()), int(dst.max())
-        neg_hook = NegativeEdgeSamplerHook(low=min_dst, high=max_dst)
-    return [neg_hook, nbr_hook]
+# Neighbor Sampler is shared across loaders
+if args.sampling_type == 'uniform':
+    nbr_hook = NeighborSamplerHook(num_nbrs=args.num_nbrs)
+elif args.sampling_type == 'recency':
+    nbr_hook = RecencyNeighborHook(
+        num_nbrs=args.n_nbrs,
+        num_nodes=test_dg.num_nodes,  # Assuming node ids at test set > train/val set
+        edge_feats_dim=test_dg.edge_feats_dim,
+    )
+else:
+    raise ValueError(f'Unknown sampling type: {args.sampling}')
 
 
-test_loader = DGDataLoader(
-    test_dg,
-    hook=_init_hooks(test_dg, args.sampling, neg_sampler, 'test'),
-    batch_size=args.bsize,
-)
+_, dst, _ = train_dg.edges
+train_neg_hook = NegativeEdgeSamplerHook(low=int(dst.min()), high=int(dst.max()))
+val_neg_hook = TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='val')
+test_neg_hook = TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='test')
 
+hm = HookManager(args.device)
+hm.register('train', train_neg_hook)
+hm.register('val', val_neg_hook)
+hm.register('test', test_neg_hook)
+hm.register_shared(nbr_hook)
+
+train_loader = DGDataLoader(train_dg, args.bsize, hook_manager=hm)
+val_loader = DGDataLoader(val_dg, args.bsize, hook_manager=hm)
+test_loader = DGDataLoader(test_dg, args.bsize, hook_manager=hm)
 
 encoder = TGN(
     edge_dim=train_dg.edge_feats_dim or args.embed_dim,
@@ -477,35 +474,29 @@ opt = torch.optim.Adam(
 
 
 for epoch in range(1, args.epochs + 1):
-    # TODO: Need a clean way to clear nbr state across epochs
-    train_loader = DGDataLoader(
-        train_dg,
-        hook=_init_hooks(test_dg, args.sampling, neg_sampler, 'train'),
-        batch_size=args.bsize,
-    )
-    val_loader = DGDataLoader(
-        val_dg,
-        hook=_init_hooks(test_dg, args.sampling, neg_sampler, 'val'),
-        batch_size=args.bsize,
-    )
-    start_time = time.perf_counter()
-    loss = train(train_loader, static_node_feats, encoder, decoder, opt)
-    end_time = time.perf_counter()
-    latency = end_time - start_time
+    with hm.activate('train'):
+        start_time = time.perf_counter()
+        loss = train(train_loader, static_node_feats, encoder, decoder, opt)
+        end_time = time.perf_counter()
+        latency = end_time - start_time
 
-    val_results = eval(
-        val_loader, static_node_feats, encoder, decoder, eval_metric, evaluator
-    )
-    print(
-        f'Epoch={epoch:02d} Latency={latency:.4f} Loss={loss:.4f} '
-        + ' '.join(f'{k}={v:.4f}' for k, v in val_results.items())
-    )
+        with hm.activaet('val'):
+            val_results = eval(
+                val_loader, static_node_feats, encoder, decoder, eval_metric, evaluator
+            )
+            print(
+                f'Epoch={epoch:02d} Latency={latency:.4f} Loss={loss:.4f} '
+                + ' '.join(f'{k}={v:.4f}' for k, v in val_results.items())
+            )
 
-    # Clear memory state between epochs
-    encoder.memory.clear_msgs(list(range(test_dg.num_nodes)))
+    # Clear memory state between epochs, except last epoch
+    if epoch < args.epochs:
+        hm.reset_state()
+        encoder.memory.clear_msgs(list(range(test_dg.num_nodes)))
 
 
-test_results = eval(
-    test_loader, static_node_feats, encoder, decoder, eval_metric, evaluator
-)
-print(' '.join(f'{k}={v:.4f}' for k, v in test_results.items()))
+with hm.activate('test'):
+    test_results = eval(
+        test_loader, static_node_feats, encoder, decoder, eval_metric, evaluator
+    )
+    print(' '.join(f'{k}={v:.4f}' for k, v in test_results.items()))

--- a/examples/linkproppred/edgebank.py
+++ b/examples/linkproppred/edgebank.py
@@ -53,7 +53,7 @@ test_dg = DGraph(test_data)
 train_data = train_dg.materialize(materialize_features=False)
 test_neg_hook = NegativeEdgeSamplerHook(low=0, high=test_dg.num_nodes)
 
-hm = HookManager()
+hm = HookManager(keys=['test'])
 hm.register('test', test_neg_hook)
 
 test_loader = DGDataLoader(test_dg, args.bsize, hook_manager=hm)

--- a/examples/linkproppred/gclstm.py
+++ b/examples/linkproppred/gclstm.py
@@ -10,7 +10,7 @@ from torchmetrics.classification import BinaryAUROC, BinaryAveragePrecision
 from tqdm import tqdm
 
 from tgm import DGBatch, DGData, DGraph
-from tgm.hooks import NegativeEdgeSamplerHook
+from tgm.hooks import HookManager, NegativeEdgeSamplerHook
 from tgm.loader import DGDataLoader
 from tgm.nn.recurrent import GCLSTM
 from tgm.util.seed import seed_everything
@@ -158,27 +158,24 @@ train_dg = DGraph(train_data, device=args.device)
 val_dg = DGraph(val_data, device=args.device)
 test_dg = DGraph(test_data, device=args.device)
 
-train_loader = DGDataLoader(
-    train_dg,
-    hook=NegativeEdgeSamplerHook(
-        low=int(train_dg.edges[1].min()), high=int(train_dg.edges[1].max())
-    ),
-    batch_unit=args.batch_time_gran,
+train_neg_hook = NegativeEdgeSamplerHook(
+    low=int(train_dg.edges[1].min()), high=int(train_dg.edges[1].max())
 )
-val_loader = DGDataLoader(
-    val_dg,
-    hook=NegativeEdgeSamplerHook(
-        low=int(val_dg.edges[1].min()), high=int(val_dg.edges[1].max())
-    ),
-    batch_unit=args.batch_time_gran,
+val_neg_hook = NegativeEdgeSamplerHook(
+    low=int(val_dg.edges[1].min()), high=int(val_dg.edges[1].max())
 )
-test_loader = DGDataLoader(
-    test_dg,
-    hook=NegativeEdgeSamplerHook(
-        low=int(test_dg.edges[1].min()), high=int(test_dg.edges[1].max())
-    ),
-    batch_unit=args.batch_time_gran,
+test_neg_hook = NegativeEdgeSamplerHook(
+    low=int(test_dg.edges[1].min()), high=int(test_dg.edges[1].max())
 )
+
+hm = HookManager(args.device)
+hm.register('train', train_neg_hook)
+hm.register('val', val_neg_hook)
+hm.register('test', test_neg_hook)
+
+train_loader = DGDataLoader(train_dg, batch_unit=args.batch_time_gran, hook_manager=hm)
+val_loader = DGDataLoader(val_dg, batch_unit=args.batch_time_gran, hook_manager=hm)
+test_loader = DGDataLoader(test_dg, batch_unit=args.batch_time_gran, hook_manager=hm)
 
 if train_dg.static_node_feats is not None:
     static_node_feats = train_dg.static_node_feats
@@ -197,22 +194,26 @@ val_metrics = MetricCollection(metrics, prefix='Validation')
 test_metrics = MetricCollection(metrics, prefix='Test')
 
 for epoch in range(1, args.epochs + 1):
-    start_time = time.perf_counter()
-    loss, h_0, c_0 = train(train_loader, static_node_feats, model, opt)
-    end_time = time.perf_counter()
-    latency = end_time - start_time
+    with hm.activate('train'):
+        start_time = time.perf_counter()
+        loss, h_0, c_0 = train(train_loader, static_node_feats, model, opt)
+        end_time = time.perf_counter()
+        latency = end_time - start_time
 
-    val_results, h_0, c_0 = eval(
-        val_loader, static_node_feats, h_0, c_0, model, val_metrics
-    )
-    val_metrics.reset()
+    with hm.activate('val'):
+        val_results, h_0, c_0 = eval(
+            val_loader, static_node_feats, h_0, c_0, model, val_metrics
+        )
+        val_metrics.reset()
 
     print(
         f'Epoch={epoch:02d} Latency={latency:.4f} Loss={loss:.4f} '
         + ' '.join(f'{k}={v.item():.4f}' for k, v in val_results.items())
     )
 
-test_results, h_0, c_0 = eval(
-    test_loader, static_node_feats, h_0, c_0, model, test_metrics
-)
-print(' '.join(f'{k}={v.item():.4f}' for k, v in test_results.items()))
+
+with hm.activate('test'):
+    test_results, h_0, c_0 = eval(
+        test_loader, static_node_feats, h_0, c_0, model, test_metrics
+    )
+    print(' '.join(f'{k}={v.item():.4f}' for k, v in test_results.items()))

--- a/examples/linkproppred/gclstm.py
+++ b/examples/linkproppred/gclstm.py
@@ -168,7 +168,7 @@ test_neg_hook = NegativeEdgeSamplerHook(
     low=int(test_dg.edges[1].min()), high=int(test_dg.edges[1].max())
 )
 
-hm = HookManager(args.device)
+hm = HookManager(keys=['train', 'val', 'test'])
 hm.register('train', train_neg_hook)
 hm.register('val', val_neg_hook)
 hm.register('test', test_neg_hook)

--- a/examples/linkproppred/gcn.py
+++ b/examples/linkproppred/gcn.py
@@ -192,7 +192,7 @@ test_neg_hook = NegativeEdgeSamplerHook(
     low=int(test_dg.edges[1].min()), high=int(test_dg.edges[1].max())
 )
 
-hm = HookManager(args.device)
+hm = HookManager(keys=['train', 'val', 'test'])
 hm.register('train', train_neg_hook)
 hm.register('val', val_neg_hook)
 hm.register('test', test_neg_hook)

--- a/examples/linkproppred/graphmixer.py
+++ b/examples/linkproppred/graphmixer.py
@@ -1,7 +1,7 @@
 import argparse
 import time
 from collections import deque
-from typing import List, Tuple
+from typing import Tuple
 
 import torch
 import torch.nn as nn
@@ -11,7 +11,8 @@ from torchmetrics.classification import BinaryAUROC, BinaryAveragePrecision
 from tqdm import tqdm
 
 from tgm import DGBatch, DGData, DGraph
-from tgm.hooks import DGHook, NegativeEdgeSamplerHook, RecencyNeighborHook
+from tgm.hooks import HookManager, NegativeEdgeSamplerHook, RecencyNeighborHook
+from tgm.hooks.base import StatefulHook
 from tgm.loader import DGDataLoader
 from tgm.nn import Time2Vec
 from tgm.util.seed import seed_everything
@@ -249,86 +250,93 @@ val_dg = DGraph(val_data, device=args.device)
 test_dg = DGraph(test_data, device=args.device)
 
 
-def _init_hooks(dg: DGraph, time_gap: int) -> List[DGHook]:
-    # Graphmixer always uses 1-hop recent neighbors
-    nbr_hook = RecencyNeighborHook(
-        num_nbrs=[args.n_nbrs], num_nodes=dg.num_nodes, edge_feats_dim=dg.edge_feats_dim
-    )
-
-    # Always produce negative edge prior to neighbor sampling for link prediction
-    _, dst, _ = dg.edges
-    min_dst, max_dst = int(dst.min()), int(dst.max())
-    neg_hook = NegativeEdgeSamplerHook(low=min_dst, high=max_dst)
-
-    class GraphMixerHook:
-        r"""Custom hook that gets 1-hop neighbors in a specific window.
-
-        If N(v_i, t_s, t_e) = nbrs of v_i from [t_s, t_e], then we materialize
-        N(node_ids, t - TIME_GAP, t) for all seed nodes in a given batch.
-        """
-
-        requires = {'neg'}
-        produces = {'time_gap_node_nids', 'time_gap_node_mask'}
-
-        def __init__(self, time_gap: int, num_nodes: int) -> None:
-            self._time_gap = time_gap
-            self._nbrs = {}
-            for node in range(num_nodes):
-                self._nbrs[node] = deque(maxlen=self._time_gap)
-
-        def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:
-            batch.neg = batch.neg.to(dg.device)
-            seed_nodes = torch.cat([batch.src, batch.dst, batch.neg])
-
-            unique, inverse_indices = seed_nodes.unique(return_inverse=True)
-
-            batch_size = len(seed_nodes)
-            nbr_nids = torch.zeros(
-                batch_size, self._time_gap, dtype=torch.long, device=dg.device
-            )
-            nbr_mask = torch.zeros(
-                batch_size, self._time_gap, dtype=torch.long, device=dg.device
-            )
-            for i, node in enumerate(unique.tolist()):
-                if nn := len(self._nbrs[node]):
-                    mask = inverse_indices == i
-                    nbr_nids[mask, :nn] = torch.tensor(
-                        self._nbrs[node], device=dg.device, dtype=torch.long
-                    )
-                    nbr_mask[mask, :nn] = nn >= self._time_gap
-
-            batch.time_gap_node_nids = nbr_nids
-            batch.time_gap_node_mask = nbr_mask
-
-            self._update(batch)
-            return batch
-
-        def _update(self, batch: DGBatch) -> None:
-            for i in range(batch.src.size(0)):
-                src_nbr = int(batch.src[i].item())
-                dst_nbr = int(batch.dst[i].item())
-                self._nbrs[src_nbr].append(dst_nbr)
-                self._nbrs[dst_nbr].append(src_nbr)
-
-    graph_mixer_hook = GraphMixerHook(time_gap, num_nodes=dg.num_nodes)
-    return [neg_hook, nbr_hook, graph_mixer_hook]
-
-
-train_loader = DGDataLoader(
-    train_dg, hook=_init_hooks(train_dg, args.time_gap), batch_size=args.bsize
-)
-val_loader = DGDataLoader(
-    val_dg, hook=_init_hooks(val_dg, args.time_gap), batch_size=args.bsize
-)
-test_loader = DGDataLoader(
-    test_dg, hook=_init_hooks(test_dg, args.time_gap), batch_size=args.bsize
+# Neighbor Sampler and GraphMixer Hook is shared across loaders
+nbr_hook = RecencyNeighborHook(
+    num_nbrs=args.n_nbrs,
+    num_nodes=test_dg.num_nodes,  # Assuming node ids at test set > train/val set
+    edge_feats_dim=test_dg.edge_feats_dim,
 )
 
 
-if train_dg.dynamic_node_feats_dim is not None:
-    raise ValueError(
-        'node features are not supported yet, make sure to incorporate them in the model'
-    )
+class GraphMixerHook(StatefulHook):
+    r"""Custom hook that gets 1-hop neighbors in a specific window.
+
+    If N(v_i, t_s, t_e) = nbrs of v_i from [t_s, t_e], then we materialize
+    N(node_ids, t - TIME_GAP, t) for all seed nodes in a given batch.
+    """
+
+    requires = {'neg'}
+    produces = {'time_gap_node_nids', 'time_gap_node_mask'}
+
+    def __init__(self, time_gap: int, num_nodes: int) -> None:
+        self._time_gap = time_gap
+        self._nbrs = {}
+        for node in range(num_nodes):
+            self._nbrs[node] = deque(maxlen=self._time_gap)
+
+    def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:
+        batch.neg = batch.neg.to(dg.device)
+        seed_nodes = torch.cat([batch.src, batch.dst, batch.neg])  # type: ignore
+
+        unique, inverse_indices = seed_nodes.unique(return_inverse=True)
+
+        batch_size = len(seed_nodes)
+        nbr_nids = torch.zeros(
+            batch_size, self._time_gap, dtype=torch.long, device=dg.device
+        )
+        nbr_mask = torch.zeros(
+            batch_size, self._time_gap, dtype=torch.long, device=dg.device
+        )
+        for i, node in enumerate(unique.tolist()):
+            if nn := len(self._nbrs[node]):
+                mask = inverse_indices == i
+                nbr_nids[mask, :nn] = torch.tensor(
+                    self._nbrs[node], device=dg.device, dtype=torch.long
+                )
+                nbr_mask[mask, :nn] = nn >= self._time_gap
+
+        batch.time_gap_node_nids = nbr_nids  # type: ignore
+        batch.time_gap_node_mask = nbr_mask  # type: ignore
+
+        self._update(batch)
+        return batch
+
+    def reset(self) -> None:
+        for node in self._nbrs:
+            self._nbrs[node].clear()
+
+    def _update(self, batch: DGBatch) -> None:
+        for i in range(batch.src.size(0)):
+            src_nbr = int(batch.src[i].item())
+            dst_nbr = int(batch.dst[i].item())
+            self._nbrs[src_nbr].append(dst_nbr)
+            self._nbrs[dst_nbr].append(src_nbr)
+
+
+graph_mixer_hook = GraphMixerHook(args.time_gap, num_nodes=test_dg.num_nodes)
+
+_, train_dst, _ = train_dg.edges
+_, val_dst, _ = val_dg.edges
+_, test_dst, _ = test_dg.edges
+train_neg_hook = NegativeEdgeSamplerHook(
+    low=int(train_dst.min()), high=int(train_dst.max())
+)
+val_neg_hook = NegativeEdgeSamplerHook(low=int(val_dst.min()), high=int(val_dst.max()))
+test_neg_hook = NegativeEdgeSamplerHook(
+    low=int(test_dst.min()), high=int(test_dst.max())
+)
+
+hm = HookManager(args.device)
+hm.register('train', train_neg_hook)
+hm.register('val', val_neg_hook)
+hm.register('test', test_neg_hook)
+hm.register_shared(nbr_hook)
+hm.register_shared(graph_mixer_hook)
+
+train_loader = DGDataLoader(train_dg, args.bsize, hook_manager=hm)
+val_loader = DGDataLoader(val_dg, args.bsize, hook_manager=hm)
+test_loader = DGDataLoader(test_dg, args.bsize, hook_manager=hm)
+
 
 if train_dg.static_node_feats is not None:
     static_node_feats = train_dg.static_node_feats
@@ -354,17 +362,23 @@ val_metrics = MetricCollection(metrics, prefix='Validation')
 test_metrics = MetricCollection(metrics, prefix='Test')
 
 for epoch in range(1, args.epochs + 1):
-    start_time = time.perf_counter()
-    loss = train(train_loader, static_node_feats, model, opt)
-    end_time = time.perf_counter()
-    latency = end_time - start_time
+    with hm.activate('train'):
+        start_time = time.perf_counter()
+        loss = train(train_loader, static_node_feats, model, opt)
+        end_time = time.perf_counter()
+        latency = end_time - start_time
 
-    val_results = eval(val_loader, static_node_feats, model, val_metrics)
-    val_metrics.reset()
-    print(
-        f'Epoch={epoch:02d} Latency={latency:.4f} Loss={loss:.4f} '
-        + ' '.join(f'{k}={v.item():.4f}' for k, v in val_results.items())
-    )
+    with hm.activate('val'):
+        val_results = eval(val_loader, static_node_feats, model, val_metrics)
+        val_metrics.reset()
+        print(
+            f'Epoch={epoch:02d} Latency={latency:.4f} Loss={loss:.4f} '
+            + ' '.join(f'{k}={v.item():.4f}' for k, v in val_results.items())
+        )
 
-test_results = eval(test_loader, static_node_feats, model, test_metrics)
-print(' '.join(f'{k}={v.item():.4f}' for k, v in test_results.items()))
+    if epoch < args.epochs:  # Reset hooks after each epoch, except last epoch
+        hm.reset_state()
+
+with hm.activate('test'):
+    test_results = eval(test_loader, static_node_feats, model, test_metrics)
+    print(' '.join(f'{k}={v.item():.4f}' for k, v in test_results.items()))

--- a/examples/linkproppred/graphmixer.py
+++ b/examples/linkproppred/graphmixer.py
@@ -326,7 +326,7 @@ test_neg_hook = NegativeEdgeSamplerHook(
     low=int(test_dst.min()), high=int(test_dst.max())
 )
 
-hm = HookManager(args.device)
+hm = HookManager(keys=['train', 'val', 'test'])
 hm.register('train', train_neg_hook)
 hm.register('val', val_neg_hook)
 hm.register('test', test_neg_hook)

--- a/examples/linkproppred/tgat.py
+++ b/examples/linkproppred/tgat.py
@@ -1,6 +1,6 @@
 import argparse
 import time
-from typing import List, Tuple
+from typing import Tuple
 
 import torch
 import torch.nn as nn
@@ -12,7 +12,7 @@ from tqdm import tqdm
 from tgm import DGBatch, DGData, DGraph
 from tgm.constants import PADDED_NODE_ID
 from tgm.hooks import (
-    DGHook,
+    HookManager,
     NegativeEdgeSamplerHook,
     NeighborSamplerHook,
     RecencyNeighborHook,
@@ -207,31 +207,38 @@ else:
         (test_dg.num_nodes, args.embed_dim), device=args.device
     )
 
+# Neighbor Sampler is shared across loaders
+if args.sampling_type == 'uniform':
+    nbr_hook = NeighborSamplerHook(num_nbrs=args.num_nbrs)
+elif args.sampling_type == 'recency':
+    nbr_hook = RecencyNeighborHook(
+        num_nbrs=args.n_nbrs,
+        num_nodes=test_dg.num_nodes,  # Assuming node ids at test set > train/val set
+        edge_feats_dim=test_dg.edge_feats_dim,
+    )
+else:
+    raise ValueError(f'Unknown sampling type: {args.sampling}')
 
-def _init_hooks(dg: DGraph, sampling_type: str) -> List[DGHook]:
-    if sampling_type == 'uniform':
-        nbr_hook = NeighborSamplerHook(num_nbrs=args.n_nbrs)
-    elif sampling_type == 'recency':
-        nbr_hook = RecencyNeighborHook(
-            num_nbrs=args.n_nbrs,
-            num_nodes=dg.num_nodes,
-            edge_feats_dim=dg.edge_feats_dim,
-        )
-    else:
-        raise ValueError(f'Unknown sampling type: {args.sampling}')
-
-    # Always produce negative edge prior to neighbor sampling for link prediction
-    _, dst, _ = dg.edges
-    min_dst, max_dst = int(dst.min()), int(dst.max())
-    neg_hook = NegativeEdgeSamplerHook(low=min_dst, high=max_dst)
-    return [neg_hook, nbr_hook]
-
-
-test_loader = DGDataLoader(
-    test_dg,
-    hook=_init_hooks(test_dg, args.sampling),
-    batch_size=args.bsize,
+_, train_dst, _ = train_dg.edges
+_, val_dst, _ = val_dg.edges
+_, test_dst, _ = test_dg.edges
+train_neg_hook = NegativeEdgeSamplerHook(
+    low=int(train_dst.min()), high=int(train_dst.max())
 )
+val_neg_hook = NegativeEdgeSamplerHook(low=int(val_dst.min()), high=int(val_dst.max()))
+test_neg_hook = NegativeEdgeSamplerHook(
+    low=int(test_dst.min()), high=int(test_dst.max())
+)
+
+hm = HookManager(args.device)
+hm.register('train', train_neg_hook)
+hm.register('val', val_neg_hook)
+hm.register('test', test_neg_hook)
+hm.register_shared(nbr_hook)
+
+train_loader = DGDataLoader(train_dg, args.bsize, hook_manager=hm)
+val_loader = DGDataLoader(val_dg, args.bsize, hook_manager=hm)
+test_loader = DGDataLoader(test_dg, args.bsize, hook_manager=hm)
 
 model = TGAT(
     edge_dim=train_dg.edge_feats_dim or args.embed_dim,
@@ -248,29 +255,23 @@ val_metrics = MetricCollection(metrics, prefix='Validation')
 test_metrics = MetricCollection(metrics, prefix='Test')
 
 for epoch in range(1, args.epochs + 1):
-    # TODO: Need a clean way to clear nbr state across epochs
-    train_loader = DGDataLoader(
-        train_dg,
-        hook=_init_hooks(test_dg, args.sampling),
-        batch_size=args.bsize,
-    )
-    val_loader = DGDataLoader(
-        val_dg,
-        hook=_init_hooks(test_dg, args.sampling),
-        batch_size=args.bsize,
-    )
-    start_time = time.perf_counter()
-    loss = train(train_loader, static_node_feats, model, opt)
-    end_time = time.perf_counter()
-    latency = end_time - start_time
+    with hm.activate('train'):
+        start_time = time.perf_counter()
+        loss = train(train_loader, static_node_feats, model, opt)
+        end_time = time.perf_counter()
+        latency = end_time - start_time
 
-    val_results = eval(val_loader, static_node_feats, model, val_metrics)
-    val_metrics.reset()
+    with hm.activate('test'):
+        val_results = eval(val_loader, static_node_feats, model, val_metrics)
+        val_metrics.reset()
+        print(
+            f'Epoch={epoch:02d} Latency={latency:.4f} Loss={loss:.4f} '
+            + ' '.join(f'{k}={v.item():.4f}' for k, v in val_results.items())
+        )
 
-    print(
-        f'Epoch={epoch:02d} Latency={latency:.4f} Loss={loss:.4f} '
-        + ' '.join(f'{k}={v.item():.4f}' for k, v in val_results.items())
-    )
+    if epoch < args.epochs:  # Reset hooks after each epoch, except last epoch
+        hm.reset_state()
 
-test_results = eval(test_loader, static_node_feats, model, test_metrics)
-print(' '.join(f'{k}={v.item():.4f}' for k, v in test_results.items()))
+with hm.activate('test'):
+    test_results = eval(test_loader, static_node_feats, model, test_metrics)
+    print(' '.join(f'{k}={v.item():.4f}' for k, v in test_results.items()))

--- a/examples/linkproppred/tgat.py
+++ b/examples/linkproppred/tgat.py
@@ -230,7 +230,7 @@ test_neg_hook = NegativeEdgeSamplerHook(
     low=int(test_dst.min()), high=int(test_dst.max())
 )
 
-hm = HookManager(args.device)
+hm = HookManager(keys=['train', 'val', 'test'])
 hm.register('train', train_neg_hook)
 hm.register('val', val_neg_hook)
 hm.register('test', test_neg_hook)

--- a/examples/linkproppred/tgn.py
+++ b/examples/linkproppred/tgn.py
@@ -1,7 +1,7 @@
 import argparse
 import time
 from collections import defaultdict
-from typing import Dict, List, Tuple
+from typing import Dict, Tuple
 
 import numpy as np
 import torch
@@ -14,7 +14,7 @@ from tqdm import tqdm
 from tgm import DGBatch, DGData, DGraph
 from tgm.constants import PADDED_NODE_ID
 from tgm.hooks import (
-    DGHook,
+    HookManager,
     NegativeEdgeSamplerHook,
     NeighborSamplerHook,
     RecencyNeighborHook,
@@ -404,28 +404,38 @@ else:
     )
 
 
-def _init_hooks(dg: DGraph, sampling_type: str) -> List[DGHook]:
-    if sampling_type == 'uniform':
-        nbr_hook = NeighborSamplerHook(num_nbrs=args.n_nbrs)
-    elif sampling_type == 'recency':
-        nbr_hook = RecencyNeighborHook(
-            num_nbrs=args.n_nbrs,
-            num_nodes=dg.num_nodes,
-            edge_feats_dim=dg.edge_feats_dim,
-        )
-    else:
-        raise ValueError(f'Unknown sampling type: {args.sampling}')
+# Neighbor Sampler is shared across loaders
+if args.sampling_type == 'uniform':
+    nbr_hook = NeighborSamplerHook(num_nbrs=args.num_nbrs)
+elif args.sampling_type == 'recency':
+    nbr_hook = RecencyNeighborHook(
+        num_nbrs=args.n_nbrs,
+        num_nodes=test_dg.num_nodes,  # Assuming node ids at test set > train/val set
+        edge_feats_dim=test_dg.edge_feats_dim,
+    )
+else:
+    raise ValueError(f'Unknown sampling type: {args.sampling}')
 
-    # Always produce negative edge prior to neighbor sampling for link prediction
-    _, dst, _ = dg.edges
-    min_dst, max_dst = int(dst.min()), int(dst.max())
-    neg_hook = NegativeEdgeSamplerHook(low=min_dst, high=max_dst)
-    return [neg_hook, nbr_hook]
-
-
-test_loader = DGDataLoader(
-    test_dg, hook=_init_hooks(test_dg, args.sampling), batch_size=args.bsize
+_, train_dst, _ = train_dg.edges
+_, val_dst, _ = val_dg.edges
+_, test_dst, _ = test_dg.edges
+train_neg_hook = NegativeEdgeSamplerHook(
+    low=int(train_dst.min()), high=int(train_dst.max())
 )
+val_neg_hook = NegativeEdgeSamplerHook(low=int(val_dst.min()), high=int(val_dst.max()))
+test_neg_hook = NegativeEdgeSamplerHook(
+    low=int(test_dst.min()), high=int(test_dst.max())
+)
+
+hm = HookManager(args.device)
+hm.register('train', train_neg_hook)
+hm.register('val', val_neg_hook)
+hm.register('test', test_neg_hook)
+hm.register_shared(nbr_hook)
+
+train_loader = DGDataLoader(train_dg, args.bsize, hook_manager=hm)
+val_loader = DGDataLoader(val_dg, args.bsize, hook_manager=hm)
+test_loader = DGDataLoader(test_dg, args.bsize, hook_manager=hm)
 
 # Get global number of nodes for TGN Memory
 num_nodes = DGraph(data).num_nodes
@@ -447,29 +457,26 @@ val_metrics = MetricCollection(metrics, prefix='Validation')
 test_metrics = MetricCollection(metrics, prefix='Test')
 
 for epoch in range(1, args.epochs + 1):
-    # TODO: Need a clean way to clear nbr state across epochs
-    train_loader = DGDataLoader(
-        train_dg, hook=_init_hooks(train_dg, args.sampling), batch_size=args.bsize
-    )
-    val_loader = DGDataLoader(
-        val_dg, hook=_init_hooks(val_dg, args.sampling), batch_size=args.bsize
-    )
-    start_time = time.perf_counter()
-    loss = train(train_loader, static_node_feats, model, opt)
-    end_time = time.perf_counter()
-    latency = end_time - start_time
+    with hm.activate('train'):
+        start_time = time.perf_counter()
+        loss = train(train_loader, static_node_feats, model, opt)
+        end_time = time.perf_counter()
+        latency = end_time - start_time
 
-    val_results = eval(val_loader, static_node_feats, model, val_metrics)
-    val_metrics.reset()
+    with hm.activate('val'):
+        val_results = eval(val_loader, static_node_feats, model, val_metrics)
+        val_metrics.reset()
+        print(
+            f'Epoch={epoch:02d} Latency={latency:.4f} Loss={loss:.4f} '
+            + ' '.join(f'{k}={v.item():.4f}' for k, v in val_results.items())
+        )
 
-    print(
-        f'Epoch={epoch:02d} Latency={latency:.4f} Loss={loss:.4f} '
-        + ' '.join(f'{k}={v.item():.4f}' for k, v in val_results.items())
-    )
-
-    # Clear memory state between epochs
-    model.memory.clear_msgs(list(range(num_nodes)))
+    if epoch < args.epochs:  # Reset hooks after each epoch, except last epoch
+        hm.reset_state()
+        # Clear memory state between epochs
+        model.memory.clear_msgs(list(range(num_nodes)))
 
 
-test_results = eval(test_loader, static_node_feats, model, test_metrics)
-print(' '.join(f'{k}={v.item():.4f}' for k, v in test_results.items()))
+with hm.activate('test'):
+    test_results = eval(test_loader, static_node_feats, model, test_metrics)
+    print(' '.join(f'{k}={v.item():.4f}' for k, v in test_results.items()))

--- a/examples/linkproppred/tgn.py
+++ b/examples/linkproppred/tgn.py
@@ -427,7 +427,7 @@ test_neg_hook = NegativeEdgeSamplerHook(
     low=int(test_dst.min()), high=int(test_dst.max())
 )
 
-hm = HookManager(args.device)
+hm = HookManager(keys=['train', 'val', 'test'])
 hm.register('train', train_neg_hook)
 hm.register('val', val_neg_hook)
 hm.register('test', test_neg_hook)

--- a/examples/nodeproppred/gclstm.py
+++ b/examples/nodeproppred/gclstm.py
@@ -173,7 +173,7 @@ num_nodes = DGraph(train_data).num_nodes
 label_dim = train_dg.dynamic_node_feats_dim
 evaluator = Evaluator(name=args.dataset)
 
-hm = HookManager(args.device)
+hm = HookManager(keys=['train', 'val', 'test'])
 train_loader = DGDataLoader(train_dg, batch_unit=args.batch_time_gran, hook_manager=hm)
 val_loader = DGDataLoader(val_dg, batch_unit=args.batch_time_gran, hook_manager=hm)
 test_loader = DGDataLoader(test_dg, batch_unit=args.batch_time_gran, hook_manager=hm)

--- a/examples/nodeproppred/gclstm.py
+++ b/examples/nodeproppred/gclstm.py
@@ -14,6 +14,7 @@ from tgb.nodeproppred.evaluate import Evaluator
 from tqdm import tqdm
 
 from tgm import DGBatch, DGData, DGraph
+from tgm.hooks import HookManager
 from tgm.loader import DGDataLoader
 from tgm.nn.recurrent import GCLSTM
 from tgm.util.seed import seed_everything
@@ -172,9 +173,10 @@ num_nodes = DGraph(train_data).num_nodes
 label_dim = train_dg.dynamic_node_feats_dim
 evaluator = Evaluator(name=args.dataset)
 
-train_loader = DGDataLoader(train_dg, batch_unit=args.batch_time_gran)
-val_loader = DGDataLoader(val_dg, batch_unit=args.batch_time_gran)
-test_loader = DGDataLoader(test_dg, batch_unit=args.batch_time_gran)
+hm = HookManager(args.device)
+train_loader = DGDataLoader(train_dg, batch_unit=args.batch_time_gran, hook_manager=hm)
+val_loader = DGDataLoader(val_dg, batch_unit=args.batch_time_gran, hook_manager=hm)
+test_loader = DGDataLoader(test_dg, batch_unit=args.batch_time_gran, hook_manager=hm)
 
 if train_dg.static_node_feats is not None:
     static_node_feats = train_dg.static_node_feats

--- a/examples/nodeproppred/gcn.py
+++ b/examples/nodeproppred/gcn.py
@@ -201,7 +201,7 @@ num_nodes = DGraph(train_data).num_nodes
 label_dim = train_dg.dynamic_node_feats_dim
 evaluator = Evaluator(name=args.dataset)
 
-hm = HookManager(args.device)
+hm = HookManager(keys=['train', 'val', 'test'])
 train_loader = DGDataLoader(train_dg, batch_unit=args.batch_time_gran, hook_manager=hm)
 val_loader = DGDataLoader(val_dg, batch_unit=args.batch_time_gran, hook_manager=hm)
 test_loader = DGDataLoader(test_dg, batch_unit=args.batch_time_gran, hook_manager=hm)

--- a/examples/nodeproppred/persistant_forecast.py
+++ b/examples/nodeproppred/persistant_forecast.py
@@ -80,7 +80,6 @@ def eval(loader: DGDataLoader, model: PersistantForecaster) -> dict:
 args = parser.parse_args()
 seed_everything(args.seed)
 
-
 data = DGData.from_tgb(args.dataset).discretize(args.time_gran)
 train_data, val_data, test_data = data.split()
 

--- a/examples/nodeproppred/tgcn.py
+++ b/examples/nodeproppred/tgcn.py
@@ -170,7 +170,8 @@ num_nodes = DGraph(test_data).num_nodes
 label_dim = train_dg.dynamic_node_feats_dim
 evaluator = Evaluator(name=args.dataset)
 
-hm = HookManager(args.device)
+hm = HookManager(keys=['train', 'val', 'test'])
+
 train_loader = DGDataLoader(train_dg, batch_unit=args.batch_time_gran, hook_manager=hm)
 val_loader = DGDataLoader(val_dg, batch_unit=args.batch_time_gran, hook_manager=hm)
 test_loader = DGDataLoader(test_dg, batch_unit=args.batch_time_gran, hook_manager=hm)

--- a/examples/nodeproppred/tgcn.py
+++ b/examples/nodeproppred/tgcn.py
@@ -189,7 +189,6 @@ model = TGCN_Model(
 opt = torch.optim.Adam(model.parameters(), lr=float(args.lr))
 
 for epoch in range(1, args.epochs + 1):
-    # TODO: Technically, we need to activate the device hook... but no other hooks necessary
     start_time = time.perf_counter()
     loss, h_0 = train(train_loader, static_node_feats, model, opt)
     end_time = time.perf_counter()

--- a/test/unit/test_dataloader.py
+++ b/test/unit/test_dataloader.py
@@ -3,7 +3,6 @@ import torch
 
 from tgm import DGBatch, DGraph
 from tgm.data import DGData
-from tgm.hooks import HookManager
 from tgm.loader import DGDataLoader
 from tgm.timedelta import TimeDeltaDG
 from tgm.util.seed import seed_everything
@@ -22,7 +21,6 @@ def test_init_ordered_dg_ordered_batch():
     dg = DGraph(data)
     loader = DGDataLoader(dg)
     assert loader._batch_size == 1
-    assert isinstance(loader._hook_manager, HookManager)
 
 
 @pytest.mark.parametrize('batch_unit', ['Y', 'M', 'W', 'D', 'h', 's', 'ms', 'us', 'ns'])

--- a/test/unit/test_dataloader.py
+++ b/test/unit/test_dataloader.py
@@ -3,6 +3,7 @@ import torch
 
 from tgm import DGBatch, DGraph
 from tgm.data import DGData
+from tgm.hooks import HookManager
 from tgm.loader import DGDataLoader
 from tgm.timedelta import TimeDeltaDG
 from tgm.util.seed import seed_everything
@@ -21,6 +22,7 @@ def test_init_ordered_dg_ordered_batch():
     dg = DGraph(data)
     loader = DGDataLoader(dg)
     assert loader._batch_size == 1
+    assert isinstance(loader._hook_manager, HookManager)
 
 
 @pytest.mark.parametrize('batch_unit', ['Y', 'M', 'W', 'D', 'h', 's', 'ms', 'us', 'ns'])

--- a/test/unit/test_hooks/test_hook_manager.py
+++ b/test/unit/test_hooks/test_hook_manager.py
@@ -152,8 +152,8 @@ def test_topo_sort_no_solution_missing_requires():
 
 @pytest.mark.skip(
     'TODO: This test only makes sense if we enable registering multiple hooks at once. '
-    'Otherwise, the "missing produced" will trigger an exception before the secon hook can '
-    'be registered. Skiping for now, and should reconsider enabling multiple hook registry.'
+    'Otherwise, the "missing produced" will trigger an exception before the second hook can '
+    'be registered. Skipping for now, and should reconsider enabling multiple hook registry.'
 )
 def test_topo_sort_no_solution_no_dag():
     h1 = MockHook()

--- a/test/unit/test_hooks/test_hook_manager.py
+++ b/test/unit/test_hooks/test_hook_manager.py
@@ -9,7 +9,6 @@ from tgm.hooks import (
     StatefulHook,
     StatelessHook,
 )
-from tgm.hooks.hooks import DeviceTransferHook
 
 
 class MockHook(StatelessHook):
@@ -62,14 +61,7 @@ def test_str():
 
 def test_init_cpu():
     hm = HookManager()
-    assert isinstance(hm._device_hook, DeviceTransferHook)
     assert any(isinstance(h, DeduplicationHook) for h in hm._shared_hooks)
-
-
-@pytest.mark.gpu
-def test_init_gpu():
-    hm = HookManager(device='cuda')
-    assert isinstance(hm._device_hook, DeviceTransferHook)
 
 
 def test_register():
@@ -235,7 +227,6 @@ def test_reset_state():
     hm.register_shared(h1)
     hm.reset_state()
     assert h1.x == 1
-    assert hm._device_hook is not None
 
 
 def test_reset_state_by_key():

--- a/test/unit/test_hooks/test_hook_manager.py
+++ b/test/unit/test_hooks/test_hook_manager.py
@@ -160,7 +160,7 @@ def test_resolve_hooks_by_key():
     assert hm._key_to_hooks['train'].index(h1) < hm._key_to_hooks['train'].index(h2)
 
 
-def test_resolve_hooks_no_solution_no_dag(dg):
+def test_resolve_hooks_no_solution_no_dag():
     h1 = MockHook()
     h2 = MockHook()
     h1.requires, h1.produces = {'x'}, {'y'}

--- a/tgm/hooks/__init__.py
+++ b/tgm/hooks/__init__.py
@@ -1,0 +1,11 @@
+from .base import DGHook, StatelessHook, StatefulHook
+from .hooks import (
+    PinMemoryHook,
+    DeviceTransferHook,
+    DeduplicationHook,
+    NegativeEdgeSamplerHook,
+    TGBNegativeEdgeSamplerHook,
+    NeighborSamplerHook,
+    RecencyNeighborHook,
+)
+from .hook_manager import HookManager

--- a/tgm/hooks/base.py
+++ b/tgm/hooks/base.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Protocol, Set, runtime_checkable
+
+from tgm import DGBatch, DGraph
+
+
+@runtime_checkable
+class DGHook(Protocol):
+    r"""The behaviours to be executed on a DGraph before materializing."""
+
+    requires: Set[str]
+    produces: Set[str]
+    has_state: bool
+
+    def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch: ...
+
+    def reset_state(self) -> None: ...
+
+
+class StatelessHook:
+    requires: Set[str] = set()
+    produces: Set[str] = set()
+    has_state: bool = False
+
+    def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:
+        raise NotImplementedError
+
+    def reset_state(self) -> None:
+        pass
+
+
+class StatefulHook:
+    requires: Set[str] = set()
+    produces: Set[str] = set()
+    has_state: bool = True

--- a/tgm/hooks/hook_manager.py
+++ b/tgm/hooks/hook_manager.py
@@ -9,8 +9,12 @@ from tgm.hooks import DeduplicationHook, DGHook
 
 
 class HookManager:
-    def __init__(self) -> None:
-        self._key_to_hooks: Dict[str, List[DGHook]] = {}  # Topological order
+    def __init__(self, keys: List[str]) -> None:
+        if not len(keys):
+            raise ValueError('HookManager keys list must be non-empty')
+
+        # Topological order
+        self._key_to_hooks: Dict[str, List[DGHook]] = {k: [] for k in keys}
         self._shared_hooks: List[DGHook] = []
         self._active_key: str | None = None
 
@@ -18,13 +22,13 @@ class HookManager:
         self._shared_hooks.append(DeduplicationHook())
 
     def __str__(self) -> str:
+        def _stringify_hook(h: DGHook) -> str:
+            return f'    - {h.__class__.__name__} (requires={h.requires}, produces={h.produces})'
+
         lines = ['HookManager:']
         lines.append('  Shared hooks:')
         for h in self._shared_hooks:
-            lines.append(
-                f'    - {h.__class__.__name__} '
-                f'(requires={h.requires}, produces={h.produces})'
-            )
+            lines.append(_stringify_hook(h))
 
         lines.append(f'  Active key: {self._active_key}')
         if self._key_to_hooks:
@@ -32,10 +36,7 @@ class HookManager:
             for key, hooks in self._key_to_hooks.items():
                 lines.append(f'    {key}:')
                 for h in hooks:
-                    lines.append(
-                        f'      - {h.__class__.__name__} '
-                        f'(requires={h.requires}, produces={h.produces})'
-                    )
+                    lines.append(_stringify_hook(h))
         else:
             lines.append('  No keyed hooks registered.')
 
@@ -43,10 +44,8 @@ class HookManager:
 
     def register_shared(self, hook: DGHook) -> None:
         self._ensure_valid_hook(hook)
-        if self._active_key is not None:
-            raise RuntimeError(
-                'Cannot register hooks while a key is active. Register hooks before using `activate`.'
-            )
+        self._ensure_no_active_key()
+
         self._shared_hooks.append(hook)
 
         # Recompute execution order for all keys
@@ -58,14 +57,10 @@ class HookManager:
             )
 
     def register(self, key: str, hook: DGHook) -> None:
+        self._ensure_valid_key(key)
         self._ensure_valid_hook(hook)
-        if self._active_key is not None:
-            raise RuntimeError(
-                'Cannot register hooks while a key is active. Register hooks before using `activate`.'
-            )
+        self._ensure_no_active_key()
 
-        if key not in self._key_to_hooks:
-            self._key_to_hooks[key] = []
         self._key_to_hooks[key].append(hook)
 
         # Precompute execution order including shared hooks once
@@ -76,10 +71,11 @@ class HookManager:
 
     def get_active_hooks(self) -> List[DGHook]:
         if self._active_key is None:
-            raise RuntimeError('No active key set. Use active() context manager.')
+            raise RuntimeError('No active key set. Use activate() context manager.')
         return self._key_to_hooks[self._active_key]
 
     def set_active_hooks(self, key: str) -> None:
+        self._ensure_valid_key(key)
         self._active_key = key
 
     def execute_active_hooks(self, dg: DGraph, batch: DGBatch) -> DGBatch:
@@ -88,12 +84,15 @@ class HookManager:
         return batch
 
     def reset_state(self, key: str | None = None) -> None:
+        if key is not None:
+            self._ensure_valid_key(key)
+
         for hook in self._shared_hooks:
             hook.reset_state()
 
         keys_to_reset = [key] if key is not None else list(self._key_to_hooks.keys())
         for k in keys_to_reset:
-            for h in self._key_to_hooks.get(k, []):
+            for h in self._key_to_hooks[k]:
                 h.reset_state()
 
     @contextmanager
@@ -110,6 +109,16 @@ class HookManager:
             raise TypeError(
                 f'Cannot register hook {type(hook).__name__}: must implement __call__(dg: DGraph, batch: DGBatch) -> DGBatch and reset_state()'
             )
+
+    def _ensure_no_active_key(self) -> None:
+        if self._active_key is not None:
+            raise RuntimeError(
+                'Cannot register hooks while a key is active. Register hooks before using `activate`.'
+            )
+
+    def _ensure_valid_key(self, key: str) -> None:
+        if key not in self._key_to_hooks:
+            raise KeyError(f'{key} was not a declared key in the hook manager')
 
     @staticmethod
     def _topological_sort_hooks(hooks: List[DGHook]) -> List[DGHook]:

--- a/tgm/hooks/hook_manager.py
+++ b/tgm/hooks/hook_manager.py
@@ -134,6 +134,17 @@ class HookManager:
 
     @staticmethod
     def _topological_sort_hooks(hooks: List[DGHook]) -> List[DGHook]:
+        # Before producing a valid hook ordering, we need to ensure
+        # that all the required attributes are produced by *some* hook.
+        all_produced = set().union(*(h.produces for h in hooks))
+        missing = set()
+        for h in hooks:
+            missing |= h.requires - all_produced
+        if missing:
+            raise ValueError(
+                f'Cannot resolve hook dependencies: required attributes not produced by any hook: {missing}'
+            )
+
         # Build adjacency list and then run Kahn's algorithmk jbs
         adj_list: Dict[DGHook, List[DGHook]] = defaultdict(list)
         for i, h1 in enumerate(hooks):

--- a/tgm/hooks/hook_manager.py
+++ b/tgm/hooks/hook_manager.py
@@ -4,18 +4,21 @@ from collections import defaultdict, deque
 from contextlib import contextmanager
 from typing import Any, Dict, Iterator, List
 
+import torch
+
 from tgm import DGBatch, DGraph
-from tgm.hooks import DeduplicationHook, DGHook
+from tgm.hooks import DeduplicationHook, DeviceTransferHook, DGHook
 
 
 class HookManager:
-    def __init__(self) -> None:
+    def __init__(self, device: str | torch.device = 'cpu') -> None:
         self._key_to_hooks: Dict[str, List[DGHook]] = {}  # Topological order
         self._shared_hooks: List[DGHook] = []
         self._active_key: str | None = None
 
-        # Implicitly add deduplication
+        # Implicitly add deduplication and device as shared hooks
         self._shared_hooks.append(DeduplicationHook())
+        self._shared_hooks.append(DeviceTransferHook(device))
 
     def register_shared(self, hook: DGHook) -> None:
         self._ensure_valid_hook(hook)

--- a/tgm/hooks/hook_manager.py
+++ b/tgm/hooks/hook_manager.py
@@ -116,8 +116,13 @@ class HookManager:
                     queue.append(v)
 
         if len(ordered) != len(hooks):
-            raise ValueError(
-                'Cannot resolve hook dependencies (cycle or missing producer)'
-            )
+            unresolved = [h for h in hooks if h not in ordered]
+
+            # For each unresolved hook, show which .requires are unsatisfied
+            err_msg = f'Cannot resolve hook dependencies:\n'
+            for h in unresolved:
+                missing = h.requires - set().union(*[u.produces for u in ordered])
+                err_msg += f'\n - {repr(h)} requires {missing} but not produced (or stuck in cycle)'
+            raise ValueError(err_msg)
 
         return ordered

--- a/tgm/hooks/hook_manager.py
+++ b/tgm/hooks/hook_manager.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import List, Set
+
+from tgm import DGBatch, DGraph
+from tgm.hooks import (
+    DeduplicationHook,
+    DeviceTransferHook,
+    DGHook,
+    PinMemoryHook,
+)
+
+
+class HookManager:
+    def __init__(self, dg: DGraph, hooks: List[DGHook]) -> None:
+        if not isinstance(hooks, list):
+            raise TypeError(f'Invalid hook type: {type(hooks)}')
+        bad_hook_names = [type(h).__name__ for h in hooks if not isinstance(h, DGHook)]
+        if len(bad_hook_names):
+            raise TypeError(
+                f'These hooks do not correctly implement the DGHook protocol: {bad_hook_names}, '
+                'ensure there is a __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch implemented'
+            )
+
+        # Implicitly add dedup hook after all user-defined hooks and before device transfer
+        hooks.append(DeduplicationHook())
+
+        if dg.device.type != 'cpu':
+            hooks.append(PinMemoryHook())
+            hooks.append(DeviceTransferHook(dg.device))
+
+        self.hooks = hooks
+        self._validate_hook_dependencies()
+
+    def reset_state(self) -> None:
+        for hook in self.hooks:
+            hook.reset_state()
+
+    @classmethod
+    def from_any(
+        cls, dg: DGraph, hook_like: HookManager | DGHook | List[DGHook] | None
+    ) -> HookManager:
+        if isinstance(hook_like, cls):
+            return hook_like
+        elif hook_like is None:
+            return cls(dg, hooks=[])
+        elif isinstance(hook_like, DGHook):
+            return cls(dg, hooks=[hook_like])
+        elif isinstance(hook_like, list):
+            return cls(dg, hooks=hook_like)
+        else:
+            raise TypeError(f'Invalid hook type: {type(hook_like)}')
+
+    def __call__(self, dg: DGraph) -> DGBatch:
+        batch = dg.materialize()
+        for hook in self.hooks:
+            batch = hook(dg, batch)
+        return batch
+
+    def _validate_hook_dependencies(self) -> None:
+        produced: Set[str] = set()
+        for hook in self.hooks:
+            missing = hook.requires - produced
+            if missing:
+                raise ValueError(
+                    f'{hook.__class__.__name__} is missing required fields: {missing}'
+                )
+            produced |= hook.produces

--- a/tgm/hooks/hook_manager.py
+++ b/tgm/hooks/hook_manager.py
@@ -95,9 +95,7 @@ class HookManager:
     def set_active_hooks(self, key: str) -> None:
         self._active_key = key
 
-    def execute_active_hooks(self, dg: DGraph) -> DGBatch:
-        batch = dg.materialize()
-
+    def execute_active_hooks(self, dg: DGraph, batch: DGBatch) -> DGBatch:
         # Always run device hook first
         batch = self._device_hook(dg, batch)
 

--- a/tgm/loader.py
+++ b/tgm/loader.py
@@ -96,7 +96,9 @@ class DGDataLoader(_SkippableDataLoaderMixin, torch.utils.data.DataLoader):  # t
 
         self._dg = dg
         self._batch_size = batch_size
-        self._hook_manager = HookManager() if hook_manager is None else hook_manager
+        self._hook_manager = (
+            HookManager(dg.device) if hook_manager is None else hook_manager
+        )
         self._slice_op = dg.slice_events if batch_ordered else dg.slice_time
 
         start_idx = 0 if batch_ordered else dg.start_time

--- a/tgm/loader.py
+++ b/tgm/loader.py
@@ -6,7 +6,7 @@ from typing import Any, Iterator, List, Literal
 import torch
 
 from tgm import DGBatch, DGraph
-from tgm.hooks import DGHook, HookManager
+from tgm.hooks import HookManager
 from tgm.timedelta import TimeDeltaDG
 
 
@@ -49,7 +49,7 @@ class DGDataLoader(_SkippableDataLoaderMixin, torch.utils.data.DataLoader):  # t
         batch_size (int): The batch size to yield at each iteration.
         batch_unit (str): The unit corresponding to the batch_size.
         on_empty (Literal['skip', 'raise', None]): Action for empty batches.
-        hook (HookManager | Hook | List[Hook] | None): Arbitrary transform behaviour to execute before materializing a batch.
+        hook_manager (HookManager | None): Arbitrary transform behaviour to execute before materializing a batch.
         **kwargs (Any): Additional arguments to torch.utils.data.DataLoader.
 
     Raises:
@@ -69,7 +69,7 @@ class DGDataLoader(_SkippableDataLoaderMixin, torch.utils.data.DataLoader):  # t
         batch_size: int = 1,
         batch_unit: str = 'r',
         on_empty: Literal['skip', 'raise', None] = 'skip',
-        hook: HookManager | DGHook | List[DGHook] | None = None,
+        hook_manager: HookManager | None = None,
         **kwargs: Any,
     ) -> None:
         if batch_size <= 0:
@@ -96,7 +96,7 @@ class DGDataLoader(_SkippableDataLoaderMixin, torch.utils.data.DataLoader):  # t
 
         self._dg = dg
         self._batch_size = batch_size
-        self._hook = HookManager.from_any(dg, hook)
+        self._hook_manager = HookManager() if hook_manager is None else hook_manager
         self._slice_op = dg.slice_events if batch_ordered else dg.slice_time
 
         start_idx = 0 if batch_ordered else dg.start_time
@@ -114,7 +114,7 @@ class DGDataLoader(_SkippableDataLoaderMixin, torch.utils.data.DataLoader):  # t
     def __call__(self, slice_start: List[int]) -> DGBatch:
         slice_end = slice_start[0] + self._batch_size
         batch = self._slice_op(slice_start[0], slice_end)
-        return self._hook(batch)
+        return self._hook_manager.execute_active_hooks(batch)
 
     def is_batch_empty(self, batch: DGBatch) -> bool:
         return batch.src.numel() == 0


### PR DESCRIPTION
### Purpose
The purpose of this PR is to finalize the hook state management API / semantics for Beta release. The primary purpose is to enable users to share and reset hooks generically across dataloaders etc.

### Design
#### Registry
- Each hook is now associated with a string `key`. The allows user to specifically register hooks for `train`, `val`, etc. There is a seperate API for registered _shared_ hooks, which will be added to _all_ keys:

https://github.com/tgm-team/tgm/blob/3224d757c49ec0077315710404eb1b537b95eb02/tgm/hooks/hook_manager.py#L34

https://github.com/tgm-team/tgm/blob/3224d757c49ec0077315710404eb1b537b95eb02/tgm/hooks/hook_manager.py#L20

#### Hook Activation
The provide a basic key-value style API for getting, setting, and activating hooks via a particular `key`. The idea is that the user can activate `train` keys during training, `val` keys during validation etc.  

https://github.com/tgm-team/tgm/blob/3224d757c49ec0077315710404eb1b537b95eb02/tgm/hooks/hook_manager.py#L50-L63

We additional provide a context manager so that a user can more clearly seperate and see which hooks are active. See, for instance, the current example:

https://github.com/tgm-team/tgm/blob/3224d757c49ec0077315710404eb1b537b95eb02/examples/linkproppred/TGB/tgat.py#L279-L283

#### Hook State Management
We still have the reset state method which now optionally takes a key (to only reset state for hooks on that specific key). Considered making this a context manager but decided this is simpler for now.

#### Additional Points
- Shared hooks are automatically added to all new _keyed hooks_.
- We only allow users to register new hooks while there is not active key (i.e. before the hot path of the code). This enables us to _pre-compute_ valid topological hook ordering outside of the data loader. See the next point.
- Since we opaquely manage keyed and shared hooks, we now need to ensure the ordering is valid (i.e. requires atributes are on the batch before produces attributes. I implemented topological sort for this purpose. We do this during registration phase.
- The device hook now has to be explicitly added :( unless we let the hook manager take a DGraph. But that's not clear as to which dgraph it should take (train/val/test). So, it's simpler to just registered device movement as a shared hook (and it could be non-shared in case for some reason user wants validation or test on a differen device, for instance).

### Other Changes
- Dataloader now takes a single `HookManager` instead of implicitly constructing it. That way, it is shared among all data loaders.
- Updated `TGAT example to show how it would work
- Created a `hooks` directory and split up some of our hook code

### To Discuss
Currently the topo sort is not really useful. This is because
- we only enable registering hooks one at a time
- we eagerly run the topological sort.

Because of this, the user will immediately get the 'missing produces' exception before topological sort even runs. Hence, they end up having to be aware of the order that they register hooks.

**Option 1**: Leave this as is. We fail fast so that as soon as a hook is registered, all the requires must already be satisfied. This is simplest, but hardest on the user.

**Option 2**: Leave as is, but add ability to register multiple hooks at once. This way, we stil fail fast, but now we actual have a reason to do the sort: the user can input multiple hooks at once in any order, and we find the right order.

**Option 3**: Don't do the topological sort eagerly. Instead, let users add hooks as they wish. Defer the topological check until we actually active / execute the hooks. We can still cache the result of the topological sort, so that it's only executed once per key. (assumign the user does not re-registry a hook, but we already structured the api such that this is not encouraged).
Let's discuss this tomorrow, otherwise, the unit tests, and exampels have been updated, and pending this detail we can merge.
My preference is either (3). If we do (3), we can add (2) as an additional features down the line. Doign only (1) and leaving (2) and or (3) for full release is valid too, but requires user to think about which order to register hooks and shared hooks.

I added a string method that nicely shows all the registered hooks and their dependency resolution order, but it's still better in my opinion if user can just blindly register hooks and the manager handles the execution / ordering.

### Relevant Issues
Close #157 