### PR TITLE
Selectively Suppress TGB Logs

### DIFF
--- a/tgm/data.py
+++ b/tgm/data.py
@@ -660,7 +660,7 @@ class DGData:
             raise ImportError('TGB required to load TGB data, try `pip install py-tgb`')
 
         def suppress_output(func: Callable, *args: Any, **kwargs: Any) -> Any:
-            # This is a hacky workaound that tries to lower the verbosity on TGB
+            # This is a hacky workaround that tries to lower the verbosity on TGB
             # logs which are currently directed to stdout. This should be removed
             # once https://github.com/shenyangHuang/TGB/issues/117 is addressed.
             import builtins


### PR DESCRIPTION
### Summary / Description

The purpose of this PR is to only suppress specific stdout print statements from TGB so that the download prompt is still visible.

**Related Issues:** #215 

#### Type of Change
- [x] Bug fix

#### Test Evidence

Unit tests and manual testing.

#### Questions / Discussion Points

The solution is hacky. Someone should cut a build and patch https://github.com/shenyangHuang/TGB/issues/117 directly in TGB.
