### PR TITLE
Build recipe feature for HookManager

### DIFF
--- a/docs/tutorials/hook_tutorial.md
+++ b/docs/tutorials/hook_tutorial.md
@@ -236,7 +236,7 @@ ______________________________________________________________________
 
 ## 6. Recipes
 
-For commonly used pre-experiment setup step, `TGM` offer a convenient way to setup experiment and `HookManager` by using `RecipeRegistry.build()` on pre-defined recipe. For example, in TGB `linkproppred` setting, a `HookManager` needs to set up for every scripts as follows:
+`TGM` offer a convenient way to setup common `HookManager` configuration by using `RecipeRegistry.build()` with a pre-defined recipe. For example, in the TGB `linkproppred` setting, the `HookManager` must register train, validation, and test hooks as follows:
 
 ```python
 dataset = PyGLinkPropPredDataset(
@@ -256,7 +256,7 @@ hm.register('val', TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='val'))
 hm.register('test', TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='test'))
 ```
 
-To avoid repeated code appearing in every script, this procedure can be encapsulated in a function and registered through `RecipeRegistry` as follows:
+To minimize boilerplate and avoid accidental typos in this setup process, this procedure can be encapsulated in a function and registered through `RecipeRegistry` as follows:
 
 ```python
 @RecipeRegistry.register(RECIPE_TGB_LINK_PRED)
@@ -293,7 +293,7 @@ def build_tgb_link_pred(dataset_name: str, train_dg: DGraph) -> HookManager:
 @RecipeRegistry.register(RECIPE_TGB_LINK_PRED)
 ```
 
-In the experiments script, all we need to do to set up `HookManager` for `TGB` linkproppred is as follows:
+Therefore, all we need to do to set up `HookManager` for `TGB` linkproppred is:
 
 ```python
 hm = RecipeRegistry.build(
@@ -303,7 +303,7 @@ registered_keys = hm.keys
 train_key, val_key, test_key = registered_keys
 ```
 
-`TGM` team provided the implementaion of recipe for `TGB` linkproppred, users are welcome to define their own `Recipe`, register it and build it with `RecipeRegistry.build()`.
+`TGM` team provided the implementation of recipe for `TGB` linkproppred, users are welcome to define their own `Recipe`, register it and build it with `RecipeRegistry.build()`.
 
 ## Summary
 

--- a/examples/linkproppred/dygformer.py
+++ b/examples/linkproppred/dygformer.py
@@ -10,9 +10,10 @@ import torch.nn.functional as F
 from tgb.linkproppred.evaluate import Evaluator
 from tqdm import tqdm
 
+from tgm import RecipeRegistry
 from tgm.constants import METRIC_TGB_LINKPROPPRED, RECIPE_TGB_LINK_PRED
 from tgm.graph import DGBatch, DGData, DGraph
-from tgm.hooks import HookManager, RecencyNeighborHook
+from tgm.hooks import RecencyNeighborHook
 from tgm.loader import DGDataLoader
 from tgm.nn import DyGFormer, Time2Vec
 from tgm.util.seed import seed_everything
@@ -267,8 +268,8 @@ nbr_hook = RecencyNeighborHook(
     edge_feats_dim=edge_feats_dim,
 )
 
