### PR TITLE
Vectorized Discretization

### DIFF
--- a/tgm/data.py
+++ b/tgm/data.py
@@ -4,7 +4,7 @@ import copy
 import csv
 import pathlib
 from dataclasses import dataclass, fields, replace
-from typing import Any, Callable, List, Set, Tuple
+from typing import Any, Callable, List, Tuple
 
 import numpy as np
 import torch
@@ -291,19 +291,34 @@ class DGData:
 
         def _get_keep_indices(event_idx: Tensor, ids: Tensor) -> Tensor:
             event_buckets = buckets[event_idx]
-            seen: Set[Any] = set()
-            keep, prev_bucket = [], None
 
-            for i in range(event_idx.numel()):
-                bucket = int(event_buckets[i])
-                node_or_edge = tuple(ids[i].tolist()) if ids.ndim > 1 else int(ids[i])
-                if bucket != prev_bucket:
-                    seen.clear()
-                    prev_bucket = bucket
-                if node_or_edge not in seen:
-                    seen.add(node_or_edge)
-                    keep.append(i)
-            return torch.tensor(keep, dtype=torch.long)
+            if ids.ndim == 1:
+                id_key = ids
+            else:
+                # Collision free radix-style encoding of edge id [src, dst]
+                # assuming edge ids >= 0, and no overflow
+                base = ids.max().item() + 1
+                src, dst = ids[:, 0], ids[:, 1]
+                id_key = src * base + dst
+
+            # Radix-style encoding of [bucket, flat_id]
+            base = id_key.max().item() + 1
+            final_key = event_buckets * base + id_key
+
+            # Stable sort to get adjacent duplicates while preserving ties
+            # with respect to the original event ordering prior to time conversion
+            sort_key, sort_idx = torch.sort(final_key, stable=True)
+
+            # Mark first occurrence in each [bucket, flat_id] group
+            is_first = torch.ones_like(sort_key, dtype=torch.bool)
+            is_first[1:] = sort_key[1:] != sort_key[:-1]
+
+            # Extract the 'first' [bucket, flat_id] based on our is_first mask
+            # We subsequently re-sort the final indices so that they index our
+            # global timeline chronologically.
+            keep = sort_idx[is_first]
+            keep = keep.sort().values
+            return keep
 
         # Edge events
         edge_mask = _get_keep_indices(self.edge_event_idx, self.edge_index)


### PR DESCRIPTION
### Summary / Description

The purpose of this pr is to vectorize our discretization implementation. Goal was to maximize performance gains with minimal implementation change, while also making it easy to add other reduction ops in the future (e.g. _mean_, _last_, _random_).

**Related Issues:** #90 

#### Latency

| Dataset | Main | perf/discretize | Speedup |
|:---:|:---:|:---:|:---:|
| tgbl-wiki | 0.84s | 0.02s | 29.41x |
| tgbn-genre | 95.29s | 1.06s | 89.90x |
| tgbl-coin | 123.39s | 1.28s | 96.27x |

#### Correctness
Discretization unit tests pass. Here are test results on all methods which use `.discretize()`

| Task / Model | Main | perf/discretize |
|---|---|---|
| Graph Prop Persistant Forecast | 0.6378 AUROC | 0.6378 AUROC |
| Graph Prop TGCN | 0.9087 AUROC | 0.9089 AUROC |
| Link Prop GC-LSTM (10 epochs) | 0.2283 MRR | 0.2283 MRR |
| Link Prop GCN (10 epochs) | 0.4068 MRR | 0.4041 MRR |