### PR TITLE
Made shared_hooks as default key in hook managers

### DIFF
--- a/examples/nodeproppred/gclstm.py
+++ b/examples/nodeproppred/gclstm.py
@@ -173,7 +173,7 @@ num_nodes = DGraph(train_data).num_nodes
 label_dim = train_dg.dynamic_node_feats_dim
 evaluator = Evaluator(name=args.dataset)
 
-hm = HookManager(keys=['train', 'val', 'test'])
+hm = HookManager()
 train_loader = DGDataLoader(train_dg, batch_unit=args.batch_time_gran, hook_manager=hm)
 val_loader = DGDataLoader(val_dg, batch_unit=args.batch_time_gran, hook_manager=hm)
 test_loader = DGDataLoader(test_dg, batch_unit=args.batch_time_gran, hook_manager=hm)

--- a/examples/nodeproppred/gcn.py
+++ b/examples/nodeproppred/gcn.py
@@ -201,7 +201,7 @@ num_nodes = DGraph(train_data).num_nodes
 label_dim = train_dg.dynamic_node_feats_dim
 evaluator = Evaluator(name=args.dataset)
 
-hm = HookManager(keys=['train', 'val', 'test'])
+hm = HookManager()
 train_loader = DGDataLoader(train_dg, batch_unit=args.batch_time_gran, hook_manager=hm)
 val_loader = DGDataLoader(val_dg, batch_unit=args.batch_time_gran, hook_manager=hm)
 test_loader = DGDataLoader(test_dg, batch_unit=args.batch_time_gran, hook_manager=hm)

--- a/examples/nodeproppred/tgcn.py
+++ b/examples/nodeproppred/tgcn.py
@@ -170,7 +170,7 @@ num_nodes = DGraph(test_data).num_nodes
 label_dim = train_dg.dynamic_node_feats_dim
 evaluator = Evaluator(name=args.dataset)
 
-hm = HookManager(keys=['train', 'val', 'test'])
+hm = HookManager()
 
 train_loader = DGDataLoader(train_dg, batch_unit=args.batch_time_gran, hook_manager=hm)
 val_loader = DGDataLoader(val_dg, batch_unit=args.batch_time_gran, hook_manager=hm)

--- a/tgm/constants.py
+++ b/tgm/constants.py
@@ -7,3 +7,5 @@ Notes:
     - A tgm.exceptions.InvalidNodeIDError will be thrown if this value
     appears as an ID in edge or node event tensors will constructing DGData.
 """
+
+DEFAULT_KEY_HOOK_MANAGER: Final[str] = '_SHARED_HOOK'


### PR DESCRIPTION
### Summary / Description

Make `_shared_hooks` the default key in `HookManager` to fix nodeproppred examples, which don't need to register any hooks.

**Related Issues:** # (issue number)

#### Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking Change
- [ ] Refactoring
- [ ] Documentation update

#### Test Evidence

Describe how this PR has been tested.

- [X] Unit tests
- [ ] Integration tests
- [ ] Performance tests

#### Questions / Discussion Points

*Related PR:* https://github.com/tgm-team/tgm/issues/193