-hm, registered_keys = HookManager.build_recipe(
-    RECIPE_TGB_LINK_PRED, args.dataset, train_dg, val_dg, test_dg
+hm, registered_keys = RecipeRegistry.build(
+    RECIPE_TGB_LINK_PRED, dataset_name=args.dataset, train_dg=train_dg
 )
 hm.register_shared(nbr_hook)
 train_key, val_key, test_key = registered_keys

--- a/examples/linkproppred/dygformer.py
+++ b/examples/linkproppred/dygformer.py
@@ -268,10 +268,11 @@ nbr_hook = RecencyNeighborHook(
     edge_feats_dim=edge_feats_dim,
 )
 
-hm, registered_keys = RecipeRegistry.build(
+hm = RecipeRegistry.build(
     RECIPE_TGB_LINK_PRED, dataset_name=args.dataset, train_dg=train_dg
 )
 hm.register_shared(nbr_hook)
+registered_keys = hm.keys
 train_key, val_key, test_key = registered_keys
 
 train_loader = DGDataLoader(train_dg, args.bsize, hook_manager=hm)

--- a/examples/linkproppred/gcn.py
+++ b/examples/linkproppred/gcn.py
@@ -6,17 +6,12 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from tgb.linkproppred.dataset_pyg import PyGLinkPropPredDataset
 from tgb.linkproppred.evaluate import Evaluator
 from torch_geometric.nn import GCNConv
 from tqdm import tqdm
 
-from tgm import DGBatch, DGData, DGraph
-from tgm.hooks import (
-    HookManager,
-    NegativeEdgeSamplerHook,
-    TGBNegativeEdgeSamplerHook,
-)
+from tgm import DGBatch, DGData, DGraph, RecipeRegistry
+from tgm.constants import METRIC_TGB_LINKPROPPRED, RECIPE_TGB_LINK_PRED
 from tgm.loader import DGDataLoader
 from tgm.timedelta import TimeDeltaDG
 from tgm.util.seed import seed_everything
@@ -148,7 +143,6 @@ def eval(
     z: torch.Tensor,
     encoder: nn.Module,
     decoder: nn.Module,
-    eval_metric: str,
     evaluator: Evaluator,
     conversion_rate: int,
 ) -> float:
@@ -169,9 +163,9 @@ def eval(
             input_dict = {
                 'y_pred_pos': y_pred[0],
                 'y_pred_neg': y_pred[1:],
-                'eval_metric': [eval_metric],
+                'eval_metric': [METRIC_TGB_LINKPROPPRED],
             }
-            perf_list.append(evaluator.eval(input_dict)[eval_metric])
+            perf_list.append(evaluator.eval(input_dict)[METRIC_TGB_LINKPROPPRED])
 
         # update the model if the prediction batch has moved to next snapshot.
         while batch.time[-1] > (snapshot_batch.time[-1] + 1) * conversion_rate:
@@ -187,12 +181,7 @@ def eval(
 args = parser.parse_args()
 seed_everything(args.seed)
 
-dataset = PyGLinkPropPredDataset(name=args.dataset, root='datasets')
-eval_metric = dataset.eval_metric
-neg_sampler = dataset.negative_sampler
 evaluator = Evaluator(name=args.dataset)
-dataset.load_val_ns()
-dataset.load_test_ns()
 
 train_data, val_data, test_data = DGData.from_tgb(args.dataset).split()
 train_dg = DGraph(train_data, device=args.device)
@@ -212,10 +201,11 @@ test_snapshots = DGraph(test_data_discretized, device=args.device)
 
 _, dst, _ = train_dg.edges
 
-hm = HookManager(keys=['train', 'val', 'test'])
-hm.register('train', NegativeEdgeSamplerHook(low=int(dst.min()), high=int(dst.max())))
-hm.register('val', TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='val'))
-hm.register('test', TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='test'))
+hm = RecipeRegistry.build(
+    RECIPE_TGB_LINK_PRED, dataset_name=args.dataset, train_dg=train_dg
+)
+registered_keys = hm.keys
+train_key, val_key, test_key = registered_keys
 
 train_loader = DGDataLoader(train_dg, args.bsize, hook_manager=hm)
 val_loader = DGDataLoader(val_dg, args.bsize, hook_manager=hm)
@@ -248,7 +238,7 @@ opt = torch.optim.Adam(
 )
 
 for epoch in range(1, args.epochs + 1):
-    with hm.activate('train'):
+    with hm.activate(train_key):
         start_time = time.perf_counter()
         loss, z = train(
             train_loader,
@@ -262,7 +252,7 @@ for epoch in range(1, args.epochs + 1):
         end_time = time.perf_counter()
         latency = end_time - start_time
 
-    with hm.activate('val'):
+    with hm.activate(val_key):
         val_mrr = eval(
             val_loader,
             val_snapshots_loader,
@@ -270,16 +260,15 @@ for epoch in range(1, args.epochs + 1):
             z,
             encoder,
             decoder,
-            eval_metric,
             evaluator,
             conversion_rate,
         )
     print(
-        f'Epoch={epoch:02d} Latency={latency:.4f} Loss={loss:.4f} Validation {eval_metric}={val_mrr:.4f}'
+        f'Epoch={epoch:02d} Latency={latency:.4f} Loss={loss:.4f} Validation {METRIC_TGB_LINKPROPPRED}={val_mrr:.4f}'
     )
 
 
-with hm.activate('test'):
+with hm.activate(test_key):
     test_mrr = eval(
         test_loader,
         test_snapshots_loader,
@@ -287,8 +276,7 @@ with hm.activate('test'):
         z,
         encoder,
         decoder,
-        eval_metric,
         evaluator,
         conversion_rate,
     )
-    print(f'Test {eval_metric}={test_mrr:.4f}')
+    print(f'Test {METRIC_TGB_LINKPROPPRED}={test_mrr:.4f}')

--- a/examples/linkproppred/tgat.py
+++ b/examples/linkproppred/tgat.py
@@ -5,19 +5,16 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from tgb.linkproppred.dataset_pyg import PyGLinkPropPredDataset
 from tgb.linkproppred.evaluate import Evaluator
 from tqdm import tqdm
 
-from tgm import DGBatch, DGData, DGraph
-from tgm.constants import PADDED_NODE_ID
-from tgm.hooks import (
-    HookManager,
-    NegativeEdgeSamplerHook,
-    NeighborSamplerHook,
-    RecencyNeighborHook,
-    TGBNegativeEdgeSamplerHook,
+from tgm import DGBatch, DGData, DGraph, RecipeRegistry
+from tgm.constants import (
+    METRIC_TGB_LINKPROPPRED,
+    PADDED_NODE_ID,
+    RECIPE_TGB_LINK_PRED,
 )
+from tgm.hooks import NeighborSamplerHook, RecencyNeighborHook
 from tgm.loader import DGDataLoader
 from tgm.nn import TemporalAttention, Time2Vec
 from tgm.util.seed import seed_everything
@@ -176,7 +173,6 @@ def eval(
     static_node_feats: torch.Tensor,
     encoder: nn.Module,
     decoder: nn.Module,
-    eval_metric: str,
     evaluator: Evaluator,
 ) -> float:
     encoder.eval()
@@ -199,9 +195,9 @@ def eval(
             input_dict = {
                 'y_pred_pos': y_pred[0],
                 'y_pred_neg': y_pred[1:],
-                'eval_metric': [eval_metric],
+                'eval_metric': [METRIC_TGB_LINKPROPPRED],
             }
-            perf_list.append(evaluator.eval(input_dict)[eval_metric])
+            perf_list.append(evaluator.eval(input_dict)[METRIC_TGB_LINKPROPPRED])
 
     return float(np.mean(perf_list))
 
@@ -209,12 +205,7 @@ def eval(
 args = parser.parse_args()
 seed_everything(args.seed)
 
-dataset = PyGLinkPropPredDataset(name=args.dataset, root='datasets')
-eval_metric = dataset.eval_metric
-neg_sampler = dataset.negative_sampler
 evaluator = Evaluator(name=args.dataset)
-dataset.load_val_ns()
-dataset.load_test_ns()
 
 train_data, val_data, test_data = DGData.from_tgb(args.dataset).split()
 train_dg = DGraph(train_data, device=args.device)
@@ -240,10 +231,11 @@ else:
 
 _, dst, _ = train_dg.edges
 
-hm = HookManager(keys=['train', 'val', 'test'])
-hm.register('train', NegativeEdgeSamplerHook(low=int(dst.min()), high=int(dst.max())))
-hm.register('val', TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='val'))
-hm.register('test', TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='test'))
+hm = RecipeRegistry.build(
+    RECIPE_TGB_LINK_PRED, dataset_name=args.dataset, train_dg=train_dg
+)
+registered_keys = hm.keys
+train_key, val_key, test_key = registered_keys
 hm.register_shared(nbr_hook)
 
 train_loader = DGDataLoader(train_dg, args.bsize, hook_manager=hm)
@@ -265,25 +257,21 @@ opt = torch.optim.Adam(
 )
 
 for epoch in range(1, args.epochs + 1):
-    with hm.activate('train'):
+    with hm.activate(train_key):
         start_time = time.perf_counter()
         loss = train(train_loader, static_node_feats, encoder, decoder, opt)
         end_time = time.perf_counter()
         latency = end_time - start_time
 
-    with hm.activate('val'):
-        val_mrr = eval(
-            val_loader, static_node_feats, encoder, decoder, eval_metric, evaluator
-        )
+    with hm.activate(val_key):
+        val_mrr = eval(val_loader, static_node_feats, encoder, decoder, evaluator)
     print(
-        f'Epoch={epoch:02d} Latency={latency:.4f} Loss={loss:.4f} Validation {eval_metric}={val_mrr:.4f}'
+        f'Epoch={epoch:02d} Latency={latency:.4f} Loss={loss:.4f} Validation {METRIC_TGB_LINKPROPPRED}={val_mrr:.4f}'
     )
 
     if epoch < args.epochs:  # Reset hooks after each epoch, except last epoch
         hm.reset_state()
 
-with hm.activate('test'):
-    test_mrr = eval(
-        test_loader, static_node_feats, encoder, decoder, eval_metric, evaluator
-    )
-    print(f'Test {eval_metric}={test_mrr:.4f}')
+with hm.activate(test_key):
+    test_mrr = eval(test_loader, static_node_feats, encoder, decoder, evaluator)
+    print(f'Test {METRIC_TGB_LINKPROPPRED}={test_mrr:.4f}')

--- a/examples/linkproppred/tgn.py
+++ b/examples/linkproppred/tgn.py
@@ -7,19 +7,16 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from tgb.linkproppred.dataset_pyg import PyGLinkPropPredDataset
 from tgb.linkproppred.evaluate import Evaluator
 from tqdm import tqdm
 
-from tgm import DGBatch, DGData, DGraph
-from tgm.constants import PADDED_NODE_ID
-from tgm.hooks import (
-    HookManager,
-    NegativeEdgeSamplerHook,
-    NeighborSamplerHook,
-    RecencyNeighborHook,
-    TGBNegativeEdgeSamplerHook,
+from tgm import DGBatch, DGData, DGraph, RecipeRegistry
+from tgm.constants import (
+    METRIC_TGB_LINKPROPPRED,
+    PADDED_NODE_ID,
+    RECIPE_TGB_LINK_PRED,
 )
+from tgm.hooks import NeighborSamplerHook, RecencyNeighborHook
 from tgm.loader import DGDataLoader
 from tgm.nn import TemporalAttention, Time2Vec
 from tgm.util.seed import seed_everything
@@ -375,7 +372,6 @@ def eval(
     static_node_feats: torch.Tensor,
     encoder: nn.Module,
     decoder: nn.Module,
-    eval_metric: str,
     evaluator: Evaluator,
 ) -> float:
     encoder.eval()
@@ -398,22 +394,16 @@ def eval(
             input_dict = {
                 'y_pred_pos': y_pred[0],
                 'y_pred_neg': y_pred[1:],
-                'eval_metric': [eval_metric],
+                'eval_metric': [METRIC_TGB_LINKPROPPRED],
             }
-            perf_list.append(evaluator.eval(input_dict)[eval_metric])
+            perf_list.append(evaluator.eval(input_dict)[METRIC_TGB_LINKPROPPRED])
 
     return float(np.mean(perf_list))
 
 
 args = parser.parse_args()
 seed_everything(args.seed)
-
-dataset = PyGLinkPropPredDataset(name=args.dataset, root='datasets')
-eval_metric = dataset.eval_metric
-neg_sampler = dataset.negative_sampler
 evaluator = Evaluator(name=args.dataset)
-dataset.load_val_ns()
-dataset.load_test_ns()
 
 train_data, val_data, test_data = DGData.from_tgb(args.dataset).split()
 train_dg = DGraph(train_data, device=args.device)
@@ -439,11 +429,12 @@ else:
 
 _, dst, _ = train_dg.edges
 
-hm = HookManager(keys=['train', 'val', 'test'])
-hm.register('train', NegativeEdgeSamplerHook(low=int(dst.min()), high=int(dst.max())))
-hm.register('val', TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='val'))
-hm.register('test', TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='test'))
+hm = RecipeRegistry.build(
+    RECIPE_TGB_LINK_PRED, dataset_name=args.dataset, train_dg=train_dg
+)
 hm.register_shared(nbr_hook)
+registered_keys = hm.keys
+train_key, val_key, test_key = registered_keys
 
 train_loader = DGDataLoader(train_dg, args.bsize, hook_manager=hm)
 val_loader = DGDataLoader(val_dg, args.bsize, hook_manager=hm)
@@ -466,18 +457,16 @@ opt = torch.optim.Adam(
 )
 
 for epoch in range(1, args.epochs + 1):
-    with hm.activate('train'):
+    with hm.activate(train_key):
         start_time = time.perf_counter()
         loss = train(train_loader, static_node_feats, encoder, decoder, opt)
         end_time = time.perf_counter()
         latency = end_time - start_time
 
-    with hm.activate('val'):
-        val_mrr = eval(
-            val_loader, static_node_feats, encoder, decoder, eval_metric, evaluator
-        )
+    with hm.activate(val_key):
+        val_mrr = eval(val_loader, static_node_feats, encoder, decoder, evaluator)
     print(
-        f'Epoch={epoch:02d} Latency={latency:.4f} Loss={loss:.4f} Validation {eval_metric}={val_mrr:.4f}'
+        f'Epoch={epoch:02d} Latency={latency:.4f} Loss={loss:.4f} Validation {METRIC_TGB_LINKPROPPRED}={val_mrr:.4f}'
     )
 
     # Clear memory state between epochs, except last epoch
@@ -486,8 +475,6 @@ for epoch in range(1, args.epochs + 1):
         encoder.memory.clear_msgs(list(range(test_dg.num_nodes)))
 
 
-with hm.activate('test'):
-    test_mrr = eval(
-        test_loader, static_node_feats, encoder, decoder, eval_metric, evaluator
-    )
-    print(f'Test {eval_metric}={test_mrr:.4f}')
+with hm.activate(test_key):
+    test_mrr = eval(test_loader, static_node_feats, encoder, decoder, evaluator)
+    print(f'Test {METRIC_TGB_LINKPROPPRED}={test_mrr:.4f}')

--- a/examples/linkproppred/tpnet.py
+++ b/examples/linkproppred/tpnet.py
@@ -7,17 +7,13 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from tgb.linkproppred.dataset_pyg import PyGLinkPropPredDataset
 from tgb.linkproppred.evaluate import Evaluator
 from tqdm import tqdm
 
+from tgm import RecipeRegistry
+from tgm.constants import METRIC_TGB_LINKPROPPRED, RECIPE_TGB_LINK_PRED
 from tgm.graph import DGBatch, DGData, DGraph
-from tgm.hooks import (
-    HookManager,
-    NegativeEdgeSamplerHook,
-    RecencyNeighborHook,
-    TGBNegativeEdgeSamplerHook,
-)
+from tgm.hooks import RecencyNeighborHook
 from tgm.loader import DGDataLoader
 from tgm.nn import RandomProjectionModule, Time2Vec, TPNet
 from tgm.util.seed import seed_everything
@@ -212,7 +208,6 @@ def eval(
     evaluator: Evaluator,
     loader: DGDataLoader,
     model: nn.Module,
-    eval_metric: str,
     static_node_feat: torch.Tensor,
 ) -> float:
     model.eval()
@@ -247,9 +242,9 @@ def eval(
             input_dict = {
                 'y_pred_pos': pos_out,
                 'y_pred_neg': neg_out,
-                'eval_metric': [eval_metric],
+                'eval_metric': [METRIC_TGB_LINKPROPPRED],
             }
-            perf_list.append(evaluator.eval(input_dict)[eval_metric])
+            perf_list.append(evaluator.eval(input_dict)[METRIC_TGB_LINKPROPPRED])
 
     return float(np.mean(perf_list))
 
@@ -257,13 +252,7 @@ def eval(
 args = parser.parse_args()
 seed_everything(args.seed)
 
-# loading negative sample from TGB
-dataset = PyGLinkPropPredDataset(name=args.dataset, root='datasets')
-eval_metric = dataset.eval_metric
-neg_sampler = dataset.negative_sampler
 evaluator = Evaluator(name=args.dataset)
-dataset.load_val_ns()
-dataset.load_test_ns()
 
 data = DGData.from_tgb(args.dataset)
 dgraph = DGraph(data)
@@ -289,11 +278,12 @@ nbr_hook = RecencyNeighborHook(
     edge_feats_dim=edge_feats_dim,
 )
 
-hm = HookManager(keys=['train', 'val', 'test'])
-hm.register('train', NegativeEdgeSamplerHook(low=int(dst.min()), high=int(dst.max())))
-hm.register('val', TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='val'))
-hm.register('test', TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='test'))
+hm = RecipeRegistry.build(
+    RECIPE_TGB_LINK_PRED, dataset_name=args.dataset, train_dg=train_dg
+)
 hm.register_shared(nbr_hook)
+registered_keys = hm.keys
+train_key, val_key, test_key = registered_keys
 
 train_loader = DGDataLoader(train_dg, args.bsize, hook_manager=hm)
 val_loader = DGDataLoader(val_dg, args.bsize, hook_manager=hm)
@@ -326,21 +316,21 @@ model = TPNet_LinkPrediction(
 opt = torch.optim.Adam(model.parameters(), lr=float(args.lr))
 
 for epoch in range(1, args.epochs + 1):
-    with hm.activate('train'):
+    with hm.activate(train_key):
         start_time = time.perf_counter()
         loss = train(train_loader, model, opt, static_node_feat)
         end_time = time.perf_counter()
         latency = end_time - start_time
-    with hm.activate('val'):
-        val_mrr = eval(evaluator, val_loader, model, eval_metric, static_node_feat)
+    with hm.activate(val_key):
+        val_mrr = eval(evaluator, val_loader, model, static_node_feat)
         print(
-            f'Epoch={epoch:02d} Latency={latency:.4f} Loss={loss:.4f} Validation {eval_metric}={val_mrr:.4f}'
+            f'Epoch={epoch:02d} Latency={latency:.4f} Loss={loss:.4f} Validation {METRIC_TGB_LINKPROPPRED}={val_mrr:.4f}'
         )
     # Clear memory state between epochs, except last epoch
     if epoch < args.epochs:
         hm.reset_state()
         model.rp_module.reset_random_projections()
 
-with hm.activate('test'):
-    test_mrr = eval(evaluator, test_loader, model, eval_metric, static_node_feat)
-    print(f'Test MRR:{eval_metric}={test_mrr:.4f}')
+with hm.activate(test_key):
+    test_mrr = eval(evaluator, test_loader, model, static_node_feat)
+    print(f'Test MRR:{METRIC_TGB_LINKPROPPRED}={test_mrr:.4f}')

--- a/examples/nodeproppred/gclstm.py
+++ b/examples/nodeproppred/gclstm.py
@@ -10,6 +10,7 @@ from tgb.nodeproppred.evaluate import Evaluator
 from tqdm import tqdm
 
 from tgm import DGBatch, DGData, DGraph
+from tgm.constants import METRIC_TGB_NODEPROPPRED
 from tgm.loader import DGDataLoader
 from tgm.nn.recurrent import GCLSTM
 from tgm.util.seed import seed_everything
@@ -110,7 +111,6 @@ def eval(
     decoder: nn.Module,
     h_0: torch.Tensor,
     c_0: torch.Tensor,
-    eval_metric: str,
     evaluator: Evaluator,
 ) -> float:
     encoder.eval()
@@ -126,8 +126,12 @@ def eval(
         z_node = z[batch.node_ids]
         y_pred = decoder(z_node)
 
-        input_dict = {'y_true': y_true, 'y_pred': y_pred, 'eval_metric': [eval_metric]}
-        perf_list.append(evaluator.eval(input_dict)[eval_metric])
+        input_dict = {
+            'y_true': y_true,
+            'y_pred': y_pred,
+            'eval_metric': [METRIC_TGB_NODEPROPPRED],
+        }
+        perf_list.append(evaluator.eval(input_dict)[METRIC_TGB_NODEPROPPRED])
 
     return float(np.mean(perf_list))
 
@@ -151,7 +155,7 @@ else:
         (test_dg.num_nodes, args.node_dim), device=args.device
     )
 
-evaluator, eval_metric = Evaluator(name=args.dataset), 'ndcg'
+evaluator = Evaluator(name=args.dataset)
 num_classes = train_dg.dynamic_node_feats_dim
 
 encoder = RecurrentGCN(
@@ -175,14 +179,11 @@ for epoch in range(1, args.epochs + 1):
         decoder,
         h_0,
         c_0,
-        eval_metric,
         evaluator,
     )
     print(
-        f'Epoch={epoch:02d} Latency={latency:.4f} Loss={loss:.4f} Validation {eval_metric}={val_ndcg:.4f}'
+        f'Epoch={epoch:02d} Latency={latency:.4f} Loss={loss:.4f} Validation {METRIC_TGB_NODEPROPPRED}={val_ndcg:.4f}'
     )
 
-test_ndcg = eval(
-    test_loader, static_node_feats, encoder, decoder, h_0, c_0, eval_metric, evaluator
-)
-print(f'Test {eval_metric}={test_ndcg:.4f}')
+test_ndcg = eval(test_loader, static_node_feats, encoder, decoder, h_0, c_0, evaluator)
+print(f'Test {METRIC_TGB_NODEPROPPRED}={test_ndcg:.4f}')

--- a/test/unit/test_hooks/test_hook_manager.py
+++ b/test/unit/test_hooks/test_hook_manager.py
@@ -67,6 +67,8 @@ def test_register():
     hm = HookManager(keys=['foo'])
     hook = MockHook()
     hm.register('foo', hook)
+
+    assert len(hm.keys) == 1
     assert hook in hm._key_to_hooks['foo']
     assert len(hm._key_to_hooks['foo']) == 1
 
@@ -78,6 +80,7 @@ def test_register_multiple():
     hm.register('train', MockHookWithState())
     hm.register('val', MockHook())
 
+    assert len(hm.keys) == 2
     assert len(hm._key_to_hooks['train']) == 2
     assert len(hm._key_to_hooks['val']) == 1
 

--- a/test/unit/test_recipe.py
+++ b/test/unit/test_recipe.py
@@ -32,7 +32,7 @@ def tgb_dataset_factory():
     return tgb_dataset
 
 
-@patch('tgm.recipe.PyGLinkPropPredDataset')
+@patch('tgb.linkproppred.dataset_pyg.PyGLinkPropPredDataset')
 def test_bad_build_recipe(mock_dataset_cls, tgb_dataset_factory, dg):
     mock_dataset = tgb_dataset_factory()
     mock_dataset_cls.return_value = mock_dataset
@@ -43,7 +43,7 @@ def test_bad_build_recipe(mock_dataset_cls, tgb_dataset_factory, dg):
         )
 
 
-@patch('tgm.recipe.PyGLinkPropPredDataset')
+@patch('tgb.linkproppred.dataset_pyg.PyGLinkPropPredDataset')
 def test_build_recipe_tgb_link_pred(mock_dataset_cls, tgb_dataset_factory, dg):
     mock_dataset = tgb_dataset_factory()
     mock_dataset_cls.return_value = mock_dataset

--- a/test/unit/test_recipe.py
+++ b/test/unit/test_recipe.py
@@ -48,9 +48,10 @@ def test_build_recipe_tgb_link_pred(mock_dataset_cls, tgb_dataset_factory, dg):
     mock_dataset = tgb_dataset_factory()
     mock_dataset_cls.return_value = mock_dataset
 
-    hm, register_keys = RecipeRegistry.build(
+    hm = RecipeRegistry.build(
         RECIPE_TGB_LINK_PRED, dataset_name='tgbl-foo', train_dg=dg
     )
+    register_keys = hm.keys
     train_hooks = hm._key_to_hooks['train']
     val_hooks = hm._key_to_hooks['val']
     test_hooks = hm._key_to_hooks['test']

--- a/test/unit/test_recipe.py
+++ b/test/unit/test_recipe.py
@@ -1,0 +1,86 @@
+from typing import Tuple
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from tgm import DGraph, RecipeRegistry
+from tgm.constants import RECIPE_TGB_LINK_PRED
+from tgm.data import DGData
+from tgm.exceptions import UndefinedRecipe
+from tgm.hooks import (
+    HookManager,
+    NegativeEdgeSamplerHook,
+    TGBNegativeEdgeSamplerHook,
+)
+
+
+@pytest.fixture
+def dg():
+    edge_index = torch.LongTensor([[1, 10], [1, 11], [1, 12], [1, 13]])
+    edge_timestamps = torch.LongTensor([1, 1, 2, 2])
+    data = DGData.from_raw(edge_timestamps, edge_index)
+    return DGraph(data)
+
+
+@pytest.fixture
+def tgb_dataset_factory():
+    tgb_dataset = MagicMock()
+    neg_sampler = MagicMock()
+    neg_sampler.eval_set = {'val': [], 'test': []}
+    tgb_dataset.negative_sampler = neg_sampler
+    return tgb_dataset
+
+
+@patch('tgm.recipe.PyGLinkPropPredDataset')
+def test_bad_build_recipe(mock_dataset_cls, tgb_dataset_factory, dg):
+    mock_dataset = tgb_dataset_factory()
+    mock_dataset_cls.return_value = mock_dataset
+
+    with pytest.raises(UndefinedRecipe):
+        hm, register_keys = RecipeRegistry.build(
+            'foo', dataset_name='tgbl-foo', train_dg=dg
+        )
+
+
+@patch('tgm.recipe.PyGLinkPropPredDataset')
+def test_build_recipe_tgb_link_pred(mock_dataset_cls, tgb_dataset_factory, dg):
+    mock_dataset = tgb_dataset_factory()
+    mock_dataset_cls.return_value = mock_dataset
+
+    hm, register_keys = RecipeRegistry.build(
+        RECIPE_TGB_LINK_PRED, dataset_name='tgbl-foo', train_dg=dg
+    )
+    train_hooks = hm._key_to_hooks['train']
+    val_hooks = hm._key_to_hooks['val']
+    test_hooks = hm._key_to_hooks['test']
+
+    assert len(register_keys) == 3
+    assert (
+        register_keys[0] == 'train'
+        and register_keys[1] == 'val'
+        and register_keys[2] == 'test'
+    )
+    assert len(train_hooks) == len(val_hooks) == len(test_hooks) == 1
+    assert isinstance(train_hooks[0], NegativeEdgeSamplerHook)
+    assert isinstance(val_hooks[0], TGBNegativeEdgeSamplerHook)
+    assert isinstance(test_hooks[0], TGBNegativeEdgeSamplerHook)
+    mock_dataset_cls.assert_called_once_with(name='tgbl-foo', root='datasets')
+    mock_dataset.load_val_ns.assert_called_once()
+    mock_dataset.load_test_ns.assert_called_once()
+
+
+def test_register_new_recipe():
+    state = {'call': 0}
+
+    @RecipeRegistry.register('foo')
+    def mock_recipe(input: str) -> Tuple[HookManager, str]:
+        state['call'] += 1
+        hm = HookManager(['global'])
+        return hm, input
+
+    hm, output = RecipeRegistry.build('foo', input='input_1')
+
+    assert isinstance(hm, HookManager)
+    assert output == 'input_1'
+    assert state['call'] == 1

--- a/tgm/__init__.py
+++ b/tgm/__init__.py
@@ -2,12 +2,8 @@
 
 from .graph import DGraph, DGBatch
 from .data import DGData
+from .recipe import RecipeRegistry
 
 __version__ = '0.1.0a0'
 
-__all__ = [
-    '__version__',
-    'DGraph',
-    'DGBatch',
-    'DGData',
-]
+__all__ = ['__version__', 'DGraph', 'DGBatch', 'DGData', 'RecipeRegistry']

--- a/tgm/constants.py
+++ b/tgm/constants.py
@@ -7,3 +7,24 @@ Notes:
     - A tgm.exceptions.InvalidNodeIDError will be thrown if this value
     appears as an ID in edge or node event tensors will constructing DGData.
 """
+
+RECIPE_TGB_LINK_PRED: Final[str] = 'TGB_LINKPROPPRED_SETTING'
+"""A name to indicate recipe used for TGBlink property prediction
+
+Notes:
+    - A tgm.exceptions.UnsupportRecipe will be thrown if user build recipe
+    from unsupported recipe
+
+"""
+
+SUPPORT_RECIPES: Final[list] = [RECIPE_TGB_LINK_PRED]
+"""A list of supported recipes can be built from HookManager
+
+Notes:
+    - A tgm.exceptions.UnsupportRecipe will be thrown if user build recipe
+    from unsupported recipe
+"""
+
+METRIC_TGB_LINKPROPPRED: Final[str] = 'mrr'
+"""Official metric used in TGB link prediction task
+"""

--- a/tgm/constants.py
+++ b/tgm/constants.py
@@ -15,3 +15,7 @@ RECIPE_TGB_LINK_PRED: Final[str] = 'TGB_LINK_PROPERTY_PREDICTION'
 METRIC_TGB_LINKPROPPRED: Final[str] = 'mrr'
 """Official metric used in TGB link prediction task.
 """
+
+METRIC_TGB_NODEPROPPRED: Final[str] = 'ndcg'
+"""Official metric used in TGB node prediction task.
+"""

--- a/tgm/constants.py
+++ b/tgm/constants.py
@@ -1,4 +1,4 @@
-from typing import Final
+from typing import Final, List
 
 PADDED_NODE_ID: Final[int] = -1
 """Sentinel node ID used to mark invalid or padded neighbors in a graph.
@@ -9,16 +9,11 @@ Notes:
 """
 
 RECIPE_TGB_LINK_PRED: Final[str] = 'TGB_LINKPROPPRED_SETTING'
-"""A name to indicate recipe used for TGBlink property prediction
-
-Notes:
-    - A tgm.exceptions.UnsupportRecipe will be thrown if user build recipe
-    from unsupported recipe
-
+"""Recipe identifier for TGB link property prediction task.
 """
 
-SUPPORT_RECIPES: Final[list] = [RECIPE_TGB_LINK_PRED]
-"""A list of supported recipes can be built from HookManager
+SUPPORTED_RECIPES: Final[List[str]] = [RECIPE_TGB_LINK_PRED]
+"""A list of supported recipes that can be built from HookManager.
 
 Notes:
     - A tgm.exceptions.UnsupportRecipe will be thrown if user build recipe
@@ -26,5 +21,5 @@ Notes:
 """
 
 METRIC_TGB_LINKPROPPRED: Final[str] = 'mrr'
-"""Official metric used in TGB link prediction task
+"""Official metric used in TGB link prediction task.
 """

--- a/tgm/constants.py
+++ b/tgm/constants.py
@@ -1,4 +1,4 @@
-from typing import Final, List
+from typing import Final
 
 PADDED_NODE_ID: Final[int] = -1
 """Sentinel node ID used to mark invalid or padded neighbors in a graph.
@@ -8,16 +8,8 @@ Notes:
     appears as an ID in edge or node event tensors will constructing DGData.
 """
 
-RECIPE_TGB_LINK_PRED: Final[str] = 'TGB_LINKPROPPRED_SETTING'
+RECIPE_TGB_LINK_PRED: Final[str] = 'TGB_LINK_PROPERTY_PREDICTION'
 """Recipe identifier for TGB link property prediction task.
-"""
-
-SUPPORTED_RECIPES: Final[List[str]] = [RECIPE_TGB_LINK_PRED]
-"""A list of supported recipes that can be built from HookManager.
-
-Notes:
-    - A tgm.exceptions.UnsupportRecipe will be thrown if user build recipe
-    from unsupported recipe
 """
 
 METRIC_TGB_LINKPROPPRED: Final[str] = 'mrr'

--- a/tgm/exceptions.py
+++ b/tgm/exceptions.py
@@ -35,5 +35,5 @@ class EmptyBatchError(TGMError):
     """Raised during time-based iteration when a batch interval contains no events."""
 
 
-class UnsupportedRecipe(TGMError):
-    """Raised when attempting to construct a recipe that is not supported."""
+class UndefinedRecipe(TGMError):
+    """Raised when attempting to construct a recipe that is not defined/registered."""

--- a/tgm/exceptions.py
+++ b/tgm/exceptions.py
@@ -33,3 +33,7 @@ class InvalidDiscretizationError(TGMError):
 
 class EmptyBatchError(TGMError):
     """Raised during time-based iteration when a batch interval contains no events."""
+
+
+class UnsupportRecipe(TGMError):
+    """Raised when attempting to construct a recipe that is not supported."""

--- a/tgm/exceptions.py
+++ b/tgm/exceptions.py
@@ -35,5 +35,5 @@ class EmptyBatchError(TGMError):
     """Raised during time-based iteration when a batch interval contains no events."""
 
 
-class UnsupportRecipe(TGMError):
+class UnsupportedRecipe(TGMError):
     """Raised when attempting to construct a recipe that is not supported."""

--- a/tgm/hooks/hook_manager.py
+++ b/tgm/hooks/hook_manager.py
@@ -10,7 +10,7 @@ from tgm import DGBatch, DGraph
 from tgm.exceptions import (
     BadHookProtocolError,
     UnresolvableHookDependenciesError,
-    UnsupportRecipe,
+    UnsupportedRecipe,
 )
 from tgm.hooks import (
     DGHook,
@@ -18,7 +18,7 @@ from tgm.hooks import (
     TGBNegativeEdgeSamplerHook,
 )
 
-from ..constants import RECIPE_TGB_LINK_PRED, SUPPORT_RECIPES
+from ..constants import RECIPE_TGB_LINK_PRED, SUPPORTED_RECIPES
 
 
 class HookManager:
@@ -232,9 +232,9 @@ class HookManager:
         Returns:
             HookManager, Registered Keys (HookManager,List[str])
         """
-        if recipe not in SUPPORT_RECIPES:
-            raise UnsupportRecipe(
-                f'Recipe {recipe} is not supported. Please choose recipe from {SUPPORT_RECIPES}'
+        if recipe not in SUPPORTED_RECIPES:
+            raise UnsupportedRecipe(
+                f'Recipe {recipe} is not supported. Please choose recipe from {SUPPORTED_RECIPES}'
             )
 
         # @TODO: well, we violated Open-close principle here. May be better design?
@@ -259,8 +259,8 @@ class HookManager:
             )
             return hm, register_keys
         else:
-            raise UnsupportRecipe(
-                f'Recipe {recipe} is not supported. Please choose recipe from {SUPPORT_RECIPES}'
+            raise UnsupportedRecipe(
+                f'Recipe {recipe} is not supported. Please choose recipe from {SUPPORTED_RECIPES}'
             )
 
     @staticmethod

--- a/tgm/hooks/hook_manager.py
+++ b/tgm/hooks/hook_manager.py
@@ -38,6 +38,11 @@ class HookManager:
         self._key_to_hooks: Dict[str, List[DGHook]] = {k: [] for k in keys}
         self._shared_hooks: List[DGHook] = []
         self._active_key: str | None = None
+        self._registered_key = keys
+
+    @property
+    def keys(self) -> List:
+        return self._registered_key
 
     def __str__(self) -> str:
         def _stringify_hook(h: DGHook) -> str:

--- a/tgm/hooks/hook_manager.py
+++ b/tgm/hooks/hook_manager.py
@@ -2,23 +2,14 @@ from __future__ import annotations
 
 from collections import defaultdict, deque
 from contextlib import contextmanager
-from typing import Any, Dict, Iterator, List, Tuple
-
-from tgb.linkproppred.dataset_pyg import PyGLinkPropPredDataset
+from typing import Any, Dict, Iterator, List
 
 from tgm import DGBatch, DGraph
 from tgm.exceptions import (
     BadHookProtocolError,
     UnresolvableHookDependenciesError,
-    UnsupportedRecipe,
 )
-from tgm.hooks import (
-    DGHook,
-    NegativeEdgeSamplerHook,
-    TGBNegativeEdgeSamplerHook,
-)
-
-from ..constants import RECIPE_TGB_LINK_PRED, SUPPORTED_RECIPES
+from tgm.hooks import DGHook
 
 
 class HookManager:
@@ -210,58 +201,6 @@ class HookManager:
     def _ensure_valid_key(self, key: str) -> None:
         if key not in self._key_to_hooks:
             raise KeyError(f'{key} was not a declared key in the hook manager')
-
-    @classmethod
-    def build_recipe(
-        cls,
-        recipe: str,
-        dataset_name: str,
-        train_dg: DGraph,
-        val_dg: DGraph,
-        test_dg: DGraph,
-    ) -> Tuple[HookManager, List[str]]:
-        f"""Build Hook Manager with pre-define config.
-
-        Args:
-            recipe (str): Name of the desired recipe
-            dataset_name (str): Name of the dataset
-            train_dg (DGraph): Train DGraph
-            val_dg (DGraph): Validation DGraph
-            test_dg (DGraph): Test DGraph
-
-        Returns:
-            HookManager, Registered Keys (HookManager,List[str])
-        """
-        if recipe not in SUPPORTED_RECIPES:
-            raise UnsupportedRecipe(
-                f'Recipe {recipe} is not supported. Please choose recipe from {SUPPORTED_RECIPES}'
-            )
-
-        # @TODO: well, we violated Open-close principle here. May be better design?
-        if recipe == RECIPE_TGB_LINK_PRED:
-            dataset = PyGLinkPropPredDataset(name=dataset_name, root='datasets')
-            dataset.load_val_ns()
-            dataset.load_test_ns()
-            _, dst, _ = train_dg.edges
-            neg_sampler = dataset.negative_sampler
-            register_keys = ['train', 'val', 'test']
-
-            hm = HookManager(keys=register_keys)
-            hm.register(
-                'train',
-                NegativeEdgeSamplerHook(low=int(dst.min()), high=int(dst.max())),
-            )
-            hm.register(
-                'val', TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='val')
-            )
-            hm.register(
-                'test', TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='test')
-            )
-            return hm, register_keys
-        else:
-            raise UnsupportedRecipe(
-                f'Recipe {recipe} is not supported. Please choose recipe from {SUPPORTED_RECIPES}'
-            )
 
     @staticmethod
     def _topological_sort_hooks(hooks: List[DGHook]) -> List[DGHook]:

--- a/tgm/recipe.py
+++ b/tgm/recipe.py
@@ -1,0 +1,65 @@
+from typing import Any, Callable, Dict, List, Tuple
+
+from tgb.linkproppred.dataset_pyg import PyGLinkPropPredDataset
+
+from tgm import DGraph
+from tgm.constants import RECIPE_TGB_LINK_PRED
+from tgm.exceptions import UndefinedRecipe
+from tgm.hooks import (
+    HookManager,
+    NegativeEdgeSamplerHook,
+    TGBNegativeEdgeSamplerHook,
+)
+
+
+class RecipeRegistry:
+    """Registry recipe for managing all pre-defined recipe in the form of Callable object.
+
+    This class allows you to register your custom recipes perform frequently-used pre-experiment setup used.
+    One common frequently-used pre-experiment setup is set up HookManager for TGB linkpropred, which is provided by TGM team.
+    Users are welcome to define their own recipe. User-defined recipe need to be registered with `RecipeRegistry` to be able to build.
+    Please see tutorial for further information
+
+    Args:
+    Raises:
+        UndefinedRecipe: If build is call on recipe that is not defined or registered.
+    """
+
+    _recipes: Dict[str, Callable] = {}
+
+    @classmethod
+    def register(cls, name: str) -> Callable:
+        def decorator(func: Callable) -> Callable:
+            cls._recipes[name] = func
+            return func
+
+        return decorator
+
+    @classmethod
+    def build(cls, name: str, **kwargs) -> Any:  # type: ignore
+        if name not in cls._recipes:
+            raise UndefinedRecipe(
+                f'Undefined or not yet registered recipe: {name}. Please select from {cls._recipes}'
+            )
+        return cls._recipes[name](**kwargs)
+
+
+@RecipeRegistry.register(RECIPE_TGB_LINK_PRED)
+def build_tgb_link_pred(
+    dataset_name: str, train_dg: DGraph
+) -> Tuple[HookManager, List[str]]:
+    """Build ready-to-use HookManager with default hooks for TGB linkproppred task."""
+    dataset = PyGLinkPropPredDataset(name=dataset_name, root='datasets')
+    dataset.load_val_ns()
+    dataset.load_test_ns()
+    _, dst, _ = train_dg.edges
+    neg_sampler = dataset.negative_sampler
+
+    hm = HookManager(keys=['train', 'val', 'test'])
+    hm.register(
+        'train', NegativeEdgeSamplerHook(low=int(dst.min()), high=int(dst.max()))
+    )
+    hm.register('val', TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='val'))
+    hm.register('test', TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='test'))
+
+    return hm, ['train', 'val', 'test']

--- a/tgm/recipe.py
+++ b/tgm/recipe.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Tuple
+from typing import Any, Callable, Dict
 
 from tgb.linkproppred.dataset_pyg import PyGLinkPropPredDataset
 
@@ -45,9 +45,7 @@ class RecipeRegistry:
 
 
 @RecipeRegistry.register(RECIPE_TGB_LINK_PRED)
-def build_tgb_link_pred(
-    dataset_name: str, train_dg: DGraph
-) -> Tuple[HookManager, List[str]]:
+def build_tgb_link_pred(dataset_name: str, train_dg: DGraph) -> HookManager:
     """Build ready-to-use HookManager with default hooks for TGB linkproppred task."""
     dataset = PyGLinkPropPredDataset(name=dataset_name, root='datasets')
     dataset.load_val_ns()
@@ -62,4 +60,4 @@ def build_tgb_link_pred(
     hm.register('val', TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='val'))
     hm.register('test', TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='test'))
 
-    return hm, ['train', 'val', 'test']
+    return hm

--- a/tgm/recipe.py
+++ b/tgm/recipe.py
@@ -46,7 +46,15 @@ class RecipeRegistry:
 
 @RecipeRegistry.register(RECIPE_TGB_LINK_PRED)
 def build_tgb_link_pred(dataset_name: str, train_dg: DGraph) -> HookManager:
-    """Build ready-to-use HookManager with default hooks for TGB linkproppred task."""
+    """Build ready-to-use HookManager with default hooks for TGB linkproppred task.
+    
+    Args:
+        dataset_name (str): The name of the TGB dataset (e.g. 'tgbl-wiki')
+        train_dg (DGraph): The training graph, used to setup the `NegativeEdgeSamplerHook` for training
+
+     Returns:
+        HookManager with registered keys: ['train', 'val', 'test']  
+     """
     dataset = PyGLinkPropPredDataset(name=dataset_name, root='datasets')
     dataset.load_val_ns()
     dataset.load_test_ns()

--- a/tgm/recipe.py
+++ b/tgm/recipe.py
@@ -1,7 +1,5 @@
 from typing import Any, Callable, Dict
 
-from tgb.linkproppred.dataset_pyg import PyGLinkPropPredDataset
-
 from tgm import DGraph
 from tgm.constants import RECIPE_TGB_LINK_PRED
 from tgm.exceptions import UndefinedRecipe
@@ -47,15 +45,22 @@ class RecipeRegistry:
 @RecipeRegistry.register(RECIPE_TGB_LINK_PRED)
 def build_tgb_link_pred(dataset_name: str, train_dg: DGraph) -> HookManager:
     """Build ready-to-use HookManager with default hooks for TGB linkproppred task.
-    
+
     Args:
         dataset_name (str): The name of the TGB dataset (e.g. 'tgbl-wiki')
         train_dg (DGraph): The training graph, used to setup the `NegativeEdgeSamplerHook` for training
 
-     Returns:
-        HookManager with registered keys: ['train', 'val', 'test']  
-     """
-    dataset = PyGLinkPropPredDataset(name=dataset_name, root='datasets')
+    Returns:
+        HookManager with registered keys: ['train', 'val', 'test']
+    """
+    try:
+        from tgb.linkproppred.dataset_pyg import PyGLinkPropPredDataset
+    except ImportError:
+        raise ImportError('TGB required to load TGB data, try `pip install py-tgb`')
+
+    dataset = PyGLinkPropPredDataset(
+        name=dataset_name, root='datasets'
+    )  # @TODO: Suppress TGB print statement
     dataset.load_val_ns()
     dataset.load_test_ns()
     _, dst, _ = train_dg.edges


### PR DESCRIPTION
### Objectives

Add build recipe feature for HookManager. This allows users to create `HookManagers` with required hooks for widely used settings (such as TGB linkpropred) by one line of code.

For `linkproppred`, instead of doing:
```python
dataset = PyGLinkPropPredDataset(name=dataset_name, root='datasets')
dataset.load_val_ns()
dataset.load_test_ns()
_, dst, _ = train_dg.edges
neg_sampler = dataset.negative_sampler

hm = HookManager(keys=['train', 'val', 'test'])
hm.register(
  'train', NegativeEdgeSamplerHook(low=int(dst.min()), high=int(dst.max()))
)
hm.register('val', TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='val'))
hm.register('test', TGBNegativeEdgeSamplerHook(neg_sampler, split_mode='test'))
```

Users now only need to
```python
hm = RecipeRegistry.build(
    RECIPE_TGB_LINK_PRED, dataset_name=args.dataset, train_dg=train_dg
)
```

Evaluation metrics can be retrieved from `tgm.constants`

*Related:* #78 


