### PR TITLE
Fix Implicit Neighbor Hook Precedence

### DIFF
--- a/examples/linkproppred/TGB/tgat.py
+++ b/examples/linkproppred/TGB/tgat.py
@@ -233,9 +233,9 @@ else:
     )
 
 # Neighbor Sampler is shared across loaders
-if args.sampling_type == 'uniform':
+if args.sampling == 'uniform':
     nbr_hook = NeighborSamplerHook(num_nbrs=args.num_nbrs)
-elif args.sampling_type == 'recency':
+elif args.sampling == 'recency':
     nbr_hook = RecencyNeighborHook(
         num_nbrs=args.n_nbrs,
         num_nodes=test_dg.num_nodes,  # Assuming node ids at test set > train/val set
@@ -273,6 +273,9 @@ opt = torch.optim.Adam(
     set(encoder.parameters()) | set(decoder.parameters()), lr=float(args.lr)
 )
 
+hm.resolve_hooks()
+print(hm)
+input()
 for epoch in range(1, args.epochs + 1):
     with hm.activate('train'):
         start_time = time.perf_counter()

--- a/examples/linkproppred/TGB/tgat.py
+++ b/examples/linkproppred/TGB/tgat.py
@@ -273,9 +273,6 @@ opt = torch.optim.Adam(
     set(encoder.parameters()) | set(decoder.parameters()), lr=float(args.lr)
 )
 
-hm.resolve_hooks()
-print(hm)
-input()
 for epoch in range(1, args.epochs + 1):
     with hm.activate('train'):
         start_time = time.perf_counter()

--- a/examples/linkproppred/TGB/tgn.py
+++ b/examples/linkproppred/TGB/tgn.py
@@ -430,9 +430,9 @@ else:
 
 
 # Neighbor Sampler is shared across loaders
-if args.sampling_type == 'uniform':
+if args.sampling == 'uniform':
     nbr_hook = NeighborSamplerHook(num_nbrs=args.num_nbrs)
-elif args.sampling_type == 'recency':
+elif args.sampling == 'recency':
     nbr_hook = RecencyNeighborHook(
         num_nbrs=args.n_nbrs,
         num_nodes=test_dg.num_nodes,  # Assuming node ids at test set > train/val set

--- a/examples/linkproppred/tgat.py
+++ b/examples/linkproppred/tgat.py
@@ -208,9 +208,9 @@ else:
     )
 
 # Neighbor Sampler is shared across loaders
-if args.sampling_type == 'uniform':
+if args.sampling == 'uniform':
     nbr_hook = NeighborSamplerHook(num_nbrs=args.num_nbrs)
-elif args.sampling_type == 'recency':
+elif args.sampling == 'recency':
     nbr_hook = RecencyNeighborHook(
         num_nbrs=args.n_nbrs,
         num_nodes=test_dg.num_nodes,  # Assuming node ids at test set > train/val set

--- a/examples/linkproppred/tgn.py
+++ b/examples/linkproppred/tgn.py
@@ -405,9 +405,9 @@ else:
 
 
 # Neighbor Sampler is shared across loaders
-if args.sampling_type == 'uniform':
+if args.sampling == 'uniform':
     nbr_hook = NeighborSamplerHook(num_nbrs=args.num_nbrs)
-elif args.sampling_type == 'recency':
+elif args.sampling == 'recency':
     nbr_hook = RecencyNeighborHook(
         num_nbrs=args.n_nbrs,
         num_nodes=test_dg.num_nodes,  # Assuming node ids at test set > train/val set

--- a/test/unit/test_hooks/test_hook_manager.py
+++ b/test/unit/test_hooks/test_hook_manager.py
@@ -350,3 +350,24 @@ def test_activate_ctx():
         assert hm._active_key == 'train'
 
     assert hm._active_key is None
+
+
+def test_topo_sort_neg_before_nbr():
+    mock_neg_hook, mock_nbr_hook = MockHook(), MockHook()
+    mock_neg_hook.requires, mock_neg_hook.produces = set(), {'neg'}
+    mock_nbr_hook.requires, mock_nbr_hook.produces = set(), {'nbr_nids'}
+
+    # Register neg first in foo, nbr first in bar
+    hm = HookManager(keys=['foo', 'bar'])
+    hm.register('foo', mock_neg_hook)
+    hm.register('foo', mock_nbr_hook)
+    hm.register('bar', mock_nbr_hook)
+    hm.register('bar', mock_neg_hook)
+
+    hm.resolve_hooks()
+    foo_hooks = hm._key_to_hooks['foo']
+    bar_hooks = hm._key_to_hooks['bar']
+
+    # Ensure negatives preceed nbrs in both cases
+    assert foo_hooks.index(mock_neg_hook) < foo_hooks.index(mock_nbr_hook)
+    assert bar_hooks.index(mock_neg_hook) < bar_hooks.index(mock_nbr_hook)

--- a/test/unit/test_hooks/test_hook_manager.py
+++ b/test/unit/test_hooks/test_hook_manager.py
@@ -368,6 +368,6 @@ def test_topo_sort_neg_before_nbr():
     foo_hooks = hm._key_to_hooks['foo']
     bar_hooks = hm._key_to_hooks['bar']
 
-    # Ensure negatives preceed nbrs in both cases
+    # Ensure negatives precede nbrs in both cases
     assert foo_hooks.index(mock_neg_hook) < foo_hooks.index(mock_nbr_hook)
     assert bar_hooks.index(mock_neg_hook) < bar_hooks.index(mock_nbr_hook)

--- a/tgm/hooks/hook_manager.py
+++ b/tgm/hooks/hook_manager.py
@@ -148,7 +148,7 @@ class HookManager:
                 # that the negatives come first (so that we sample neighbors for the negatives).
                 # But since neighbor sampler does not explicitly require negatives, the topological
                 # sort may put these out of order. In order to fix this, we add an extra edge
-                # into tthe DAG before sorting. Long term, we need to think about how to avoid
+                # into the DAG before sorting. Long term, we need to think about how to avoid
                 # things like this, and make it seamless for the user.
                 is_neg_hook = lambda h: 'neg' in h.produces
                 is_nbr_hook = lambda h: 'nbr_nids' in h.produces

--- a/tgm/hooks/hook_manager.py
+++ b/tgm/hooks/hook_manager.py
@@ -143,20 +143,17 @@ class HookManager:
                     # If h2 requires something h1 produces, add edge
                     adj_list[h1].append(h2)
 
-        # TODO: This is a hacky short term fix for implcit hook ordering constraints.
-        # If both a negative hook and a neighbor hook are present, it is crucial
-        # that the negatives come first (so that we sample neighbors for the negatives).
-        # But since neighbor sampler does not explicitly require negatives, the topological
-        # sort may put these out of order. In order to fix this, we add an extra edge
-        # into tthe DAG before sorting. Long term, we need to think about how to avoid
-        # things like this, and make it seamless for the user.
-        is_neg_hook = lambda h: 'neg' in h.produces
-        is_nbr_hook = lambda h: 'nbr_nids' in h.produces
-        for h1 in hooks:
-            if is_neg_hook(h1):
-                for h2 in hooks:
-                    if is_nbr_hook(h2):
-                        adj_list[h1].append(h2)
+                # TODO: This is a hacky short term fix for implcit hook ordering constraints.
+                # If both a negative hook and a neighbor hook are present, it is crucial
+                # that the negatives come first (so that we sample neighbors for the negatives).
+                # But since neighbor sampler does not explicitly require negatives, the topological
+                # sort may put these out of order. In order to fix this, we add an extra edge
+                # into tthe DAG before sorting. Long term, we need to think about how to avoid
+                # things like this, and make it seamless for the user.
+                is_neg_hook = lambda h: 'neg' in h.produces
+                is_nbr_hook = lambda h: 'nbr_nids' in h.produces
+                if is_neg_hook(h1) and is_nbr_hook(h2):
+                    adj_list[h1].append(h2)
 
         indegree: Dict[DGHook, int] = {h: 0 for h in hooks}
         for u in adj_list:


### PR DESCRIPTION
### Summary / Description

Since neighbor sampler does not explicitly require negative, the topological sort may put the neighbor sampler first.
But if we *are* using negatives, then it's crucial that they come before the neighbor sampling.

To fix this, I monkey patched the topological sort by creating an edge in the DAG between negative and neighbor hooks if they both exist in our registry.

**Related Issues:** #191 

#### Type of Change

- [X] Bug fix

#### Test Evidence

- [X] Unit tests