### PR TITLE
POC for Dense Feature Store in Backend

### DIFF
--- a/test/unit/test_dgraph.py
+++ b/test/unit/test_dgraph.py
@@ -79,12 +79,6 @@ def test_init_gpu(data):
     exp_dynamic_node_feats[10, 6] = data.dynamic_node_feats[2]
     exp_dynamic_node_feats = exp_dynamic_node_feats.cuda()
     torch.testing.assert_close(dg.dynamic_node_feats.to_dense(), exp_dynamic_node_feats)
-
-    exp_edge_feats = torch.zeros(dg.end_time + 1, dg.num_nodes, dg.num_nodes, 5)
-    exp_edge_feats[1, 2, 2] = data.edge_feats[0]
-    exp_edge_feats[5, 2, 4] = data.edge_feats[1]
-    exp_edge_feats[20, 1, 8] = data.edge_feats[2]
-    exp_edge_feats = exp_edge_feats.cuda()
     torch.testing.assert_close(dg.edge_feats, data.edge_feats.to('cuda'))
 
 

--- a/test/unit/test_storage_impl.py
+++ b/test/unit/test_storage_impl.py
@@ -222,41 +222,26 @@ def test_get_edge_feats(DGStorageImpl, edge_only_data_with_features):
     data = edge_only_data_with_features
     storage = DGStorageImpl(data)
 
-    exp_edge_feats = torch.zeros(11, 8 + 1, 8 + 1, 5)
-    exp_edge_feats[1, 2, 2] = data.edge_feats[0]
-    exp_edge_feats[5, 2, 4] = data.edge_feats[1]
-    exp_edge_feats[10, 6, 8] = data.edge_feats[2]
     assert torch.equal(
-        storage.get_edge_feats(DGSliceTracker()).to_dense(), exp_edge_feats
+        storage.get_edge_feats(DGSliceTracker()),
+        edge_only_data_with_features.edge_feats,
     )
-
-    exp_edge_feats = torch.zeros(11, 8 + 1, 8 + 1, 5)
-    exp_edge_feats[5, 2, 4] = data.edge_feats[1]
-    exp_edge_feats[10, 6, 8] = data.edge_feats[2]
     assert torch.equal(
-        storage.get_edge_feats(DGSliceTracker(start_time=5)).to_dense(), exp_edge_feats
+        storage.get_edge_feats(DGSliceTracker(start_time=5)),
+        edge_only_data_with_features.edge_feats[1:],
     )
-
-    exp_edge_feats = torch.zeros(5, 2 + 1, 2 + 1, 5)
-    exp_edge_feats[1, 2, 2] = data.edge_feats[0]
     assert torch.equal(
-        storage.get_edge_feats(DGSliceTracker(end_time=4)).to_dense(), exp_edge_feats
+        storage.get_edge_feats(DGSliceTracker(end_time=4)),
+        edge_only_data_with_features.edge_feats[:1],
     )
-
-    exp_edge_feats = torch.zeros(10, 4 + 1, 4 + 1, 5)
-    exp_edge_feats[5, 2, 4] = data.edge_feats[1]
     assert torch.equal(
-        storage.get_edge_feats(DGSliceTracker(start_time=5, end_time=9)).to_dense(),
-        exp_edge_feats,
+        storage.get_edge_feats(DGSliceTracker(start_time=5)),
+        edge_only_data_with_features.edge_feats[1:],
     )
-
-    exp_edge_feats = torch.zeros(11, 8 + 1, 8 + 1, 5)
-    exp_edge_feats[10, 6, 8] = data.edge_feats[2]
     assert torch.equal(
-        storage.get_edge_feats(DGSliceTracker(start_idx=2, end_idx=5)).to_dense(),
-        exp_edge_feats,
+        storage.get_edge_feats(DGSliceTracker(start_idx=2, end_idx=5)),
+        edge_only_data_with_features.edge_feats[2].unsqueeze(0),
     )
