### PR TITLE
moving deep copy outside of loop

### DIFF
--- a/examples/linkproppred/dygformer.py
+++ b/examples/linkproppred/dygformer.py
@@ -203,9 +203,8 @@ def eval(
     model.eval()
     perf_list = []
     for batch in tqdm(loader):
+        copy_batch = copy.deepcopy(batch)
         for idx, neg_batch in enumerate(batch.neg_batch_list):
-            copy_batch = copy.deepcopy(batch)
-
             copy_batch.src = batch.src[idx].unsqueeze(0)
             copy_batch.dst = batch.dst[idx].unsqueeze(0)
             copy_batch.time = batch.time[idx].unsqueeze(0)

--- a/examples/linkproppred/tpnet.py
+++ b/examples/linkproppred/tpnet.py
@@ -213,9 +213,8 @@ def eval(
     model.eval()
     perf_list = []
     for batch in tqdm(loader):
+        copy_batch = copy.deepcopy(batch)
         for idx, neg_batch in enumerate(batch.neg_batch_list):
-            copy_batch = copy.deepcopy(batch)
-
             copy_batch.src = batch.src[idx].unsqueeze(0)
             copy_batch.dst = batch.dst[idx].unsqueeze(0)
             copy_batch.time = batch.time[idx].unsqueeze(0)


### PR DESCRIPTION
### Summary / Description

Move the deepcopy out of the neg_batch loop and just make a single deepcopy for each batch.


#### Type of Change
- [x] Refactoring

#### Test Evidence

Tested in my research code, speed up from around 2-3 hours to 1 hour consistently now with TPNet. 

#### Questions / Discussion Points

This shouldn't break anything but good to have another pair of eyes. 