-
     assert (
         storage.get_edge_feats(DGSliceTracker(start_idx=2, end_idx=5, end_time=6))
         is None

--- a/tgm/_storage/backends/array_backend.py
+++ b/tgm/_storage/backends/array_backend.py
@@ -179,23 +179,7 @@ class DGStorageArrayBackend(DGStorageBase):
         if edge_mask.sum() == 0:
             return None
 
-        time = self._data.timestamps[self._data.edge_event_idx[edge_mask]]
-        edges = self._data.edge_index[edge_mask]
-        indices = torch.stack([time, edges[:, 0], edges[:, 1]], dim=0)
-        values = self._data.edge_feats[edge_mask]
-
-        max_node_id = edges.max()
-        if self._data.node_event_idx is not None:
-            node_mask = (self._data.node_event_idx >= lb_idx) & (
-                self._data.node_event_idx < ub_idx
-            )
-            if len(self._data.node_ids[node_mask]):  # type: ignore
-                max_node_id = max(max_node_id, self._data.node_ids[node_mask].max())  # type: ignore
-
-        max_time = slice.end_time or self._data.timestamps[ub_idx - 1]
-        edge_feats_dim = self.get_edge_feats_dim()
-        shape = (max_time + 1, max_node_id + 1, max_node_id + 1, edge_feats_dim)
-        return torch.sparse_coo_tensor(indices, values, shape)  # type: ignore
+        return self._data.edge_feats[edge_mask]
 
     def get_static_node_feats_dim(self) -> Optional[int]:
         if self._data.static_node_feats is None:

--- a/tgm/_storage/base.py
+++ b/tgm/_storage/base.py
@@ -57,7 +57,7 @@ class DGStorageBase(ABC):
 
     @abstractmethod
     def get_dynamic_node_feats(self, slice: DGSliceTracker) -> Optional[Tensor]:
-        """Return dynamic node features a sparse COO tensor within the slice, if any."""
+        """Return dynamic node features as a sparse COO tensor within the slice, if any."""
         ...
 
     @abstractmethod

--- a/tgm/_storage/base.py
+++ b/tgm/_storage/base.py
@@ -57,17 +57,17 @@ class DGStorageBase(ABC):
 
     @abstractmethod
     def get_dynamic_node_feats(self, slice: DGSliceTracker) -> Optional[Tensor]:
-        """Return dynamic node features as a sparse COO tensor within the slice, if any."""
+        """Return dynamic node features within the slice, if any."""
         ...
 
     @abstractmethod
     def get_edge_feats(self, slice: DGSliceTracker) -> Optional[Tensor]:
-        """Return edge features as a sparse COO tensor within the slice, if any."""
+        """Return edge features within the slice, if any."""
         ...
 
     @abstractmethod
     def get_static_node_feats(self) -> Optional[Tensor]:
-        """Return static node features as a sparse COO tensor within the slice, if any."""
+        """Return static node features of the entire graph."""
         ...
 
     @abstractmethod

--- a/tgm/_storage/base.py
+++ b/tgm/_storage/base.py
@@ -57,7 +57,7 @@ class DGStorageBase(ABC):
 
     @abstractmethod
     def get_dynamic_node_feats(self, slice: DGSliceTracker) -> Optional[Tensor]:
-        """Return dynamic node features within the slice, if any."""
+        """Return dynamic node features a sparse COO tensor within the slice, if any."""
         ...
 
     @abstractmethod

--- a/tgm/graph.py
+++ b/tgm/graph.py
@@ -76,7 +76,7 @@ class DGraph:
             batch.node_times, batch.node_ids = self.dynamic_node_feats._indices()
             batch.dynamic_node_feats = self.dynamic_node_feats._values()
         if materialize_features and self.edge_feats is not None:
-            batch.edge_feats = self.edge_feats._values()
+            batch.edge_feats = self.edge_feats
         return batch
 
     def slice_events(
@@ -215,7 +215,7 @@ class DGraph:
     def dynamic_node_feats(self) -> Optional[Tensor]:
         """The aggregated dynamic node features over the dynamic graph.
 
-        If dynamic node features exist, returns a Tensor.sparse_coo_tensor(T x V x d_node_dynamic).
+        If dynamic node features exist, returns a tensor of shape (T x V x d_node_dynamic).
         """
         feats = self._storage.get_dynamic_node_feats(self._slice)
         if feats is not None:
@@ -226,7 +226,7 @@ class DGraph:
     def edge_feats(self) -> Optional[Tensor]:
         """The aggregated edge features over the dynamic graph.
 
-        If edge features exist, returns a Tensor.sparse_coo_tensor(T x V x V x d_edge).
+        If edge features exist, returns a tensor of shape (T x V x V x d_edge).
         """
         feats = self._storage.get_edge_feats(self._slice)
         if feats is not None:
@@ -289,10 +289,9 @@ class DGBatch:
         dst (Tensor): Destination node indices for edges in the batch. Shape `(E,)`.
         time (Tensor): Timestamps of each edge event. Shape `(E,)`.
         dynamic_node_feats (Tensor | None, optional): Dynamic node features for nodes
-            in the batch. Typically sparse tensor of shape `(T x V x d_node_dynamic)`.
-        edge_feats (Tensor | None, optional): Edge features for the batch. Typically
-            sparse tensor of shape `(E x d_edge)` or `(T x V x V x d_edge)` depending
-            on storage.
+            in the batch. Tensor of shape `(T x V x d_node_dynamic)`.
+        edge_feats (Tensor | None, optional): Edge features for the batch. Tensor
+            of shape `(T x V x V x d_edge)`.
         node_times (Tensor | None, optional): Timestamps corresponding to dynamic node features.
         node_ids (Tensor | None, optional): Node IDs corresponding to dynamic node features.
     """

--- a/tgm/graph.py
+++ b/tgm/graph.py
@@ -215,7 +215,7 @@ class DGraph:
     def dynamic_node_feats(self) -> Optional[Tensor]:
         """The aggregated dynamic node features over the dynamic graph.
 
-        If dynamic node features exist, returns a tensor of shape (T x V x d_node_dynamic).
+        If dynamic node features exist, returns a Tensor.sparse_coo_tensor(T x V x d_node_dynamic).
         """
         feats = self._storage.get_dynamic_node_feats(self._slice)
         if feats is not None:


### PR DESCRIPTION
Aafter profiling, it turns out this is not the primary bottleneck it seems, for `nodeprop` examples at least:

E.g.
<img width="1338" height="716" alt="Screenshot from 2025-09-10 19-46-55" src="https://github.com/user-attachments/assets/929ee0e5-c562-4881-a29d-412060e9e702" />

23/25seconds are spent in tgb evaluator.

However, I did encounter a `IntegerOverflowError` when trying to run the `sparse-coo` backend on `tgbl-review`, which probably had trouble tracking indices of a sparse tensor having size `(T x V x V x d_edge)`


Relevant issue: #203 