### PR TITLE
DType Management

### DIFF
--- a/test/unit/test_data.py
+++ b/test/unit/test_data.py
@@ -176,6 +176,26 @@ def test_init_dg_data_bad_args_invalid_node_id():
         )
 
 
+def test_init_dg_data_node_id_with_downcast_warning():
+    assert False
+
+
+def test_init_dg_data_timestamp_with_downcast_warning():
+    assert False
+
+
+def test_init_dg_data_invalid_node_id_with_id_overflow():
+    assert False
+
+
+def test_init_dg_data_invalid_time_overflow():
+    assert False
+
+
+def test_init_dg_data_number_of_events_overflow():
+    assert False
+
+
 def test_init_dg_data_bad_args_empty_graph():
     # Empty graph not supported
     with pytest.raises(EmptyGraphError):
@@ -911,6 +931,10 @@ def test_discretize_no_op():
     data = DGData.from_raw(edge_timestamps, edge_index, time_delta='s')
     coarse_data = data.discretize('s')
     assert id(data) != id(coarse_data)  # No Shared memory
+
+
+def test_discretize_with_huge_ids_no_overflow():
+    assert False
 
 
 def test_discretize_bad_args():

--- a/test/unit/test_data.py
+++ b/test/unit/test_data.py
@@ -176,6 +176,46 @@ def test_init_dg_data_bad_args_invalid_node_id():
         )
 
 
+def test_init_dg_data_with_nan_feats():
+    edge_index = torch.IntTensor([[0, 0]])
+    edge_timestamps = torch.LongTensor([1])
+    node_ids = torch.IntTensor([0])
+    node_timestamps = torch.LongTensor([2])
+
+    edge_feats = torch.rand((1, 1)).float()
+    edge_feats[0][0] = torch.nan
+
+    with pytest.raises(ValueError):
+        DGData.from_raw(
+            edge_timestamps,
+            edge_index,
+            node_ids=node_ids,
+            node_timestamps=node_timestamps,
+            edge_feats=edge_feats,
+        )
+
+    node_feats = torch.rand((1, 1)).float()
+    node_feats[0][0] = torch.nan
+
+    with pytest.raises(ValueError):
+        DGData.from_raw(
+            edge_timestamps,
+            edge_index,
+            node_ids=node_ids,
+            node_timestamps=node_timestamps,
+            dynamic_node_feats=node_feats,
+        )
+
+    with pytest.raises(ValueError):
+        DGData.from_raw(
+            edge_timestamps,
+            edge_index,
+            node_ids=node_ids,
+            node_timestamps=node_timestamps,
+            static_node_feats=node_feats,
+        )
+
+
 def test_init_dg_data_with_downcast_warning():
     edge_index = torch.IntTensor([[0, 1]])
     edge_timestamps = torch.LongTensor([1])

--- a/test/unit/test_data.py
+++ b/test/unit/test_data.py
@@ -176,22 +176,42 @@ def test_init_dg_data_bad_args_invalid_node_id():
         )
 
 
+@pytest.mark.skip('TODO')
 def test_init_dg_data_node_id_with_downcast_warning():
     assert False
 
 
+@pytest.mark.skip('TODO')
 def test_init_dg_data_timestamp_with_downcast_warning():
     assert False
 
 
+@pytest.mark.skip('TODO')
+def test_init_dg_data_edge_feats_with_downcast_warning():
+    assert False
+
+
+@pytest.mark.skip('TODO')
+def test_init_dg_data_dynamic_node_feats_with_downcast_warning():
+    assert False
+
+
+@pytest.mark.skip('TODO')
+def test_init_dg_data_static_node_feats_with_downcast_warning():
+    assert False
+
+
+@pytest.mark.skip('TODO')
 def test_init_dg_data_invalid_node_id_with_id_overflow():
     assert False
 
 
+@pytest.mark.skip('TODO')
 def test_init_dg_data_invalid_time_overflow():
     assert False
 
 
+@pytest.mark.skip('TODO')
 def test_init_dg_data_number_of_events_overflow():
     assert False
 
@@ -216,7 +236,7 @@ def test_init_dg_data_bad_args_bad_timestamps():
 
 
 def test_init_dg_data_bad_args_bad_edge_index():
-    edge_timestamps = torch.IntTensor([-1, 5])
+    edge_timestamps = torch.IntTensor([1, 5])
     with pytest.raises(TypeError):
         _ = DGData.from_raw(edge_timestamps, 'foo')
 
@@ -226,7 +246,7 @@ def test_init_dg_data_bad_args_bad_edge_index():
 
 def test_init_dg_data_bad_args_bad_edge_feats():
     edge_index = torch.IntTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.IntTensor([-1, 5])
+    edge_timestamps = torch.IntTensor([1, 5])
     with pytest.raises(TypeError):
         _ = DGData.from_raw(edge_timestamps, edge_index, 'foo')
 
@@ -608,6 +628,7 @@ def test_from_pandas_with_edge_features():
         'edge_features': [torch.rand(5).tolist(), torch.rand(5).tolist()],
     }
     events_df = pd.DataFrame(events_dict)
+    events_df[['src', 'dst', 't']] = events_df[['src', 'dst', 't']].astype('int32')
 
     data = DGData.from_pandas(
         events_df,
@@ -631,14 +652,19 @@ def test_from_pandas_with_node_events():
         'dst': [3, 20],
         't': [1337, 1338],
     }
+    edge_df = pd.DataFrame(edge_dict)
+    edge_df[['src', 'dst', 't']] = edge_df[['src', 'dst', 't']].astype('int32')
+
     node_dict = {'node': [7, 8], 't': [3, 6]}
+    node_df = pd.DataFrame(node_dict)
+    node_df[['node', 't']] = node_df[['node', 't']].astype('int32')
 
     data = DGData.from_pandas(
-        edge_df=pd.DataFrame(edge_dict),
+        edge_df=edge_df,
         edge_src_col='src',
         edge_dst_col='dst',
         edge_time_col='t',
-        node_df=pd.DataFrame(node_dict),
+        node_df=node_df,
         node_id_col='node',
         node_time_col='t',
     )
@@ -657,12 +683,16 @@ def test_from_pandas_with_node_features():
         't': [1337, 1338],
     }
     edge_df = pd.DataFrame(edge_dict)
+    edge_df[['src', 'dst', 't']] = edge_df[['src', 'dst', 't']].astype('int32')
+
     node_dict = {
         'node': [7, 8],
         't': [3, 6],
         'node_features': [torch.rand(5).tolist(), torch.rand(5).tolist()],
     }
     node_df = pd.DataFrame(node_dict)
+    node_df[['node', 't']] = node_df[['node', 't']].astype('int32')
+    # node_df['node_features'] = node_df['node_features'].astype('float32')
 
     data = DGData.from_pandas(
         edge_df=edge_df,
@@ -765,7 +795,7 @@ def test_from_tgbl(mock_dataset_cls, tgb_dataset_factory, with_node_feats):
 
     if with_node_feats:
         torch.testing.assert_close(
-            data.static_node_feats, torch.Tensor(dataset.node_feat).double()
+            data.static_node_feats, torch.Tensor(dataset.node_feat)
         )
     else:
         assert data.static_node_feats is None
@@ -933,6 +963,7 @@ def test_discretize_no_op():
     assert id(data) != id(coarse_data)  # No Shared memory
 
 
+@pytest.mark.skip('TODO')
 def test_discretize_with_huge_ids_no_overflow():
     assert False
 

--- a/test/unit/test_data.py
+++ b/test/unit/test_data.py
@@ -21,12 +21,12 @@ from tgm.timedelta import TimeDeltaDG
 
 
 def test_init_dg_data():
-    edge_index = torch.LongTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.LongTensor([1, 5])
+    edge_index = torch.IntTensor([[2, 3], [10, 20]])
+    edge_timestamps = torch.IntTensor([1, 5])
     data = DGData.from_raw(edge_timestamps, edge_index)
     torch.testing.assert_close(data.edge_index, edge_index)
     torch.testing.assert_close(data.timestamps, edge_timestamps)
-    torch.testing.assert_close(data.edge_event_idx, torch.LongTensor([0, 1]))
+    torch.testing.assert_close(data.edge_event_idx, torch.IntTensor([0, 1]))
     assert data.edge_feats is None
     assert data.node_event_idx is None
     assert data.node_ids is None
@@ -36,28 +36,28 @@ def test_init_dg_data():
 
 
 def test_init_dg_data_with_time_delta():
-    edge_index = torch.LongTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.LongTensor([1, 5])
+    edge_index = torch.IntTensor([[2, 3], [10, 20]])
+    edge_timestamps = torch.IntTensor([1, 5])
     data = DGData.from_raw(edge_timestamps, edge_index, time_delta=TimeDeltaDG('s'))
     assert data.time_delta == TimeDeltaDG('s')
 
 
 def test_init_dg_data_with_string_time_delta():
-    edge_index = torch.LongTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.LongTensor([1, 5])
+    edge_index = torch.IntTensor([[2, 3], [10, 20]])
+    edge_timestamps = torch.IntTensor([1, 5])
     data = DGData.from_raw(edge_timestamps, edge_index, time_delta='s')
     assert data.time_delta == TimeDeltaDG('s')
 
 
 def test_init_dg_data_no_node_events_with_edge_features():
-    edge_index = torch.LongTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.LongTensor([1, 5])
+    edge_index = torch.IntTensor([[2, 3], [10, 20]])
+    edge_timestamps = torch.IntTensor([1, 5])
     edge_feats = torch.rand(2, 5)
     data = DGData.from_raw(edge_timestamps, edge_index, edge_feats)
     torch.testing.assert_close(data.edge_index, edge_index)
     torch.testing.assert_close(data.timestamps, edge_timestamps)
     torch.testing.assert_close(data.edge_feats, edge_feats)
-    torch.testing.assert_close(data.edge_event_idx, torch.LongTensor([0, 1]))
+    torch.testing.assert_close(data.edge_event_idx, torch.IntTensor([0, 1]))
     assert data.node_event_idx is None
     assert data.node_ids is None
     assert data.dynamic_node_feats is None
@@ -66,19 +66,19 @@ def test_init_dg_data_no_node_events_with_edge_features():
 
 
 def test_init_dg_data_node_events():
-    edge_index = torch.LongTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.LongTensor([1, 5])
+    edge_index = torch.IntTensor([[2, 3], [10, 20]])
+    edge_timestamps = torch.IntTensor([1, 5])
     edge_feats = torch.rand(2, 5)
-    node_ids = torch.LongTensor([1, 2, 3])
-    node_timestamps = torch.LongTensor([6, 7, 8])
+    node_ids = torch.IntTensor([1, 2, 3])
+    node_timestamps = torch.IntTensor([6, 7, 8])
     data = DGData.from_raw(
         edge_timestamps, edge_index, edge_feats, node_timestamps, node_ids
     )
     torch.testing.assert_close(data.edge_index, edge_index)
-    torch.testing.assert_close(data.timestamps, torch.LongTensor([1, 5, 6, 7, 8]))
+    torch.testing.assert_close(data.timestamps, torch.IntTensor([1, 5, 6, 7, 8]))
     torch.testing.assert_close(data.edge_feats, edge_feats)
-    torch.testing.assert_close(data.edge_event_idx, torch.LongTensor([0, 1]))
-    torch.testing.assert_close(data.node_event_idx, torch.LongTensor([2, 3, 4]))
+    torch.testing.assert_close(data.edge_event_idx, torch.IntTensor([0, 1]))
+    torch.testing.assert_close(data.node_event_idx, torch.IntTensor([2, 3, 4]))
     torch.testing.assert_close(data.node_ids, node_ids)
     assert data.dynamic_node_feats is None
     assert data.static_node_feats is None
@@ -86,11 +86,11 @@ def test_init_dg_data_node_events():
 
 
 def test_init_dg_data_node_events_and_node_features():
-    edge_index = torch.LongTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.LongTensor([1, 5])
+    edge_index = torch.IntTensor([[2, 3], [10, 20]])
+    edge_timestamps = torch.IntTensor([1, 5])
     edge_feats = torch.rand(2, 5)
-    node_ids = torch.LongTensor([1, 2, 3])
-    node_timestamps = torch.LongTensor([6, 7, 8])
+    node_ids = torch.IntTensor([1, 2, 3])
+    node_timestamps = torch.IntTensor([6, 7, 8])
     dynamic_node_feats = torch.rand(3, 7)
     static_node_feats = torch.rand(21, 11)
     data = DGData.from_raw(
@@ -103,10 +103,10 @@ def test_init_dg_data_node_events_and_node_features():
         static_node_feats,
     )
     torch.testing.assert_close(data.edge_index, edge_index)
-    torch.testing.assert_close(data.timestamps, torch.LongTensor([1, 5, 6, 7, 8]))
+    torch.testing.assert_close(data.timestamps, torch.IntTensor([1, 5, 6, 7, 8]))
     torch.testing.assert_close(data.edge_feats, edge_feats)
-    torch.testing.assert_close(data.edge_event_idx, torch.LongTensor([0, 1]))
-    torch.testing.assert_close(data.node_event_idx, torch.LongTensor([2, 3, 4]))
+    torch.testing.assert_close(data.edge_event_idx, torch.IntTensor([0, 1]))
+    torch.testing.assert_close(data.node_event_idx, torch.IntTensor([2, 3, 4]))
     torch.testing.assert_close(data.node_ids, node_ids)
     torch.testing.assert_close(data.dynamic_node_feats, dynamic_node_feats)
     torch.testing.assert_close(data.static_node_feats, static_node_feats)
@@ -114,11 +114,11 @@ def test_init_dg_data_node_events_and_node_features():
 
 
 def test_init_dg_data_sort_required():
-    edge_index = torch.LongTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.LongTensor([5, 1])
+    edge_index = torch.IntTensor([[2, 3], [10, 20]])
+    edge_timestamps = torch.IntTensor([5, 1])
     edge_feats = torch.rand(2, 5)
-    node_ids = torch.LongTensor([1, 2, 3])
-    node_timestamps = torch.LongTensor([8, 7, 6])
+    node_ids = torch.IntTensor([1, 2, 3])
+    node_timestamps = torch.IntTensor([8, 7, 6])
     dynamic_node_feats = torch.rand(3, 7)
     static_node_feats = torch.rand(21, 11)
     data = DGData.from_raw(
@@ -131,8 +131,8 @@ def test_init_dg_data_sort_required():
         static_node_feats,
     )
 
-    exp_edge_index = torch.LongTensor([[10, 20], [2, 3]])
-    exp_node_ids = torch.LongTensor([3, 2, 1])
+    exp_edge_index = torch.IntTensor([[10, 20], [2, 3]])
+    exp_node_ids = torch.IntTensor([3, 2, 1])
     exp_edge_feats = torch.Tensor([edge_feats[1].tolist(), edge_feats[0].tolist()])
     exp_dynamic_node_feats = torch.Tensor(
         [
@@ -142,12 +142,12 @@ def test_init_dg_data_sort_required():
         ]
     )
     torch.testing.assert_close(data.edge_index, exp_edge_index)
-    torch.testing.assert_close(data.timestamps, torch.LongTensor([1, 5, 6, 7, 8]))
+    torch.testing.assert_close(data.timestamps, torch.IntTensor([1, 5, 6, 7, 8]))
     torch.testing.assert_close(data.edge_feats, exp_edge_feats)
-    torch.testing.assert_close(data.edge_event_idx, torch.LongTensor([1, 0]))
+    torch.testing.assert_close(data.edge_event_idx, torch.IntTensor([1, 0]))
     torch.testing.assert_close(
         data.node_event_idx,
-        torch.LongTensor(
+        torch.IntTensor(
             [4, 3, 2],
         ),
     )
@@ -158,15 +158,15 @@ def test_init_dg_data_sort_required():
 
 
 def test_init_dg_data_bad_args_invalid_node_id():
-    edge_index = torch.LongTensor([[PADDED_NODE_ID, 3], [10, 20]])
-    edge_timestamps = torch.LongTensor([1, 5])
+    edge_index = torch.IntTensor([[PADDED_NODE_ID, 3], [10, 20]])
+    edge_timestamps = torch.IntTensor([1, 5])
     with pytest.raises(InvalidNodeIDError):
         _ = DGData.from_raw(edge_timestamps, edge_index)
 
-    edge_index = torch.LongTensor([[1, 3], [10, 20]])
-    edge_timestamps = torch.LongTensor([1, 5])
-    node_ids = torch.LongTensor([PADDED_NODE_ID])
-    node_timestamps = torch.LongTensor([1])
+    edge_index = torch.IntTensor([[1, 3], [10, 20]])
+    edge_timestamps = torch.IntTensor([1, 5])
+    node_ids = torch.IntTensor([PADDED_NODE_ID])
+    node_timestamps = torch.IntTensor([1])
     with pytest.raises(InvalidNodeIDError):
         _ = DGData.from_raw(
             edge_timestamps,
@@ -186,27 +186,27 @@ def test_init_dg_data_bad_args_empty_graph():
 
 def test_init_dg_data_bad_args_bad_timestamps():
     # Negative timestamps not supported
-    edge_index = torch.LongTensor([[2, 3], [10, 20]])
+    edge_index = torch.IntTensor([[2, 3], [10, 20]])
     with pytest.raises(ValueError):
-        _ = DGData.from_raw(torch.LongTensor([-1, 5]), edge_index)
+        _ = DGData.from_raw(torch.IntTensor([-1, 5]), edge_index)
 
-    edge_index = torch.LongTensor([[2, 3], [10, 20]])
+    edge_index = torch.IntTensor([[2, 3], [10, 20]])
     with pytest.raises(TypeError):
         _ = DGData.from_raw('foo', edge_index)
 
 
 def test_init_dg_data_bad_args_bad_edge_index():
-    edge_timestamps = torch.LongTensor([-1, 5])
+    edge_timestamps = torch.IntTensor([-1, 5])
     with pytest.raises(TypeError):
         _ = DGData.from_raw(edge_timestamps, 'foo')
 
     with pytest.raises(ValueError):
-        _ = DGData.from_raw(edge_timestamps, torch.LongTensor([1, 2]))
+        _ = DGData.from_raw(edge_timestamps, torch.IntTensor([1, 2]))
 
 
 def test_init_dg_data_bad_args_bad_edge_feats():
-    edge_index = torch.LongTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.LongTensor([-1, 5])
+    edge_index = torch.IntTensor([[2, 3], [10, 20]])
+    edge_timestamps = torch.IntTensor([-1, 5])
     with pytest.raises(TypeError):
         _ = DGData.from_raw(edge_timestamps, edge_index, 'foo')
 
@@ -215,10 +215,10 @@ def test_init_dg_data_bad_args_bad_edge_feats():
 
 
 def test_init_dg_data_bad_args_bad_node_ids():
-    edge_index = torch.LongTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.LongTensor([1, 5])
+    edge_index = torch.IntTensor([[2, 3], [10, 20]])
+    edge_timestamps = torch.IntTensor([1, 5])
     edge_feats = torch.rand(2, 5)
-    node_timestamps = torch.LongTensor([6, 7, 8])
+    node_timestamps = torch.IntTensor([6, 7, 8])
 
     with pytest.raises(TypeError):
         _ = DGData.from_raw(
@@ -231,15 +231,15 @@ def test_init_dg_data_bad_args_bad_node_ids():
             edge_index,
             edge_feats,
             node_timestamps,
-            node_ids=torch.LongTensor([0]),
+            node_ids=torch.IntTensor([0]),
         )
 
 
 def test_init_dg_data_bad_args_non_integral_types():
-    edge_index = torch.LongTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.LongTensor([1, 5])
-    node_timestamps = torch.LongTensor([6, 7, 8])
-    node_ids = torch.LongTensor([0, 1, 0])
+    edge_index = torch.IntTensor([[2, 3], [10, 20]])
+    edge_timestamps = torch.IntTensor([1, 5])
+    node_timestamps = torch.IntTensor([6, 7, 8])
+    node_ids = torch.IntTensor([0, 1, 0])
 
     with pytest.raises(TypeError):
         _ = DGData.from_raw(
@@ -272,11 +272,11 @@ def test_init_dg_data_bad_args_non_integral_types():
 
 
 def test_init_dg_data_bad_args_bad_dynamic_node_feats():
-    edge_index = torch.LongTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.LongTensor([1, 5])
+    edge_index = torch.IntTensor([[2, 3], [10, 20]])
+    edge_timestamps = torch.IntTensor([1, 5])
     edge_feats = torch.rand(2, 5)
-    node_ids = torch.LongTensor([1, 2, 3])
-    node_timestamps = torch.LongTensor([6, 7, 8])
+    node_ids = torch.IntTensor([1, 2, 3])
+    node_timestamps = torch.IntTensor([6, 7, 8])
 
     with pytest.raises(TypeError):
         _ = DGData.from_raw(
@@ -300,10 +300,10 @@ def test_init_dg_data_bad_args_bad_dynamic_node_feats():
 
 def test_init_dg_data_bad_args_bad_static_node_feats():
     # Num nodes = 21
-    edge_index = torch.LongTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.LongTensor([1, 5])
-    node_ids = torch.LongTensor([1, 2, 3])
-    node_timestamps = torch.LongTensor([6, 7, 8])
+    edge_index = torch.IntTensor([[2, 3], [10, 20]])
+    edge_timestamps = torch.IntTensor([1, 5])
+    node_ids = torch.IntTensor([1, 2, 3])
+    node_timestamps = torch.IntTensor([6, 7, 8])
 
     with pytest.raises(TypeError):
         _ = DGData.from_raw(
@@ -322,8 +322,8 @@ def test_init_dg_data_bad_args_bad_static_node_feats():
         )
 
     # Num nodes = 21
-    edge_index = torch.LongTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.LongTensor([1, 5])
+    edge_index = torch.IntTensor([[2, 3], [10, 20]])
+    edge_timestamps = torch.IntTensor([1, 5])
 
     with pytest.raises(ValueError):
         _ = DGData.from_raw(
@@ -337,10 +337,10 @@ def test_init_dg_data_bad_args_bad_static_node_feats():
         )
 
     # Num nodes = 101
-    edge_index = torch.LongTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.LongTensor([1, 5])
-    node_ids = torch.LongTensor([1, 2, 100])
-    node_timestamps = torch.LongTensor([6, 7, 8])
+    edge_index = torch.IntTensor([[2, 3], [10, 20]])
+    edge_timestamps = torch.IntTensor([1, 5])
+    node_ids = torch.IntTensor([1, 2, 100])
+    node_timestamps = torch.IntTensor([6, 7, 8])
 
     with pytest.raises(ValueError):
         _ = DGData.from_raw(
@@ -355,8 +355,8 @@ def test_init_dg_data_bad_args_bad_static_node_feats():
 
 
 def test_from_csv_with_edge_features():
-    edge_index = torch.LongTensor([[2, 3], [10, 20]])
-    timestamps = torch.LongTensor([1, 5])
+    edge_index = torch.IntTensor([[2, 3], [10, 20]])
+    timestamps = torch.IntTensor([1, 5])
     edge_feats = torch.rand(2, 5)
     data = DGData.from_raw(
         edge_timestamps=timestamps, edge_index=edge_index, edge_feats=edge_feats
@@ -402,10 +402,10 @@ def test_from_csv_with_edge_features():
 
 
 def test_from_csv_with_node_events():
-    edge_index = torch.LongTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.LongTensor([1, 1])
-    node_ids = torch.LongTensor([7, 8])
-    node_timestamps = torch.LongTensor([3, 6])
+    edge_index = torch.IntTensor([[2, 3], [10, 20]])
+    edge_timestamps = torch.IntTensor([1, 1])
+    node_ids = torch.IntTensor([7, 8])
+    node_timestamps = torch.IntTensor([3, 6])
     data = DGData.from_raw(
         edge_timestamps=edge_timestamps,
         edge_index=edge_index,
@@ -474,10 +474,10 @@ def test_from_csv_with_node_events():
 
 
 def test_from_csv_with_node_features():
-    edge_index = torch.LongTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.LongTensor([1, 1])
-    node_ids = torch.LongTensor([7, 8])
-    node_timestamps = torch.LongTensor([3, 6])
+    edge_index = torch.IntTensor([[2, 3], [10, 20]])
+    edge_timestamps = torch.IntTensor([1, 1])
+    node_ids = torch.IntTensor([7, 8])
+    node_timestamps = torch.IntTensor([3, 6])
     dynamic_node_feats = torch.rand(2, 5)
     static_node_feats = torch.rand(21, 3)
 
@@ -806,8 +806,8 @@ def test_from_tgbn(mock_dataset_cls, tgb_dataset_factory):
 
 
 def test_discretize_reduce_op_first():
-    edge_index = torch.LongTensor([[1, 2], [1, 2], [2, 3], [1, 2], [4, 5]])
-    edge_timestamps = torch.LongTensor([1, 2, 3, 63, 65])
+    edge_index = torch.IntTensor([[1, 2], [1, 2], [2, 3], [1, 2], [4, 5]])
+    edge_timestamps = torch.IntTensor([1, 2, 3, 63, 65])
     edge_feats = torch.rand(5, 5)
     static_node_feats = torch.rand(6, 11)
     data = DGData.from_raw(
@@ -824,9 +824,9 @@ def test_discretize_reduce_op_first():
     assert data.time_delta == TimeDeltaDG('m')
     assert id(coarse_data) != id(data)
 
-    exp_timestamps = torch.LongTensor([0, 0, 1, 1])
-    exp_edge_event_idx = torch.LongTensor([0, 1, 2, 3])
-    exp_edge_index = torch.LongTensor([[1, 2], [2, 3], [1, 2], [4, 5]])
+    exp_timestamps = torch.IntTensor([0, 0, 1, 1])
+    exp_edge_event_idx = torch.IntTensor([0, 1, 2, 3])
+    exp_edge_index = torch.IntTensor([[1, 2], [2, 3], [1, 2], [4, 5]])
     exp_edge_feats = torch.stack(
         [edge_feats[0], edge_feats[2], edge_feats[3], edge_feats[4]]
     )
@@ -844,12 +844,12 @@ def test_discretize_reduce_op_first():
 
 
 def test_discretize_with_node_events_reduce_op_first():
-    edge_index = torch.LongTensor([[1, 2], [1, 2], [2, 3], [1, 2], [4, 5]])
-    edge_timestamps = torch.LongTensor([1, 2, 3, 63, 65])
+    edge_index = torch.IntTensor([[1, 2], [1, 2], [2, 3], [1, 2], [4, 5]])
+    edge_timestamps = torch.IntTensor([1, 2, 3, 63, 65])
     edge_feats = torch.rand(5, 5)
 
-    node_ids = torch.LongTensor([6, 6, 7, 6, 6, 7])
-    node_timestamps = torch.LongTensor([10, 20, 30, 70, 80, 90])
+    node_ids = torch.IntTensor([6, 6, 7, 6, 6, 7])
+    node_timestamps = torch.IntTensor([10, 20, 30, 70, 80, 90])
     dynamic_node_feats = torch.rand(6, 5)
     static_node_feats = torch.rand(8, 11)
     data = DGData.from_raw(
@@ -870,16 +870,16 @@ def test_discretize_with_node_events_reduce_op_first():
     assert data.time_delta == TimeDeltaDG('m')
     assert id(coarse_data) != id(data)
 
-    exp_timestamps = torch.LongTensor([0, 0, 0, 0, 1, 1, 1, 1])
-    exp_edge_event_idx = torch.LongTensor([0, 1, 4, 5])
-    exp_edge_index = torch.LongTensor([[1, 2], [2, 3], [1, 2], [4, 5]])
+    exp_timestamps = torch.IntTensor([0, 0, 0, 0, 1, 1, 1, 1])
+    exp_edge_event_idx = torch.IntTensor([0, 1, 4, 5])
+    exp_edge_index = torch.IntTensor([[1, 2], [2, 3], [1, 2], [4, 5]])
     exp_edge_feats = torch.stack(
         [edge_feats[0], edge_feats[2], edge_feats[3], edge_feats[4]]
     )
     exp_static_node_feats = static_node_feats
 
-    exp_node_event_idx = torch.LongTensor([2, 3, 6, 7])
-    exp_node_ids = torch.LongTensor([6, 7, 6, 7])
+    exp_node_event_idx = torch.IntTensor([2, 3, 6, 7])
+    exp_node_ids = torch.IntTensor([6, 7, 6, 7])
 
     exp_dynamic_node_feats = torch.stack(
         [
@@ -902,8 +902,8 @@ def test_discretize_with_node_events_reduce_op_first():
 
 
 def test_discretize_no_op():
-    edge_index = torch.LongTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.LongTensor([1, 5])
+    edge_index = torch.IntTensor([[2, 3], [10, 20]])
+    edge_timestamps = torch.IntTensor([1, 5])
     data = DGData.from_raw(edge_timestamps, edge_index)
     coarse_data = data.discretize('r')
     assert id(data) != id(coarse_data)  # No Shared memory
@@ -914,8 +914,8 @@ def test_discretize_no_op():
 
 
 def test_discretize_bad_args():
-    edge_index = torch.LongTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.LongTensor([1, 5])
+    edge_index = torch.IntTensor([[2, 3], [10, 20]])
+    edge_timestamps = torch.IntTensor([1, 5])
 
     with pytest.raises(EventOrderedConversionError):
         data = DGData.from_raw(edge_timestamps, edge_index, time_delta='r')
@@ -984,8 +984,8 @@ def test_split_cannot_override_tgb_split():
 
 
 def test_clone():
-    edge_index = torch.LongTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.LongTensor([1, 5])
+    edge_index = torch.IntTensor([[2, 3], [10, 20]])
+    edge_timestamps = torch.IntTensor([1, 5])
 
     dg1 = DGData.from_raw(edge_timestamps, edge_index)
     dg2 = dg1.clone()

--- a/test/unit/test_data.py
+++ b/test/unit/test_data.py
@@ -22,7 +22,7 @@ from tgm.timedelta import TimeDeltaDG
 
 def test_init_dg_data():
     edge_index = torch.IntTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.IntTensor([1, 5])
+    edge_timestamps = torch.LongTensor([1, 5])
     data = DGData.from_raw(edge_timestamps, edge_index)
     torch.testing.assert_close(data.edge_index, edge_index)
     torch.testing.assert_close(data.timestamps, edge_timestamps)
@@ -37,21 +37,21 @@ def test_init_dg_data():
 
 def test_init_dg_data_with_time_delta():
     edge_index = torch.IntTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.IntTensor([1, 5])
+    edge_timestamps = torch.LongTensor([1, 5])
     data = DGData.from_raw(edge_timestamps, edge_index, time_delta=TimeDeltaDG('s'))
     assert data.time_delta == TimeDeltaDG('s')
 
 
 def test_init_dg_data_with_string_time_delta():
     edge_index = torch.IntTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.IntTensor([1, 5])
+    edge_timestamps = torch.LongTensor([1, 5])
     data = DGData.from_raw(edge_timestamps, edge_index, time_delta='s')
     assert data.time_delta == TimeDeltaDG('s')
 
 
 def test_init_dg_data_no_node_events_with_edge_features():
     edge_index = torch.IntTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.IntTensor([1, 5])
+    edge_timestamps = torch.LongTensor([1, 5])
     edge_feats = torch.rand(2, 5)
     data = DGData.from_raw(edge_timestamps, edge_index, edge_feats)
     torch.testing.assert_close(data.edge_index, edge_index)
@@ -67,15 +67,15 @@ def test_init_dg_data_no_node_events_with_edge_features():
 
 def test_init_dg_data_node_events():
     edge_index = torch.IntTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.IntTensor([1, 5])
+    edge_timestamps = torch.LongTensor([1, 5])
     edge_feats = torch.rand(2, 5)
     node_ids = torch.IntTensor([1, 2, 3])
-    node_timestamps = torch.IntTensor([6, 7, 8])
+    node_timestamps = torch.LongTensor([6, 7, 8])
     data = DGData.from_raw(
         edge_timestamps, edge_index, edge_feats, node_timestamps, node_ids
     )
     torch.testing.assert_close(data.edge_index, edge_index)
-    torch.testing.assert_close(data.timestamps, torch.IntTensor([1, 5, 6, 7, 8]))
+    torch.testing.assert_close(data.timestamps, torch.LongTensor([1, 5, 6, 7, 8]))
     torch.testing.assert_close(data.edge_feats, edge_feats)
     torch.testing.assert_close(data.edge_event_idx, torch.IntTensor([0, 1]))
     torch.testing.assert_close(data.node_event_idx, torch.IntTensor([2, 3, 4]))
@@ -87,10 +87,10 @@ def test_init_dg_data_node_events():
 
 def test_init_dg_data_node_events_and_node_features():
     edge_index = torch.IntTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.IntTensor([1, 5])
+    edge_timestamps = torch.LongTensor([1, 5])
     edge_feats = torch.rand(2, 5)
     node_ids = torch.IntTensor([1, 2, 3])
-    node_timestamps = torch.IntTensor([6, 7, 8])
+    node_timestamps = torch.LongTensor([6, 7, 8])
     dynamic_node_feats = torch.rand(3, 7)
     static_node_feats = torch.rand(21, 11)
     data = DGData.from_raw(
@@ -103,7 +103,7 @@ def test_init_dg_data_node_events_and_node_features():
         static_node_feats,
     )
     torch.testing.assert_close(data.edge_index, edge_index)
-    torch.testing.assert_close(data.timestamps, torch.IntTensor([1, 5, 6, 7, 8]))
+    torch.testing.assert_close(data.timestamps, torch.LongTensor([1, 5, 6, 7, 8]))
     torch.testing.assert_close(data.edge_feats, edge_feats)
     torch.testing.assert_close(data.edge_event_idx, torch.IntTensor([0, 1]))
     torch.testing.assert_close(data.node_event_idx, torch.IntTensor([2, 3, 4]))
@@ -115,10 +115,10 @@ def test_init_dg_data_node_events_and_node_features():
 
 def test_init_dg_data_sort_required():
     edge_index = torch.IntTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.IntTensor([5, 1])
+    edge_timestamps = torch.LongTensor([5, 1])
     edge_feats = torch.rand(2, 5)
     node_ids = torch.IntTensor([1, 2, 3])
-    node_timestamps = torch.IntTensor([8, 7, 6])
+    node_timestamps = torch.LongTensor([8, 7, 6])
     dynamic_node_feats = torch.rand(3, 7)
     static_node_feats = torch.rand(21, 11)
     data = DGData.from_raw(
@@ -142,7 +142,7 @@ def test_init_dg_data_sort_required():
         ]
     )
     torch.testing.assert_close(data.edge_index, exp_edge_index)
-    torch.testing.assert_close(data.timestamps, torch.IntTensor([1, 5, 6, 7, 8]))
+    torch.testing.assert_close(data.timestamps, torch.LongTensor([1, 5, 6, 7, 8]))
     torch.testing.assert_close(data.edge_feats, exp_edge_feats)
     torch.testing.assert_close(data.edge_event_idx, torch.IntTensor([1, 0]))
     torch.testing.assert_close(
@@ -159,14 +159,14 @@ def test_init_dg_data_sort_required():
 
 def test_init_dg_data_bad_args_invalid_node_id():
     edge_index = torch.IntTensor([[PADDED_NODE_ID, 3], [10, 20]])
-    edge_timestamps = torch.IntTensor([1, 5])
+    edge_timestamps = torch.LongTensor([1, 5])
     with pytest.raises(InvalidNodeIDError):
         _ = DGData.from_raw(edge_timestamps, edge_index)
 
     edge_index = torch.IntTensor([[1, 3], [10, 20]])
-    edge_timestamps = torch.IntTensor([1, 5])
+    edge_timestamps = torch.LongTensor([1, 5])
     node_ids = torch.IntTensor([PADDED_NODE_ID])
-    node_timestamps = torch.IntTensor([1])
+    node_timestamps = torch.LongTensor([1])
     with pytest.raises(InvalidNodeIDError):
         _ = DGData.from_raw(
             edge_timestamps,
@@ -178,16 +178,14 @@ def test_init_dg_data_bad_args_invalid_node_id():
 
 def test_init_dg_data_with_downcast_warning():
     edge_index = torch.IntTensor([[0, 1]])
-    edge_timestamps = torch.IntTensor([1])
+    edge_timestamps = torch.LongTensor([1])
     node_ids = torch.IntTensor([2])
-    node_timestamps = torch.IntTensor([2])
+    node_timestamps = torch.LongTensor([2])
 
     # Fields to test for downcasting
     test_cases = {
-        'edge_timestamps': edge_timestamps.long(),
         'edge_index': edge_index.long(),
         'node_ids': node_ids.long(),
-        'node_timestamps': node_timestamps.long(),
         'edge_feats': torch.rand((len(edge_index), 1), dtype=torch.float64),
         'dynamic_node_feats': torch.rand((len(node_ids), 1), dtype=torch.float64),
         'static_node_feats': torch.rand((3, 1), dtype=torch.float64),
@@ -218,14 +216,14 @@ def test_init_dg_data_with_downcast_warning():
 def test_init_dg_data_invalid_node_id_with_id_overflow():
     max_int32 = torch.iinfo(torch.int32).max
 
-    edge_timestamps = torch.IntTensor([0])
+    edge_timestamps = torch.LongTensor([0])
     edge_index = torch.LongTensor([[0, max_int32 + 1]])
     with pytest.raises(InvalidNodeIDError):
         DGData.from_raw(edge_timestamps, edge_index)
 
-    edge_timestamps = torch.IntTensor([0])
+    edge_timestamps = torch.LongTensor([0])
     edge_index = torch.IntTensor([[0, 1]])
-    node_timestamps = torch.IntTensor([0])
+    node_timestamps = torch.LongTensor([0])
     node_ids = torch.LongTensor([max_int32 + 1])
     with pytest.raises(InvalidNodeIDError):
         DGData.from_raw(
@@ -244,7 +242,7 @@ def test_init_dg_data_invalid_time_overflow():
     with pytest.raises(ValueError):
         DGData.from_raw(edge_timestamps, edge_index)
 
-    edge_timestamps = torch.IntTensor([0])
+    edge_timestamps = torch.LongTensor([0])
     edge_index = torch.IntTensor([[0, 1]])
     node_timestamps = torch.LongTensor([max_int32 + 1])
     node_ids = torch.IntTensor([0])
@@ -277,7 +275,7 @@ def test_init_dg_data_bad_args_bad_timestamps():
 
 
 def test_init_dg_data_bad_args_bad_edge_index():
-    edge_timestamps = torch.IntTensor([1, 5])
+    edge_timestamps = torch.LongTensor([1, 5])
     with pytest.raises(TypeError):
         _ = DGData.from_raw(edge_timestamps, 'foo')
 
@@ -287,7 +285,7 @@ def test_init_dg_data_bad_args_bad_edge_index():
 
 def test_init_dg_data_bad_args_bad_edge_feats():
     edge_index = torch.IntTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.IntTensor([1, 5])
+    edge_timestamps = torch.LongTensor([1, 5])
     with pytest.raises(TypeError):
         _ = DGData.from_raw(edge_timestamps, edge_index, 'foo')
 
@@ -297,9 +295,9 @@ def test_init_dg_data_bad_args_bad_edge_feats():
 
 def test_init_dg_data_bad_args_bad_node_ids():
     edge_index = torch.IntTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.IntTensor([1, 5])
+    edge_timestamps = torch.LongTensor([1, 5])
     edge_feats = torch.rand(2, 5)
-    node_timestamps = torch.IntTensor([6, 7, 8])
+    node_timestamps = torch.LongTensor([6, 7, 8])
 
     with pytest.raises(TypeError):
         _ = DGData.from_raw(
@@ -318,8 +316,8 @@ def test_init_dg_data_bad_args_bad_node_ids():
 
 def test_init_dg_data_bad_args_non_integral_types():
     edge_index = torch.IntTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.IntTensor([1, 5])
-    node_timestamps = torch.IntTensor([6, 7, 8])
+    edge_timestamps = torch.LongTensor([1, 5])
+    node_timestamps = torch.LongTensor([6, 7, 8])
     node_ids = torch.IntTensor([0, 1, 0])
 
     with pytest.raises(TypeError):
@@ -354,10 +352,10 @@ def test_init_dg_data_bad_args_non_integral_types():
 
 def test_init_dg_data_bad_args_bad_dynamic_node_feats():
     edge_index = torch.IntTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.IntTensor([1, 5])
+    edge_timestamps = torch.LongTensor([1, 5])
     edge_feats = torch.rand(2, 5)
     node_ids = torch.IntTensor([1, 2, 3])
-    node_timestamps = torch.IntTensor([6, 7, 8])
+    node_timestamps = torch.LongTensor([6, 7, 8])
 
     with pytest.raises(TypeError):
         _ = DGData.from_raw(
@@ -382,9 +380,9 @@ def test_init_dg_data_bad_args_bad_dynamic_node_feats():
 def test_init_dg_data_bad_args_bad_static_node_feats():
     # Num nodes = 21
     edge_index = torch.IntTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.IntTensor([1, 5])
+    edge_timestamps = torch.LongTensor([1, 5])
     node_ids = torch.IntTensor([1, 2, 3])
-    node_timestamps = torch.IntTensor([6, 7, 8])
+    node_timestamps = torch.LongTensor([6, 7, 8])
 
     with pytest.raises(TypeError):
         _ = DGData.from_raw(
@@ -404,7 +402,7 @@ def test_init_dg_data_bad_args_bad_static_node_feats():
 
     # Num nodes = 21
     edge_index = torch.IntTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.IntTensor([1, 5])
+    edge_timestamps = torch.LongTensor([1, 5])
 
     with pytest.raises(ValueError):
         _ = DGData.from_raw(
@@ -419,9 +417,9 @@ def test_init_dg_data_bad_args_bad_static_node_feats():
 
     # Num nodes = 101
     edge_index = torch.IntTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.IntTensor([1, 5])
+    edge_timestamps = torch.LongTensor([1, 5])
     node_ids = torch.IntTensor([1, 2, 100])
-    node_timestamps = torch.IntTensor([6, 7, 8])
+    node_timestamps = torch.LongTensor([6, 7, 8])
 
     with pytest.raises(ValueError):
         _ = DGData.from_raw(
@@ -437,7 +435,7 @@ def test_init_dg_data_bad_args_bad_static_node_feats():
 
 def test_from_csv_with_edge_features():
     edge_index = torch.IntTensor([[2, 3], [10, 20]])
-    timestamps = torch.IntTensor([1, 5])
+    timestamps = torch.LongTensor([1, 5])
     edge_feats = torch.rand(2, 5)
     data = DGData.from_raw(
         edge_timestamps=timestamps, edge_index=edge_index, edge_feats=edge_feats
@@ -484,9 +482,9 @@ def test_from_csv_with_edge_features():
 
 def test_from_csv_with_node_events():
     edge_index = torch.IntTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.IntTensor([1, 1])
+    edge_timestamps = torch.LongTensor([1, 1])
     node_ids = torch.IntTensor([7, 8])
-    node_timestamps = torch.IntTensor([3, 6])
+    node_timestamps = torch.LongTensor([3, 6])
     data = DGData.from_raw(
         edge_timestamps=edge_timestamps,
         edge_index=edge_index,
@@ -556,9 +554,9 @@ def test_from_csv_with_node_events():
 
 def test_from_csv_with_node_features():
     edge_index = torch.IntTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.IntTensor([1, 1])
+    edge_timestamps = torch.LongTensor([1, 1])
     node_ids = torch.IntTensor([7, 8])
-    node_timestamps = torch.IntTensor([3, 6])
+    node_timestamps = torch.LongTensor([3, 6])
     dynamic_node_feats = torch.rand(2, 5)
     static_node_feats = torch.rand(21, 3)
 
@@ -897,7 +895,7 @@ def test_from_tgbn(mock_dataset_cls, tgb_dataset_factory):
 
 def test_discretize_reduce_op_first():
     edge_index = torch.IntTensor([[1, 2], [1, 2], [2, 3], [1, 2], [4, 5]])
-    edge_timestamps = torch.IntTensor([1, 2, 3, 63, 65])
+    edge_timestamps = torch.LongTensor([1, 2, 3, 63, 65])
     edge_feats = torch.rand(5, 5)
     static_node_feats = torch.rand(6, 11)
     data = DGData.from_raw(
@@ -914,7 +912,7 @@ def test_discretize_reduce_op_first():
     assert data.time_delta == TimeDeltaDG('m')
     assert id(coarse_data) != id(data)
 
-    exp_timestamps = torch.IntTensor([0, 0, 1, 1])
+    exp_timestamps = torch.LongTensor([0, 0, 1, 1])
     exp_edge_event_idx = torch.IntTensor([0, 1, 2, 3])
     exp_edge_index = torch.IntTensor([[1, 2], [2, 3], [1, 2], [4, 5]])
     exp_edge_feats = torch.stack(
@@ -935,11 +933,11 @@ def test_discretize_reduce_op_first():
 
 def test_discretize_with_node_events_reduce_op_first():
     edge_index = torch.IntTensor([[1, 2], [1, 2], [2, 3], [1, 2], [4, 5]])
-    edge_timestamps = torch.IntTensor([1, 2, 3, 63, 65])
+    edge_timestamps = torch.LongTensor([1, 2, 3, 63, 65])
     edge_feats = torch.rand(5, 5)
 
     node_ids = torch.IntTensor([6, 6, 7, 6, 6, 7])
-    node_timestamps = torch.IntTensor([10, 20, 30, 70, 80, 90])
+    node_timestamps = torch.LongTensor([10, 20, 30, 70, 80, 90])
     dynamic_node_feats = torch.rand(6, 5)
     static_node_feats = torch.rand(8, 11)
     data = DGData.from_raw(
@@ -960,7 +958,7 @@ def test_discretize_with_node_events_reduce_op_first():
     assert data.time_delta == TimeDeltaDG('m')
     assert id(coarse_data) != id(data)
 
-    exp_timestamps = torch.IntTensor([0, 0, 0, 0, 1, 1, 1, 1])
+    exp_timestamps = torch.LongTensor([0, 0, 0, 0, 1, 1, 1, 1])
     exp_edge_event_idx = torch.IntTensor([0, 1, 4, 5])
     exp_edge_index = torch.IntTensor([[1, 2], [2, 3], [1, 2], [4, 5]])
     exp_edge_feats = torch.stack(
@@ -993,7 +991,7 @@ def test_discretize_with_node_events_reduce_op_first():
 
 def test_discretize_no_op():
     edge_index = torch.IntTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.IntTensor([1, 5])
+    edge_timestamps = torch.LongTensor([1, 5])
     data = DGData.from_raw(edge_timestamps, edge_index)
     coarse_data = data.discretize('r')
     assert id(data) != id(coarse_data)  # No Shared memory
@@ -1009,7 +1007,7 @@ def test_discretize_with_huge_ids_no_overflow():
     edge_index = torch.IntTensor(
         [[1, 2], [1, 2], [2, 3], [1, 2], [max_int32 - 1, max_int32 - 1]]
     )
-    edge_timestamps = torch.IntTensor([1, 2, 3, max_int32 - 1, max_int32 - 1])
+    edge_timestamps = torch.LongTensor([1, 2, 3, max_int32 - 1, max_int32 - 1])
     edge_feats = torch.rand(5, 5)
     data = DGData.from_raw(edge_timestamps, edge_index, edge_feats, time_delta='m')
     new_granularity = TimeDeltaDG('h')
@@ -1019,7 +1017,7 @@ def test_discretize_with_huge_ids_no_overflow():
     assert data.time_delta == TimeDeltaDG('m')
     assert id(coarse_data) != id(data)
 
-    exp_timestamps = torch.IntTensor(
+    exp_timestamps = torch.LongTensor(
         [0, 0, (max_int32 - 1) // 60, (max_int32 - 1) // 60]
     )
     exp_edge_event_idx = torch.IntTensor([0, 1, 2, 3])
@@ -1038,7 +1036,7 @@ def test_discretize_with_huge_ids_no_overflow():
 
 def test_discretize_bad_args():
     edge_index = torch.IntTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.IntTensor([1, 5])
+    edge_timestamps = torch.LongTensor([1, 5])
 
     with pytest.raises(EventOrderedConversionError):
         data = DGData.from_raw(edge_timestamps, edge_index, time_delta='r')
@@ -1108,7 +1106,7 @@ def test_split_cannot_override_tgb_split():
 
 def test_clone():
     edge_index = torch.IntTensor([[2, 3], [10, 20]])
-    edge_timestamps = torch.IntTensor([1, 5])
+    edge_timestamps = torch.LongTensor([1, 5])
 
     dg1 = DGData.from_raw(edge_timestamps, edge_index)
     dg2 = dg1.clone()

--- a/test/unit/test_data.py
+++ b/test/unit/test_data.py
@@ -733,7 +733,6 @@ def test_from_pandas_with_node_features():
     }
     node_df = pd.DataFrame(node_dict)
     node_df[['node', 't']] = node_df[['node', 't']].astype('int32')
-    # node_df['node_features'] = node_df['node_features'].astype('float32')
 
     data = DGData.from_pandas(
         edge_df=edge_df,

--- a/test/unit/test_dataloader.py
+++ b/test/unit/test_dataloader.py
@@ -20,8 +20,8 @@ def run_seed_before_tests():
 
 
 def test_init_ordered_dg_ordered_batch():
-    edge_index = torch.LongTensor([[2, 3]])
-    edge_timestamps = torch.LongTensor([1])
+    edge_index = torch.IntTensor([[2, 3]])
+    edge_timestamps = torch.IntTensor([1])
     data = DGData.from_raw(edge_timestamps, edge_index)
     dg = DGraph(data)
     loader = DGDataLoader(dg)
@@ -30,8 +30,8 @@ def test_init_ordered_dg_ordered_batch():
 
 @pytest.mark.parametrize('batch_unit', ['Y', 'M', 'W', 'D', 'h', 's', 'ms', 'us', 'ns'])
 def test_init_ordered_dg_non_ordered_batch(batch_unit):
-    edge_index = torch.LongTensor([[2, 3]])
-    edge_timestamps = torch.LongTensor([1])
+    edge_index = torch.IntTensor([[2, 3]])
+    edge_timestamps = torch.IntTensor([1])
     data = DGData.from_raw(edge_timestamps, edge_index)
     dg = DGraph(data)
     with pytest.raises(EventOrderedConversionError):
@@ -39,8 +39,8 @@ def test_init_ordered_dg_non_ordered_batch(batch_unit):
 
 
 def test_init_bad_batch_size():
-    edge_index = torch.LongTensor([[2, 3]])
-    edge_timestamps = torch.LongTensor([1])
+    edge_index = torch.IntTensor([[2, 3]])
+    edge_timestamps = torch.IntTensor([1])
     data = DGData.from_raw(edge_timestamps, edge_index)
     dg = DGraph(data)
     with pytest.raises(ValueError):
@@ -50,7 +50,7 @@ def test_init_bad_batch_size():
 @pytest.mark.parametrize('drop_last', [True, False])
 @pytest.mark.parametrize('time_delta', ['r', 's'])
 def test_iteration_ordered(drop_last, time_delta):
-    edge_index = torch.LongTensor(
+    edge_index = torch.IntTensor(
         [
             [1, 2],
             [2, 3],
@@ -64,7 +64,7 @@ def test_iteration_ordered(drop_last, time_delta):
             [10, 11],
         ]
     )
-    edge_timestamps = torch.LongTensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    edge_timestamps = torch.IntTensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
     data = DGData.from_raw(edge_timestamps, edge_index, time_delta=time_delta)
     dg = DGraph(data)
     loader = DGDataLoader(dg, batch_size=3, batch_unit='r', drop_last=drop_last)
@@ -86,7 +86,7 @@ def test_iteration_ordered(drop_last, time_delta):
 
 @pytest.mark.parametrize('drop_last', [True, False])
 def test_iteration_by_time_equal_unit(drop_last):
-    edge_index = torch.LongTensor(
+    edge_index = torch.IntTensor(
         [
             [1, 2],
             [2, 3],
@@ -100,7 +100,7 @@ def test_iteration_by_time_equal_unit(drop_last):
             [10, 11],
         ]
     )
-    edge_timestamps = torch.LongTensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    edge_timestamps = torch.IntTensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
     data = DGData.from_raw(edge_timestamps, edge_index, time_delta='s')
     dg = DGraph(data)
     loader = DGDataLoader(
@@ -127,7 +127,7 @@ def test_iteration_by_time_equal_unit(drop_last):
 
 @pytest.mark.parametrize('drop_last', [True, False])
 def test_iteration_by_time_with_conversion_time_delta_value(drop_last):
-    edge_index = torch.LongTensor(
+    edge_index = torch.IntTensor(
         [
             [1, 2],
             [2, 3],
@@ -140,7 +140,7 @@ def test_iteration_by_time_with_conversion_time_delta_value(drop_last):
             [9, 10],
         ]
     )
-    edge_timestamps = torch.LongTensor([0, 0, 1, 1, 1, 12, 18, 24, 24])
+    edge_timestamps = torch.IntTensor([0, 0, 1, 1, 1, 12, 18, 24, 24])
     data = DGData.from_raw(
         edge_timestamps, edge_index, time_delta=TimeDeltaDG('s', value=10)
     )
@@ -167,8 +167,8 @@ def test_iteration_by_time_with_conversion_time_delta_value(drop_last):
 
 
 def test_iteration_non_ordered_dg_non_ordered_batch_unit_too_granular():
-    edge_index = torch.LongTensor([[2, 3]])
-    edge_timestamps = torch.LongTensor([1])
+    edge_index = torch.IntTensor([[2, 3]])
+    edge_timestamps = torch.IntTensor([1])
     data = DGData.from_raw(edge_timestamps, edge_index, time_delta='m')
     dg = DGraph(data)
     with pytest.raises(InvalidDiscretizationError):
@@ -185,10 +185,10 @@ def test_iteration_non_ordered_dg_non_ordered_batch_unit_too_granular():
 
 
 def test_iteration_with_only_node_events_is_non_empty():
-    edge_index = torch.LongTensor([[2, 3], [2, 3]])
-    edge_timestamps = torch.LongTensor([1, 5])
-    node_timestamps = torch.LongTensor([2, 3, 4])
-    node_ids = torch.LongTensor([2, 2, 2])
+    edge_index = torch.IntTensor([[2, 3], [2, 3]])
+    edge_timestamps = torch.IntTensor([1, 5])
+    node_timestamps = torch.IntTensor([2, 3, 4])
+    node_ids = torch.IntTensor([2, 2, 2])
 
     # Can't actually get node events without dynamic node feats
     dynamic_node_feats = torch.rand(3, 3)
@@ -213,8 +213,8 @@ def test_iteration_with_only_node_events_is_non_empty():
 
 
 def test_iteration_with_empty_batch():
-    edge_index = torch.LongTensor([[2, 3], [2, 3]])
-    edge_timestamps = torch.LongTensor([1, 5])
+    edge_index = torch.IntTensor([[2, 3], [2, 3]])
+    edge_timestamps = torch.IntTensor([1, 5])
     data = DGData.from_raw(edge_timestamps, edge_index, time_delta='s')
     dg = DGraph(data)
 
@@ -229,8 +229,8 @@ def test_iteration_with_empty_batch():
 
 
 def test_iteration_with_empty_batch_process_empty():
-    edge_index = torch.LongTensor([[2, 3], [2, 3]])
-    edge_timestamps = torch.LongTensor([1, 5])
+    edge_index = torch.IntTensor([[2, 3], [2, 3]])
+    edge_timestamps = torch.IntTensor([1, 5])
     data = DGData.from_raw(edge_timestamps, edge_index, time_delta='s')
     dg = DGraph(data)
 
@@ -245,8 +245,8 @@ def test_iteration_with_empty_batch_process_empty():
 
 
 def test_iteration_with_empty_batch_raise():
-    edge_index = torch.LongTensor([[2, 3], [2, 3]])
-    edge_timestamps = torch.LongTensor([1, 5])
+    edge_index = torch.IntTensor([[2, 3], [2, 3]])
+    edge_timestamps = torch.IntTensor([1, 5])
     data = DGData.from_raw(edge_timestamps, edge_index, time_delta='s')
     dg = DGraph(data)
 

--- a/test/unit/test_dataloader.py
+++ b/test/unit/test_dataloader.py
@@ -21,7 +21,7 @@ def run_seed_before_tests():
 
 def test_init_ordered_dg_ordered_batch():
     edge_index = torch.IntTensor([[2, 3]])
-    edge_timestamps = torch.IntTensor([1])
+    edge_timestamps = torch.LongTensor([1])
     data = DGData.from_raw(edge_timestamps, edge_index)
     dg = DGraph(data)
     loader = DGDataLoader(dg)
@@ -31,7 +31,7 @@ def test_init_ordered_dg_ordered_batch():
 @pytest.mark.parametrize('batch_unit', ['Y', 'M', 'W', 'D', 'h', 's', 'ms', 'us', 'ns'])
 def test_init_ordered_dg_non_ordered_batch(batch_unit):
     edge_index = torch.IntTensor([[2, 3]])
-    edge_timestamps = torch.IntTensor([1])
+    edge_timestamps = torch.LongTensor([1])
     data = DGData.from_raw(edge_timestamps, edge_index)
     dg = DGraph(data)
     with pytest.raises(EventOrderedConversionError):
@@ -40,7 +40,7 @@ def test_init_ordered_dg_non_ordered_batch(batch_unit):
 
 def test_init_bad_batch_size():
     edge_index = torch.IntTensor([[2, 3]])
-    edge_timestamps = torch.IntTensor([1])
+    edge_timestamps = torch.LongTensor([1])
     data = DGData.from_raw(edge_timestamps, edge_index)
     dg = DGraph(data)
     with pytest.raises(ValueError):
@@ -64,7 +64,7 @@ def test_iteration_ordered(drop_last, time_delta):
             [10, 11],
         ]
     )
-    edge_timestamps = torch.IntTensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    edge_timestamps = torch.LongTensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
     data = DGData.from_raw(edge_timestamps, edge_index, time_delta=time_delta)
     dg = DGraph(data)
     loader = DGDataLoader(dg, batch_size=3, batch_unit='r', drop_last=drop_last)
@@ -100,7 +100,7 @@ def test_iteration_by_time_equal_unit(drop_last):
             [10, 11],
         ]
     )
-    edge_timestamps = torch.IntTensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    edge_timestamps = torch.LongTensor([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
     data = DGData.from_raw(edge_timestamps, edge_index, time_delta='s')
     dg = DGraph(data)
     loader = DGDataLoader(
@@ -140,7 +140,7 @@ def test_iteration_by_time_with_conversion_time_delta_value(drop_last):
             [9, 10],
         ]
     )
-    edge_timestamps = torch.IntTensor([0, 0, 1, 1, 1, 12, 18, 24, 24])
+    edge_timestamps = torch.LongTensor([0, 0, 1, 1, 1, 12, 18, 24, 24])
     data = DGData.from_raw(
         edge_timestamps, edge_index, time_delta=TimeDeltaDG('s', value=10)
     )
@@ -168,7 +168,7 @@ def test_iteration_by_time_with_conversion_time_delta_value(drop_last):
 
 def test_iteration_non_ordered_dg_non_ordered_batch_unit_too_granular():
     edge_index = torch.IntTensor([[2, 3]])
-    edge_timestamps = torch.IntTensor([1])
+    edge_timestamps = torch.LongTensor([1])
     data = DGData.from_raw(edge_timestamps, edge_index, time_delta='m')
     dg = DGraph(data)
     with pytest.raises(InvalidDiscretizationError):
@@ -186,8 +186,8 @@ def test_iteration_non_ordered_dg_non_ordered_batch_unit_too_granular():
 
 def test_iteration_with_only_node_events_is_non_empty():
     edge_index = torch.IntTensor([[2, 3], [2, 3]])
-    edge_timestamps = torch.IntTensor([1, 5])
-    node_timestamps = torch.IntTensor([2, 3, 4])
+    edge_timestamps = torch.LongTensor([1, 5])
+    node_timestamps = torch.LongTensor([2, 3, 4])
     node_ids = torch.IntTensor([2, 2, 2])
 
     # Can't actually get node events without dynamic node feats
@@ -214,7 +214,7 @@ def test_iteration_with_only_node_events_is_non_empty():
 
 def test_iteration_with_empty_batch():
     edge_index = torch.IntTensor([[2, 3], [2, 3]])
-    edge_timestamps = torch.IntTensor([1, 5])
+    edge_timestamps = torch.LongTensor([1, 5])
     data = DGData.from_raw(edge_timestamps, edge_index, time_delta='s')
     dg = DGraph(data)
 
@@ -230,7 +230,7 @@ def test_iteration_with_empty_batch():
 
 def test_iteration_with_empty_batch_process_empty():
     edge_index = torch.IntTensor([[2, 3], [2, 3]])
-    edge_timestamps = torch.IntTensor([1, 5])
+    edge_timestamps = torch.LongTensor([1, 5])
     data = DGData.from_raw(edge_timestamps, edge_index, time_delta='s')
     dg = DGraph(data)
 
@@ -246,7 +246,7 @@ def test_iteration_with_empty_batch_process_empty():
 
 def test_iteration_with_empty_batch_raise():
     edge_index = torch.IntTensor([[2, 3], [2, 3]])
-    edge_timestamps = torch.IntTensor([1, 5])
+    edge_timestamps = torch.LongTensor([1, 5])
     data = DGData.from_raw(edge_timestamps, edge_index, time_delta='s')
     dg = DGraph(data)
 

--- a/test/unit/test_dgraph.py
+++ b/test/unit/test_dgraph.py
@@ -10,9 +10,9 @@ from tgm.data import DGData
 @pytest.fixture
 def data():
     edge_index = torch.IntTensor([[2, 2], [2, 4], [1, 8]])
-    edge_timestamps = torch.IntTensor([1, 5, 20])
+    edge_timestamps = torch.LongTensor([1, 5, 20])
     edge_feats = torch.rand(3, 5)
-    node_timestamps = torch.IntTensor([1, 5, 10])
+    node_timestamps = torch.LongTensor([1, 5, 10])
     node_ids = torch.IntTensor([2, 4, 6])
     dynamic_node_feats = torch.rand([3, 5])
     static_node_feats = torch.rand(9, 11)
@@ -48,7 +48,7 @@ def test_init_from_data(data):
     expected_edges = (
         torch.tensor([2, 2, 1], dtype=torch.int32),
         torch.tensor([2, 4, 8], dtype=torch.int32),
-        torch.tensor([1, 5, 20], dtype=torch.int32),
+        torch.tensor([1, 5, 20], dtype=torch.int64),
     )
     torch.testing.assert_close(dg.edges, expected_edges)
 
@@ -69,7 +69,7 @@ def test_init_gpu(data):
     expected_edges = (
         torch.tensor([2, 2, 1], dtype=torch.int32, device='cuda'),
         torch.tensor([2, 4, 8], dtype=torch.int32, device='cuda'),
-        torch.tensor([1, 5, 20], dtype=torch.int32, device='cuda'),
+        torch.tensor([1, 5, 20], dtype=torch.int64, device='cuda'),
     )
     torch.testing.assert_close(dg.edges, expected_edges)
 
@@ -104,7 +104,7 @@ def test_materialize(data):
     dg = DGraph(data)
     exp_src = torch.tensor([2, 2, 1], dtype=torch.int32)
     exp_dst = torch.tensor([2, 4, 8], dtype=torch.int32)
-    exp_t = torch.tensor([1, 5, 20], dtype=torch.int32)
+    exp_t = torch.tensor([1, 5, 20], dtype=torch.int64)
     exp = DGBatch(
         exp_src,
         exp_dst,
@@ -121,7 +121,7 @@ def test_materialize_skip_feature_materialization(data):
     dg = DGraph(data)
     exp_src = torch.tensor([2, 2, 1], dtype=torch.int32)
     exp_dst = torch.tensor([2, 4, 8], dtype=torch.int32)
-    exp_t = torch.tensor([1, 5, 20], dtype=torch.int32)
+    exp_t = torch.tensor([1, 5, 20], dtype=torch.int64)
     exp = DGBatch(exp_src, exp_dst, exp_t, None, None)
     torch.testing.assert_close(
         asdict(dg.materialize(materialize_features=False)), asdict(exp)
@@ -152,7 +152,7 @@ def test_slice_time_no_upper_bound(data):
     exp_edges = (
         torch.IntTensor([2, 1]),
         torch.IntTensor([4, 8]),
-        torch.IntTensor([5, 20]),
+        torch.LongTensor([5, 20]),
     )
     torch.testing.assert_close(dg1.edges, exp_edges)
 
@@ -183,7 +183,7 @@ def test_slice_time_at_end_time(data):
     exp_edges = (
         torch.IntTensor([2, 2]),
         torch.IntTensor([2, 4]),
-        torch.IntTensor([1, 5]),
+        torch.LongTensor([1, 5]),
     )
     torch.testing.assert_close(dg1.edges, exp_edges)
 
@@ -223,7 +223,7 @@ def test_slice_time_to_empty(data):
     exp_edges = (
         torch.IntTensor([2, 2]),
         torch.IntTensor([2, 4]),
-        torch.IntTensor([1, 5]),
+        torch.LongTensor([1, 5]),
     )
     torch.testing.assert_close(dg1.edges, exp_edges)
 
@@ -249,7 +249,7 @@ def test_slice_time_to_empty(data):
     exp_edges = (
         torch.IntTensor([2]),
         torch.IntTensor([4]),
-        torch.IntTensor([5]),
+        torch.LongTensor([5]),
     )
     torch.testing.assert_close(dg2.edges, exp_edges)
 
@@ -271,7 +271,7 @@ def test_slice_time_to_empty(data):
     assert dg3.num_timestamps == 1
     assert dg3.nodes == {6}
 
-    exp_edges = (torch.IntTensor([]), torch.IntTensor([]), torch.IntTensor([]))
+    exp_edges = (torch.IntTensor([]), torch.IntTensor([]), torch.LongTensor([]))
     torch.testing.assert_close(dg3.edges, exp_edges)
 
     exp_dynamic_node_feats = torch.zeros(dg3.end_time + 1, dg3.num_nodes, 5)
@@ -294,7 +294,7 @@ def test_slice_time_to_empty(data):
     assert dg4.dynamic_node_feats is None
     assert dg4.edge_feats is None
 
-    exp_edges = (torch.IntTensor([]), torch.IntTensor([]), torch.IntTensor([]))
+    exp_edges = (torch.IntTensor([]), torch.IntTensor([]), torch.LongTensor([]))
     torch.testing.assert_close(dg4.edges, exp_edges)
 
     # Check original graph cache is not updated
@@ -331,7 +331,7 @@ def test_slice_events(data):
     exp_edges = (
         torch.IntTensor([2]),
         torch.IntTensor([4]),
-        torch.IntTensor([5]),
+        torch.LongTensor([5]),
     )
     torch.testing.assert_close(dg1.edges, exp_edges)
 
@@ -375,7 +375,7 @@ def test_slice_events_slice_time_combination(data):
     exp_edges = (
         torch.IntTensor([2]),
         torch.IntTensor([4]),
-        torch.IntTensor([5]),
+        torch.LongTensor([5]),
     )
     torch.testing.assert_close(dg1.edges, exp_edges)
 

--- a/test/unit/test_dgraph.py
+++ b/test/unit/test_dgraph.py
@@ -9,11 +9,11 @@ from tgm.data import DGData
 
 @pytest.fixture
 def data():
-    edge_index = torch.LongTensor([[2, 2], [2, 4], [1, 8]])
-    edge_timestamps = torch.LongTensor([1, 5, 20])
+    edge_index = torch.IntTensor([[2, 2], [2, 4], [1, 8]])
+    edge_timestamps = torch.IntTensor([1, 5, 20])
     edge_feats = torch.rand(3, 5)
-    node_timestamps = torch.LongTensor([1, 5, 10])
-    node_ids = torch.LongTensor([2, 4, 6])
+    node_timestamps = torch.IntTensor([1, 5, 10])
+    node_ids = torch.IntTensor([2, 4, 6])
     dynamic_node_feats = torch.rand([3, 5])
     static_node_feats = torch.rand(9, 11)
     return DGData.from_raw(
@@ -46,9 +46,9 @@ def test_init_from_data(data):
     assert dg.device == torch.device('cpu')
 
     expected_edges = (
-        torch.tensor([2, 2, 1], dtype=torch.int64),
-        torch.tensor([2, 4, 8], dtype=torch.int64),
-        torch.tensor([1, 5, 20], dtype=torch.int64),
+        torch.tensor([2, 2, 1], dtype=torch.int32),
+        torch.tensor([2, 4, 8], dtype=torch.int32),
+        torch.tensor([1, 5, 20], dtype=torch.int32),
     )
     torch.testing.assert_close(dg.edges, expected_edges)
 
@@ -67,9 +67,9 @@ def test_init_gpu(data):
     assert dg.device == torch.device('cuda')
 
     expected_edges = (
-        torch.tensor([2, 2, 1], dtype=torch.int64, device='cuda'),
-        torch.tensor([2, 4, 8], dtype=torch.int64, device='cuda'),
-        torch.tensor([1, 5, 20], dtype=torch.int64, device='cuda'),
+        torch.tensor([2, 2, 1], dtype=torch.int32, device='cuda'),
+        torch.tensor([2, 4, 8], dtype=torch.int32, device='cuda'),
+        torch.tensor([1, 5, 20], dtype=torch.int32, device='cuda'),
     )
     torch.testing.assert_close(dg.edges, expected_edges)
 
@@ -102,9 +102,9 @@ def test_init_bad_data():
 
 def test_materialize(data):
     dg = DGraph(data)
-    exp_src = torch.tensor([2, 2, 1], dtype=torch.int64)
-    exp_dst = torch.tensor([2, 4, 8], dtype=torch.int64)
-    exp_t = torch.tensor([1, 5, 20], dtype=torch.int64)
+    exp_src = torch.tensor([2, 2, 1], dtype=torch.int32)
+    exp_dst = torch.tensor([2, 4, 8], dtype=torch.int32)
+    exp_t = torch.tensor([1, 5, 20], dtype=torch.int32)
     exp = DGBatch(
         exp_src,
         exp_dst,
@@ -119,9 +119,9 @@ def test_materialize(data):
 
 def test_materialize_skip_feature_materialization(data):
     dg = DGraph(data)
-    exp_src = torch.tensor([2, 2, 1], dtype=torch.int64)
-    exp_dst = torch.tensor([2, 4, 8], dtype=torch.int64)
-    exp_t = torch.tensor([1, 5, 20], dtype=torch.int64)
+    exp_src = torch.tensor([2, 2, 1], dtype=torch.int32)
+    exp_dst = torch.tensor([2, 4, 8], dtype=torch.int32)
+    exp_t = torch.tensor([1, 5, 20], dtype=torch.int32)
     exp = DGBatch(exp_src, exp_dst, exp_t, None, None)
     torch.testing.assert_close(
         asdict(dg.materialize(materialize_features=False)), asdict(exp)
@@ -150,9 +150,9 @@ def test_slice_time_no_upper_bound(data):
     assert dg.nodes == {1, 2, 4, 6, 8}
 
     exp_edges = (
-        torch.LongTensor([2, 1]),
-        torch.LongTensor([4, 8]),
-        torch.LongTensor([5, 20]),
+        torch.IntTensor([2, 1]),
+        torch.IntTensor([4, 8]),
+        torch.IntTensor([5, 20]),
     )
     torch.testing.assert_close(dg1.edges, exp_edges)
 
@@ -181,9 +181,9 @@ def test_slice_time_at_end_time(data):
     assert dg1.nodes == {2, 4, 6}
 
     exp_edges = (
-        torch.LongTensor([2, 2]),
-        torch.LongTensor([2, 4]),
-        torch.LongTensor([1, 5]),
+        torch.IntTensor([2, 2]),
+        torch.IntTensor([2, 4]),
+        torch.IntTensor([1, 5]),
     )
     torch.testing.assert_close(dg1.edges, exp_edges)
 
@@ -221,9 +221,9 @@ def test_slice_time_to_empty(data):
     assert dg1.nodes == {2, 4, 6}
 
     exp_edges = (
-        torch.LongTensor([2, 2]),
-        torch.LongTensor([2, 4]),
-        torch.LongTensor([1, 5]),
+        torch.IntTensor([2, 2]),
+        torch.IntTensor([2, 4]),
+        torch.IntTensor([1, 5]),
     )
     torch.testing.assert_close(dg1.edges, exp_edges)
 
@@ -247,9 +247,9 @@ def test_slice_time_to_empty(data):
     assert dg2.nodes == {2, 4, 6}
 
     exp_edges = (
-        torch.LongTensor([2]),
-        torch.LongTensor([4]),
-        torch.LongTensor([5]),
+        torch.IntTensor([2]),
+        torch.IntTensor([4]),
+        torch.IntTensor([5]),
     )
     torch.testing.assert_close(dg2.edges, exp_edges)
 
@@ -271,7 +271,7 @@ def test_slice_time_to_empty(data):
     assert dg3.num_timestamps == 1
     assert dg3.nodes == {6}
 
-    exp_edges = (torch.LongTensor([]), torch.LongTensor([]), torch.LongTensor([]))
+    exp_edges = (torch.IntTensor([]), torch.IntTensor([]), torch.IntTensor([]))
     torch.testing.assert_close(dg3.edges, exp_edges)
 
     exp_dynamic_node_feats = torch.zeros(dg3.end_time + 1, dg3.num_nodes, 5)
@@ -294,7 +294,7 @@ def test_slice_time_to_empty(data):
     assert dg4.dynamic_node_feats is None
     assert dg4.edge_feats is None
 
-    exp_edges = (torch.LongTensor([]), torch.LongTensor([]), torch.LongTensor([]))
+    exp_edges = (torch.IntTensor([]), torch.IntTensor([]), torch.IntTensor([]))
     torch.testing.assert_close(dg4.edges, exp_edges)
 
     # Check original graph cache is not updated
@@ -329,9 +329,9 @@ def test_slice_events(data):
     assert dg1.nodes == {2, 4, 6}
 
     exp_edges = (
-        torch.LongTensor([2]),
-        torch.LongTensor([4]),
-        torch.LongTensor([5]),
+        torch.IntTensor([2]),
+        torch.IntTensor([4]),
+        torch.IntTensor([5]),
     )
     torch.testing.assert_close(dg1.edges, exp_edges)
 
@@ -373,9 +373,9 @@ def test_slice_events_slice_time_combination(data):
     assert dg1.nodes == {2, 4}
 
     exp_edges = (
-        torch.LongTensor([2]),
-        torch.LongTensor([4]),
-        torch.LongTensor([5]),
+        torch.IntTensor([2]),
+        torch.IntTensor([4]),
+        torch.IntTensor([5]),
     )
     torch.testing.assert_close(dg1.edges, exp_edges)
 

--- a/test/unit/test_hooks/test_deduplication_hook.py
+++ b/test/unit/test_hooks/test_deduplication_hook.py
@@ -8,8 +8,8 @@ from tgm.hooks import DeduplicationHook
 
 @pytest.fixture
 def dg():
-    edge_index = torch.LongTensor([[2, 2], [2, 4], [1, 8]])
-    edge_timestamps = torch.LongTensor([1, 5, 20])
+    edge_index = torch.IntTensor([[2, 2], [2, 4], [1, 8]])
+    edge_timestamps = torch.IntTensor([1, 5, 20])
     data = DGData.from_raw(edge_timestamps, edge_index)
     return DGraph(data)
 
@@ -28,33 +28,33 @@ def test_dedup(dg):
     batch = dg.materialize()
     processed_batch = hook(dg, batch)
     torch.testing.assert_close(
-        processed_batch.unique_nids, torch.LongTensor([1, 2, 4, 8])
+        processed_batch.unique_nids, torch.IntTensor([1, 2, 4, 8])
     )
     torch.testing.assert_close(
-        processed_batch.global_to_local(batch.src), torch.LongTensor([1, 1, 0])
+        processed_batch.global_to_local(batch.src), torch.IntTensor([1, 1, 0])
     )
     torch.testing.assert_close(
-        processed_batch.global_to_local(batch.dst), torch.LongTensor([1, 2, 3])
+        processed_batch.global_to_local(batch.dst), torch.IntTensor([1, 2, 3])
     )
 
 
 def test_dedup_with_negatives(dg):
     hook = DeduplicationHook()
     batch = dg.materialize()
-    batch.neg = torch.LongTensor([1, 5, 10])  # add some mock negatives
+    batch.neg = torch.IntTensor([1, 5, 10])  # add some mock negatives
 
     processed_batch = hook(dg, batch)
     torch.testing.assert_close(
-        processed_batch.unique_nids, torch.LongTensor([1, 2, 4, 5, 8, 10])
+        processed_batch.unique_nids, torch.IntTensor([1, 2, 4, 5, 8, 10])
     )
     torch.testing.assert_close(
-        processed_batch.global_to_local(batch.src), torch.LongTensor([1, 1, 0])
+        processed_batch.global_to_local(batch.src), torch.IntTensor([1, 1, 0])
     )
     torch.testing.assert_close(
-        processed_batch.global_to_local(batch.dst), torch.LongTensor([1, 2, 4])
+        processed_batch.global_to_local(batch.dst), torch.IntTensor([1, 2, 4])
     )
     torch.testing.assert_close(
-        processed_batch.global_to_local(batch.neg), torch.LongTensor([0, 3, 5])
+        processed_batch.global_to_local(batch.neg), torch.IntTensor([0, 3, 5])
     )
 
 
@@ -62,24 +62,24 @@ def test_dedup_with_nbrs(dg):
     hook = DeduplicationHook()
     batch = dg.materialize()
     batch.nbr_nids = [  # add some mock neighbours
-        torch.LongTensor([1, 5]),  # First hop
-        torch.LongTensor([10]),  # Second hop
+        torch.IntTensor([1, 5]),  # First hop
+        torch.IntTensor([10]),  # Second hop
     ]
-    batch.nbr_mask = [torch.LongTensor([1, 1]), torch.LongTensor([1])]
+    batch.nbr_mask = [torch.IntTensor([1, 1]), torch.IntTensor([1])]
 
     processed_batch = hook(dg, batch)
     torch.testing.assert_close(
-        processed_batch.unique_nids, torch.LongTensor([1, 2, 4, 5, 8, 10])
+        processed_batch.unique_nids, torch.IntTensor([1, 2, 4, 5, 8, 10])
     )
     torch.testing.assert_close(
-        processed_batch.global_to_local(batch.src), torch.LongTensor([1, 1, 0])
+        processed_batch.global_to_local(batch.src), torch.IntTensor([1, 1, 0])
     )
     torch.testing.assert_close(
-        processed_batch.global_to_local(batch.dst), torch.LongTensor([1, 2, 4])
+        processed_batch.global_to_local(batch.dst), torch.IntTensor([1, 2, 4])
     )
     torch.testing.assert_close(
-        processed_batch.global_to_local(batch.nbr_nids[0]), torch.LongTensor([0, 3])
+        processed_batch.global_to_local(batch.nbr_nids[0]), torch.IntTensor([0, 3])
     )
     torch.testing.assert_close(
-        processed_batch.global_to_local(batch.nbr_nids[1]), torch.LongTensor([5])
+        processed_batch.global_to_local(batch.nbr_nids[1]), torch.IntTensor([5])
     )

--- a/test/unit/test_hooks/test_device_transfer_hook.py
+++ b/test/unit/test_hooks/test_device_transfer_hook.py
@@ -8,8 +8,8 @@ from tgm.hooks import DeviceTransferHook
 
 @pytest.fixture
 def dg():
-    edge_index = torch.LongTensor([[1, 10], [1, 11], [1, 12], [1, 13]])
-    edge_timestamps = torch.LongTensor([1, 1, 2, 2])
+    edge_index = torch.IntTensor([[1, 10], [1, 11], [1, 12], [1, 13]])
+    edge_timestamps = torch.IntTensor([1, 1, 2, 2])
     data = DGData.from_raw(edge_timestamps, edge_index)
     return DGraph(data)
 

--- a/test/unit/test_hooks/test_device_transfer_hook.py
+++ b/test/unit/test_hooks/test_device_transfer_hook.py
@@ -9,7 +9,7 @@ from tgm.hooks import DeviceTransferHook
 @pytest.fixture
 def dg():
     edge_index = torch.IntTensor([[1, 10], [1, 11], [1, 12], [1, 13]])
-    edge_timestamps = torch.IntTensor([1, 1, 2, 2])
+    edge_timestamps = torch.LongTensor([1, 1, 2, 2])
     data = DGData.from_raw(edge_timestamps, edge_index)
     return DGraph(data)
 

--- a/test/unit/test_hooks/test_hook_manager.py
+++ b/test/unit/test_hooks/test_hook_manager.py
@@ -41,8 +41,8 @@ class MockHookWithState(StatefulHook):
 
 @pytest.fixture
 def dg():
-    edge_index = torch.LongTensor([[1, 10], [1, 11], [1, 12], [1, 13]])
-    edge_timestamps = torch.LongTensor([1, 1, 2, 2])
+    edge_index = torch.IntTensor([[1, 10], [1, 11], [1, 12], [1, 13]])
+    edge_timestamps = torch.IntTensor([1, 1, 2, 2])
     data = DGData.from_raw(edge_timestamps, edge_index)
     return DGraph(data)
 

--- a/test/unit/test_hooks/test_hook_manager.py
+++ b/test/unit/test_hooks/test_hook_manager.py
@@ -42,7 +42,7 @@ class MockHookWithState(StatefulHook):
 @pytest.fixture
 def dg():
     edge_index = torch.IntTensor([[1, 10], [1, 11], [1, 12], [1, 13]])
-    edge_timestamps = torch.IntTensor([1, 1, 2, 2])
+    edge_timestamps = torch.LongTensor([1, 1, 2, 2])
     data = DGData.from_raw(edge_timestamps, edge_index)
     return DGraph(data)
 

--- a/test/unit/test_hooks/test_negative_edge_sampler_hook.py
+++ b/test/unit/test_hooks/test_negative_edge_sampler_hook.py
@@ -9,7 +9,7 @@ from tgm.hooks import NegativeEdgeSamplerHook
 @pytest.fixture
 def data():
     edge_index = torch.IntTensor([[2, 2], [2, 4], [1, 8]])
-    edge_timestamps = torch.IntTensor([1, 5, 20])
+    edge_timestamps = torch.LongTensor([1, 5, 20])
     return DGData.from_raw(edge_timestamps, edge_index)
 
 

--- a/test/unit/test_hooks/test_negative_edge_sampler_hook.py
+++ b/test/unit/test_hooks/test_negative_edge_sampler_hook.py
@@ -8,8 +8,8 @@ from tgm.hooks import NegativeEdgeSamplerHook
 
 @pytest.fixture
 def data():
-    edge_index = torch.LongTensor([[2, 2], [2, 4], [1, 8]])
-    edge_timestamps = torch.LongTensor([1, 5, 20])
+    edge_index = torch.IntTensor([[2, 2], [2, 4], [1, 8]])
+    edge_timestamps = torch.IntTensor([1, 5, 20])
     return DGData.from_raw(edge_timestamps, edge_index)
 
 

--- a/test/unit/test_hooks/test_neighbor_sampler_hook.py
+++ b/test/unit/test_hooks/test_neighbor_sampler_hook.py
@@ -13,8 +13,8 @@ from tgm.loader import DGDataLoader
 
 @pytest.fixture
 def data():
-    edge_index = torch.LongTensor([[2, 2], [2, 4], [1, 8]])
-    edge_timestamps = torch.LongTensor([1, 5, 20])
+    edge_index = torch.IntTensor([[2, 2], [2, 4], [1, 8]])
+    edge_timestamps = torch.IntTensor([1, 5, 20])
     edge_feats = torch.rand(3, 5)
     return DGData.from_raw(edge_timestamps, edge_index, edge_feats)
 
@@ -46,8 +46,8 @@ def test_neighbor_sampler_hook_link_pred(data):
     batch = dg.materialize()
 
     # Link Prediction will add negative edges to seed nodes for sampling
-    batch.neg = torch.LongTensor([0] * len(batch.dst))
-    batch.neg_time = torch.LongTensor([0] * len(batch.dst))
+    batch.neg = torch.IntTensor([0] * len(batch.dst))
+    batch.neg_time = torch.IntTensor([0] * len(batch.dst))
     batch = hook(dg, batch)
     assert isinstance(batch, DGBatch)
     assert hasattr(batch, 'nids')
@@ -105,9 +105,9 @@ def basic_sample_graph():
     # Alice (0) #
     #############
     """
-    edge_index = torch.LongTensor([[0, 1], [0, 2], [2, 3], [2, 0]])
-    edge_timestamps = torch.LongTensor([1, 2, 3, 4])
-    edge_feats = torch.LongTensor(
+    edge_index = torch.IntTensor([[0, 1], [0, 2], [2, 3], [2, 0]])
+    edge_timestamps = torch.IntTensor([1, 2, 3, 4])
+    edge_feats = torch.Tensor(
         [[1], [2], [5], [2]]
     )  # edge feat is simply summing the node IDs at two end points
     data = DGData.from_raw(edge_timestamps, edge_index, edge_feats)

--- a/test/unit/test_hooks/test_neighbor_sampler_hook.py
+++ b/test/unit/test_hooks/test_neighbor_sampler_hook.py
@@ -14,7 +14,7 @@ from tgm.loader import DGDataLoader
 @pytest.fixture
 def data():
     edge_index = torch.IntTensor([[2, 2], [2, 4], [1, 8]])
-    edge_timestamps = torch.IntTensor([1, 5, 20])
+    edge_timestamps = torch.LongTensor([1, 5, 20])
     edge_feats = torch.rand(3, 5)
     return DGData.from_raw(edge_timestamps, edge_index, edge_feats)
 
@@ -106,7 +106,7 @@ def basic_sample_graph():
     #############
     """
     edge_index = torch.IntTensor([[0, 1], [0, 2], [2, 3], [2, 0]])
-    edge_timestamps = torch.IntTensor([1, 2, 3, 4])
+    edge_timestamps = torch.LongTensor([1, 2, 3, 4])
     edge_feats = torch.Tensor(
         [[1], [2], [5], [2]]
     )  # edge feat is simply summing the node IDs at two end points

--- a/test/unit/test_hooks/test_pin_memory_hook.py
+++ b/test/unit/test_hooks/test_pin_memory_hook.py
@@ -8,8 +8,8 @@ from tgm.hooks import PinMemoryHook
 
 @pytest.fixture
 def dg():
-    edge_index = torch.LongTensor([[1, 10], [1, 11], [1, 12], [1, 13]])
-    edge_timestamps = torch.LongTensor([1, 1, 2, 2])
+    edge_index = torch.IntTensor([[1, 10], [1, 11], [1, 12], [1, 13]])
+    edge_timestamps = torch.IntTensor([1, 1, 2, 2])
     data = DGData.from_raw(edge_timestamps, edge_index)
     return DGraph(data)
 

--- a/test/unit/test_hooks/test_pin_memory_hook.py
+++ b/test/unit/test_hooks/test_pin_memory_hook.py
@@ -9,7 +9,7 @@ from tgm.hooks import PinMemoryHook
 @pytest.fixture
 def dg():
     edge_index = torch.IntTensor([[1, 10], [1, 11], [1, 12], [1, 13]])
-    edge_timestamps = torch.IntTensor([1, 1, 2, 2])
+    edge_timestamps = torch.LongTensor([1, 1, 2, 2])
     data = DGData.from_raw(edge_timestamps, edge_index)
     return DGraph(data)
 

--- a/test/unit/test_hooks/test_recency_nbr_hook.py
+++ b/test/unit/test_hooks/test_recency_nbr_hook.py
@@ -703,8 +703,3 @@ def test_tgb_non_time_respecting_negative_neighbor_sampling_test(
     assert nbr_nids[0][4][0] == 2
     assert nbr_nids[1][4][0] == PADDED_NODE_ID
     assert nbr_nids[0][5][0] == 2
-
-
-@pytest.mark.skip('TODO')
-def test_sampler_with_huge_ids_no_overflow():
-    assert False

--- a/test/unit/test_hooks/test_recency_nbr_hook.py
+++ b/test/unit/test_hooks/test_recency_nbr_hook.py
@@ -40,9 +40,9 @@ def basic_sample_graph():
     # Alice (0) #
     #############
     """
-    edge_index = torch.LongTensor([[0, 1], [0, 2], [2, 3], [2, 0]])
-    edge_timestamps = torch.LongTensor([1, 2, 3, 4])
-    edge_feats = torch.LongTensor(
+    edge_index = torch.IntTensor([[0, 1], [0, 2], [2, 3], [2, 0]])
+    edge_timestamps = torch.IntTensor([1, 2, 3, 4])
+    edge_feats = torch.Tensor(
         [[1], [2], [5], [2]]
     )  # edge feat is simply summing the node IDs at two end points
     data = DGData.from_raw(edge_timestamps, edge_index, edge_feats)
@@ -331,10 +331,10 @@ def recency_buffer_graph():
     src = [0] * 100
     dst = list(range(1, 101))
     edge_index = [src, dst]
-    edge_index = torch.LongTensor(edge_index)
+    edge_index = torch.IntTensor(edge_index)
     edge_index = edge_index.transpose(0, 1)
-    edge_timestamps = torch.LongTensor(list(range(0, 100)))
-    edge_feats = torch.LongTensor(
+    edge_timestamps = torch.IntTensor(list(range(0, 100)))
+    edge_feats = torch.Tensor(
         list(range(1, 101))
     )  # edge feat is simply summing the node IDs at two end points
     edge_feats = edge_feats.view(-1, 1)  # 1 feature per edge
@@ -404,9 +404,9 @@ def two_hop_basic_graph():
     5 -> t=5 -> 0
     5 -> t=6 -> 2
     """
-    edge_index = torch.LongTensor([[0, 1], [1, 2], [3, 2], [4, 2], [5, 0], [5, 2]])
-    edge_timestamps = torch.LongTensor([1, 2, 3, 4, 5, 6])
-    edge_feats = torch.LongTensor(
+    edge_index = torch.IntTensor([[0, 1], [1, 2], [3, 2], [4, 2], [5, 0], [5, 2]])
+    edge_timestamps = torch.IntTensor([1, 2, 3, 4, 5, 6])
+    edge_feats = torch.Tensor(
         [[1], [3], [5], [6], [5], [7]]
     )  # edge feat is simply summing the node IDs at two end points
     data = DGData.from_raw(edge_timestamps, edge_index, edge_feats)

--- a/test/unit/test_hooks/test_recency_nbr_hook.py
+++ b/test/unit/test_hooks/test_recency_nbr_hook.py
@@ -703,3 +703,7 @@ def test_tgb_non_time_respecting_negative_neighbor_sampling_test(
     assert nbr_nids[0][4][0] == 2
     assert nbr_nids[1][4][0] == PADDED_NODE_ID
     assert nbr_nids[0][5][0] == 2
+
+
+def test_sampler_with_huge_ids_no_overflow():
+    assert False

--- a/test/unit/test_hooks/test_recency_nbr_hook.py
+++ b/test/unit/test_hooks/test_recency_nbr_hook.py
@@ -41,7 +41,7 @@ def basic_sample_graph():
     #############
     """
     edge_index = torch.IntTensor([[0, 1], [0, 2], [2, 3], [2, 0]])
-    edge_timestamps = torch.IntTensor([1, 2, 3, 4])
+    edge_timestamps = torch.LongTensor([1, 2, 3, 4])
     edge_feats = torch.Tensor(
         [[1], [2], [5], [2]]
     )  # edge feat is simply summing the node IDs at two end points
@@ -333,7 +333,7 @@ def recency_buffer_graph():
     edge_index = [src, dst]
     edge_index = torch.IntTensor(edge_index)
     edge_index = edge_index.transpose(0, 1)
-    edge_timestamps = torch.IntTensor(list(range(0, 100)))
+    edge_timestamps = torch.LongTensor(list(range(0, 100)))
     edge_feats = torch.Tensor(
         list(range(1, 101))
     )  # edge feat is simply summing the node IDs at two end points
@@ -405,7 +405,7 @@ def two_hop_basic_graph():
     5 -> t=6 -> 2
     """
     edge_index = torch.IntTensor([[0, 1], [1, 2], [3, 2], [4, 2], [5, 0], [5, 2]])
-    edge_timestamps = torch.IntTensor([1, 2, 3, 4, 5, 6])
+    edge_timestamps = torch.LongTensor([1, 2, 3, 4, 5, 6])
     edge_feats = torch.Tensor(
         [[1], [3], [5], [6], [5], [7]]
     )  # edge feat is simply summing the node IDs at two end points

--- a/test/unit/test_hooks/test_recency_nbr_hook.py
+++ b/test/unit/test_hooks/test_recency_nbr_hook.py
@@ -705,5 +705,6 @@ def test_tgb_non_time_respecting_negative_neighbor_sampling_test(
     assert nbr_nids[0][5][0] == 2
 
 
+@pytest.mark.skip('TODO')
 def test_sampler_with_huge_ids_no_overflow():
     assert False

--- a/test/unit/test_hooks/test_tgb_negative_sampling_hook.py
+++ b/test/unit/test_hooks/test_tgb_negative_sampling_hook.py
@@ -10,8 +10,8 @@ from tgm.hooks import TGBNegativeEdgeSamplerHook
 
 @pytest.fixture
 def data():
-    edge_index = torch.LongTensor([[2, 2], [2, 4], [1, 8]])
-    edge_timestamps = torch.LongTensor([1, 5, 20])
+    edge_index = torch.IntTensor([[2, 2], [2, 4], [1, 8]])
+    edge_timestamps = torch.IntTensor([1, 5, 20])
     return DGData.from_raw(edge_timestamps=edge_timestamps, edge_index=edge_index)
 
 

--- a/test/unit/test_hooks/test_tgb_negative_sampling_hook.py
+++ b/test/unit/test_hooks/test_tgb_negative_sampling_hook.py
@@ -11,7 +11,7 @@ from tgm.hooks import TGBNegativeEdgeSamplerHook
 @pytest.fixture
 def data():
     edge_index = torch.IntTensor([[2, 2], [2, 4], [1, 8]])
-    edge_timestamps = torch.IntTensor([1, 5, 20])
+    edge_timestamps = torch.LongTensor([1, 5, 20])
     return DGData.from_raw(edge_timestamps=edge_timestamps, edge_index=edge_index)
 
 

--- a/test/unit/test_recipe.py
+++ b/test/unit/test_recipe.py
@@ -17,8 +17,8 @@ from tgm.hooks import (
 
 @pytest.fixture
 def dg():
-    edge_index = torch.LongTensor([[1, 10], [1, 11], [1, 12], [1, 13]])
-    edge_timestamps = torch.LongTensor([1, 1, 2, 2])
+    edge_index = torch.IntTensor([[1, 10], [1, 11], [1, 12], [1, 13]])
+    edge_timestamps = torch.IntTensor([1, 1, 2, 2])
     data = DGData.from_raw(edge_timestamps, edge_index)
     return DGraph(data)
 

--- a/test/unit/test_recipe.py
+++ b/test/unit/test_recipe.py
@@ -18,7 +18,7 @@ from tgm.hooks import (
 @pytest.fixture
 def dg():
     edge_index = torch.IntTensor([[1, 10], [1, 11], [1, 12], [1, 13]])
-    edge_timestamps = torch.IntTensor([1, 1, 2, 2])
+    edge_timestamps = torch.LongTensor([1, 1, 2, 2])
     data = DGData.from_raw(edge_timestamps, edge_index)
     return DGraph(data)
 

--- a/test/unit/test_split.py
+++ b/test/unit/test_split.py
@@ -17,8 +17,8 @@ def test_time_split_bad_args():
 
 
 def test_temporal_split():
-    edge_times = torch.tensor([1, 2, 3, 4])
-    edge_index = torch.tensor([[1, 2], [3, 4], [5, 6], [7, 8]])
+    edge_times = torch.IntTensor([1, 2, 3, 4])
+    edge_index = torch.IntTensor([[1, 2], [3, 4], [5, 6], [7, 8]])
     num_nodes = edge_index.max() + 1
     static_node_feats = torch.rand(num_nodes, 5)
 
@@ -52,11 +52,11 @@ def test_temporal_split():
 
 
 def test_temporal_split_with_node_feats():
-    edge_times = torch.tensor([1, 2, 3, 4])
-    edge_index = torch.tensor([[1, 2], [3, 4], [5, 6], [7, 8]])
+    edge_times = torch.IntTensor([1, 2, 3, 4])
+    edge_index = torch.IntTensor([[1, 2], [3, 4], [5, 6], [7, 8]])
 
-    node_times = torch.tensor([1, 2, 4])
-    node_ids = torch.tensor([1, 2, 3])
+    node_times = torch.IntTensor([1, 2, 4])
+    node_ids = torch.IntTensor([1, 2, 3])
     dynamic_node_feats = torch.rand(3, 7)
     num_nodes = edge_index.max() + 1
     static_node_feats = torch.rand(num_nodes, 5)
@@ -95,11 +95,11 @@ def test_temporal_split_with_node_feats():
 
 
 def test_temporal_split_only_train_split():
-    edge_times = torch.tensor([1, 2, 3, 4])
-    edge_index = torch.tensor([[1, 2], [3, 4], [5, 6], [7, 8]])
+    edge_times = torch.IntTensor([1, 2, 3, 4])
+    edge_index = torch.IntTensor([[1, 2], [3, 4], [5, 6], [7, 8]])
 
-    node_times = torch.tensor([0, 2, 4])
-    node_ids = torch.tensor([1, 2, 3])
+    node_times = torch.IntTensor([0, 2, 4])
+    node_ids = torch.IntTensor([1, 2, 3])
     dynamic_node_feats = torch.rand(3, 7)
     num_nodes = edge_index.max() + 1
     static_node_feats = torch.rand(num_nodes, 5)
@@ -129,8 +129,8 @@ def test_temporal_ratio_split_bad_args():
 
 
 def test_temporal_ratio_split():
-    edge_times = torch.tensor([1, 2, 3, 4])
-    edge_index = torch.tensor([[1, 2], [3, 4], [5, 6], [7, 8]])
+    edge_times = torch.IntTensor([1, 2, 3, 4])
+    edge_index = torch.IntTensor([[1, 2], [3, 4], [5, 6], [7, 8]])
     num_nodes = edge_index.max() + 1
     static_node_feats = torch.rand(num_nodes, 5)
 
@@ -164,11 +164,11 @@ def test_temporal_ratio_split():
 
 
 def test_temporal_ratio_split_with_node_feats():
-    edge_times = torch.tensor([1, 2, 3, 4])
-    edge_index = torch.tensor([[1, 2], [3, 4], [5, 6], [7, 8]])
+    edge_times = torch.IntTensor([1, 2, 3, 4])
+    edge_index = torch.IntTensor([[1, 2], [3, 4], [5, 6], [7, 8]])
 
-    node_times = torch.tensor([1, 2, 4])
-    node_ids = torch.tensor([1, 2, 3])
+    node_times = torch.IntTensor([1, 2, 4])
+    node_ids = torch.IntTensor([1, 2, 3])
     dynamic_node_feats = torch.rand(3, 7)
     num_nodes = edge_index.max() + 1
     static_node_feats = torch.rand(num_nodes, 5)
@@ -210,11 +210,11 @@ def test_temporal_ratio_split_with_node_feats():
 
 
 def test_temporal_ratio_split_only_train_split():
-    edge_times = torch.tensor([1, 2, 3, 4])
-    edge_index = torch.tensor([[1, 2], [3, 4], [5, 6], [7, 8]])
+    edge_times = torch.IntTensor([1, 2, 3, 4])
+    edge_index = torch.IntTensor([[1, 2], [3, 4], [5, 6], [7, 8]])
 
-    node_times = torch.tensor([0, 2, 4])
-    node_ids = torch.tensor([1, 2, 3])
+    node_times = torch.IntTensor([0, 2, 4])
+    node_ids = torch.IntTensor([1, 2, 3])
     dynamic_node_feats = torch.rand(3, 7)
     num_nodes = edge_index.max() + 1
     static_node_feats = torch.rand(num_nodes, 5)

--- a/test/unit/test_split.py
+++ b/test/unit/test_split.py
@@ -17,7 +17,7 @@ def test_time_split_bad_args():
 
 
 def test_temporal_split():
-    edge_times = torch.IntTensor([1, 2, 3, 4])
+    edge_times = torch.LongTensor([1, 2, 3, 4])
     edge_index = torch.IntTensor([[1, 2], [3, 4], [5, 6], [7, 8]])
     num_nodes = edge_index.max() + 1
     static_node_feats = torch.rand(num_nodes, 5)
@@ -52,10 +52,10 @@ def test_temporal_split():
 
 
 def test_temporal_split_with_node_feats():
-    edge_times = torch.IntTensor([1, 2, 3, 4])
+    edge_times = torch.LongTensor([1, 2, 3, 4])
     edge_index = torch.IntTensor([[1, 2], [3, 4], [5, 6], [7, 8]])
 
-    node_times = torch.IntTensor([1, 2, 4])
+    node_times = torch.LongTensor([1, 2, 4])
     node_ids = torch.IntTensor([1, 2, 3])
     dynamic_node_feats = torch.rand(3, 7)
     num_nodes = edge_index.max() + 1
@@ -95,10 +95,10 @@ def test_temporal_split_with_node_feats():
 
 
 def test_temporal_split_only_train_split():
-    edge_times = torch.IntTensor([1, 2, 3, 4])
+    edge_times = torch.LongTensor([1, 2, 3, 4])
     edge_index = torch.IntTensor([[1, 2], [3, 4], [5, 6], [7, 8]])
 
-    node_times = torch.IntTensor([0, 2, 4])
+    node_times = torch.LongTensor([0, 2, 4])
     node_ids = torch.IntTensor([1, 2, 3])
     dynamic_node_feats = torch.rand(3, 7)
     num_nodes = edge_index.max() + 1
@@ -129,7 +129,7 @@ def test_temporal_ratio_split_bad_args():
 
 
 def test_temporal_ratio_split():
-    edge_times = torch.IntTensor([1, 2, 3, 4])
+    edge_times = torch.LongTensor([1, 2, 3, 4])
     edge_index = torch.IntTensor([[1, 2], [3, 4], [5, 6], [7, 8]])
     num_nodes = edge_index.max() + 1
     static_node_feats = torch.rand(num_nodes, 5)
@@ -164,10 +164,10 @@ def test_temporal_ratio_split():
 
 
 def test_temporal_ratio_split_with_node_feats():
-    edge_times = torch.IntTensor([1, 2, 3, 4])
+    edge_times = torch.LongTensor([1, 2, 3, 4])
     edge_index = torch.IntTensor([[1, 2], [3, 4], [5, 6], [7, 8]])
 
-    node_times = torch.IntTensor([1, 2, 4])
+    node_times = torch.LongTensor([1, 2, 4])
     node_ids = torch.IntTensor([1, 2, 3])
     dynamic_node_feats = torch.rand(3, 7)
     num_nodes = edge_index.max() + 1
@@ -210,10 +210,10 @@ def test_temporal_ratio_split_with_node_feats():
 
 
 def test_temporal_ratio_split_only_train_split():
-    edge_times = torch.IntTensor([1, 2, 3, 4])
+    edge_times = torch.LongTensor([1, 2, 3, 4])
     edge_index = torch.IntTensor([[1, 2], [3, 4], [5, 6], [7, 8]])
 
-    node_times = torch.IntTensor([0, 2, 4])
+    node_times = torch.LongTensor([0, 2, 4])
     node_ids = torch.IntTensor([1, 2, 3])
     dynamic_node_feats = torch.rand(3, 7)
     num_nodes = edge_index.max() + 1

--- a/test/unit/test_storage_impl.py
+++ b/test/unit/test_storage_impl.py
@@ -27,26 +27,26 @@ def DGStorageImpl(request):
 
 @pytest.fixture
 def edge_only_data():
-    edge_index = torch.LongTensor([[2, 2], [2, 4], [6, 8]])
-    edge_timestamps = torch.LongTensor([1, 5, 10])
+    edge_index = torch.IntTensor([[2, 2], [2, 4], [6, 8]])
+    edge_timestamps = torch.IntTensor([1, 5, 10])
     return DGData.from_raw(edge_timestamps, edge_index)
 
 
 @pytest.fixture
 def edge_only_data_with_features():
-    edge_index = torch.LongTensor([[2, 2], [2, 4], [6, 8]])
-    edge_timestamps = torch.LongTensor([1, 5, 10])
+    edge_index = torch.IntTensor([[2, 2], [2, 4], [6, 8]])
+    edge_timestamps = torch.IntTensor([1, 5, 10])
     edge_feats = torch.rand(3, 5)
     return DGData.from_raw(edge_timestamps, edge_index, edge_feats)
 
 
 @pytest.fixture
 def data_with_features():
-    edge_index = torch.LongTensor([[2, 2], [2, 4], [1, 8]])
-    edge_timestamps = torch.LongTensor([1, 5, 20])
+    edge_index = torch.IntTensor([[2, 2], [2, 4], [1, 8]])
+    edge_timestamps = torch.IntTensor([1, 5, 20])
     edge_feats = torch.rand(3, 5)
-    node_timestamps = torch.LongTensor([1, 5, 10])
-    node_ids = torch.LongTensor([2, 4, 6])
+    node_timestamps = torch.IntTensor([1, 5, 10])
+    node_ids = torch.IntTensor([2, 4, 6])
     dynamic_node_feats = torch.rand(3, 5)
     static_node_feats = torch.rand(9, 11)
     return DGData.from_raw(
@@ -127,41 +127,41 @@ def test_get_edges(DGStorageImpl, data, request):
     storage = DGStorageImpl(data)
 
     expected = (
-        torch.tensor([2, 2, 6], dtype=torch.int64),
-        torch.tensor([2, 4, 8], dtype=torch.int64),
-        torch.tensor([1, 5, 10], dtype=torch.int64),
+        torch.tensor([2, 2, 6], dtype=torch.int32),
+        torch.tensor([2, 4, 8], dtype=torch.int32),
+        torch.tensor([1, 5, 10], dtype=torch.int32),
     )
     torch.testing.assert_close(storage.get_edges(DGSliceTracker()), expected)
 
     expected = (
-        torch.tensor([2, 6], dtype=torch.int64),
-        torch.tensor([4, 8], dtype=torch.int64),
-        torch.tensor([5, 10], dtype=torch.int64),
+        torch.tensor([2, 6], dtype=torch.int32),
+        torch.tensor([4, 8], dtype=torch.int32),
+        torch.tensor([5, 10], dtype=torch.int32),
     )
     torch.testing.assert_close(
         storage.get_edges(DGSliceTracker(start_time=5)), expected
     )
 
     expected = (
-        torch.tensor([2], dtype=torch.int64),
-        torch.tensor([2], dtype=torch.int64),
-        torch.tensor([1], dtype=torch.int64),
+        torch.tensor([2], dtype=torch.int32),
+        torch.tensor([2], dtype=torch.int32),
+        torch.tensor([1], dtype=torch.int32),
     )
     torch.testing.assert_close(storage.get_edges(DGSliceTracker(end_time=4)), expected)
 
     expected = (
-        torch.tensor([2], dtype=torch.int64),
-        torch.tensor([4], dtype=torch.int64),
-        torch.tensor([5], dtype=torch.int64),
+        torch.tensor([2], dtype=torch.int32),
+        torch.tensor([4], dtype=torch.int32),
+        torch.tensor([5], dtype=torch.int32),
     )
     torch.testing.assert_close(
         storage.get_edges(DGSliceTracker(start_time=5, end_time=9)), expected
     )
 
     expected = (
-        torch.tensor([6], dtype=torch.int64),
-        torch.tensor([8], dtype=torch.int64),
-        torch.tensor([10], dtype=torch.int64),
+        torch.tensor([6], dtype=torch.int32),
+        torch.tensor([8], dtype=torch.int32),
+        torch.tensor([10], dtype=torch.int32),
     )
 
     torch.testing.assert_close(
@@ -169,9 +169,9 @@ def test_get_edges(DGStorageImpl, data, request):
     )
 
     expected = (
-        torch.tensor([], dtype=torch.int64),
-        torch.tensor([], dtype=torch.int64),
-        torch.tensor([], dtype=torch.int64),
+        torch.tensor([], dtype=torch.int32),
+        torch.tensor([], dtype=torch.int32),
+        torch.tensor([], dtype=torch.int32),
     )
     torch.testing.assert_close(
         storage.get_edges(DGSliceTracker(start_idx=2, end_idx=5, end_time=6)), expected
@@ -371,9 +371,9 @@ def basic_sample_graph():
     # Alice (0) #
     #############
     """
-    edge_index = torch.LongTensor([[0, 1], [0, 2], [2, 3], [2, 0]])
-    edge_timestamps = torch.LongTensor([1, 2, 3, 4])
-    edge_feats = torch.LongTensor(
+    edge_index = torch.IntTensor([[0, 1], [0, 2], [2, 3], [2, 0]])
+    edge_timestamps = torch.IntTensor([1, 2, 3, 4])
+    edge_feats = torch.Tensor(
         [[1], [2], [5], [2]]
     )  # edge feat is simply summing the node IDs at two end points
     data = DGData.from_raw(edge_timestamps, edge_index, edge_feats)

--- a/test/unit/test_storage_impl.py
+++ b/test/unit/test_storage_impl.py
@@ -28,14 +28,14 @@ def DGStorageImpl(request):
 @pytest.fixture
 def edge_only_data():
     edge_index = torch.IntTensor([[2, 2], [2, 4], [6, 8]])
-    edge_timestamps = torch.IntTensor([1, 5, 10])
+    edge_timestamps = torch.LongTensor([1, 5, 10])
     return DGData.from_raw(edge_timestamps, edge_index)
 
 
 @pytest.fixture
 def edge_only_data_with_features():
     edge_index = torch.IntTensor([[2, 2], [2, 4], [6, 8]])
-    edge_timestamps = torch.IntTensor([1, 5, 10])
+    edge_timestamps = torch.LongTensor([1, 5, 10])
     edge_feats = torch.rand(3, 5)
     return DGData.from_raw(edge_timestamps, edge_index, edge_feats)
 
@@ -43,9 +43,9 @@ def edge_only_data_with_features():
 @pytest.fixture
 def data_with_features():
     edge_index = torch.IntTensor([[2, 2], [2, 4], [1, 8]])
-    edge_timestamps = torch.IntTensor([1, 5, 20])
+    edge_timestamps = torch.LongTensor([1, 5, 20])
     edge_feats = torch.rand(3, 5)
-    node_timestamps = torch.IntTensor([1, 5, 10])
+    node_timestamps = torch.LongTensor([1, 5, 10])
     node_ids = torch.IntTensor([2, 4, 6])
     dynamic_node_feats = torch.rand(3, 5)
     static_node_feats = torch.rand(9, 11)
@@ -129,14 +129,14 @@ def test_get_edges(DGStorageImpl, data, request):
     expected = (
         torch.tensor([2, 2, 6], dtype=torch.int32),
         torch.tensor([2, 4, 8], dtype=torch.int32),
-        torch.tensor([1, 5, 10], dtype=torch.int32),
+        torch.tensor([1, 5, 10], dtype=torch.int64),
     )
     torch.testing.assert_close(storage.get_edges(DGSliceTracker()), expected)
 
     expected = (
         torch.tensor([2, 6], dtype=torch.int32),
         torch.tensor([4, 8], dtype=torch.int32),
-        torch.tensor([5, 10], dtype=torch.int32),
+        torch.tensor([5, 10], dtype=torch.int64),
     )
     torch.testing.assert_close(
         storage.get_edges(DGSliceTracker(start_time=5)), expected
@@ -145,14 +145,14 @@ def test_get_edges(DGStorageImpl, data, request):
     expected = (
         torch.tensor([2], dtype=torch.int32),
         torch.tensor([2], dtype=torch.int32),
-        torch.tensor([1], dtype=torch.int32),
+        torch.tensor([1], dtype=torch.int64),
     )
     torch.testing.assert_close(storage.get_edges(DGSliceTracker(end_time=4)), expected)
 
     expected = (
         torch.tensor([2], dtype=torch.int32),
         torch.tensor([4], dtype=torch.int32),
-        torch.tensor([5], dtype=torch.int32),
+        torch.tensor([5], dtype=torch.int64),
     )
     torch.testing.assert_close(
         storage.get_edges(DGSliceTracker(start_time=5, end_time=9)), expected
@@ -161,7 +161,7 @@ def test_get_edges(DGStorageImpl, data, request):
     expected = (
         torch.tensor([6], dtype=torch.int32),
         torch.tensor([8], dtype=torch.int32),
-        torch.tensor([10], dtype=torch.int32),
+        torch.tensor([10], dtype=torch.int64),
     )
 
     torch.testing.assert_close(
@@ -171,7 +171,7 @@ def test_get_edges(DGStorageImpl, data, request):
     expected = (
         torch.tensor([], dtype=torch.int32),
         torch.tensor([], dtype=torch.int32),
-        torch.tensor([], dtype=torch.int32),
+        torch.tensor([], dtype=torch.int64),
     )
     torch.testing.assert_close(
         storage.get_edges(DGSliceTracker(start_idx=2, end_idx=5, end_time=6)), expected
@@ -372,7 +372,7 @@ def basic_sample_graph():
     #############
     """
     edge_index = torch.IntTensor([[0, 1], [0, 2], [2, 3], [2, 0]])
-    edge_timestamps = torch.IntTensor([1, 2, 3, 4])
+    edge_timestamps = torch.LongTensor([1, 2, 3, 4])
     edge_feats = torch.Tensor(
         [[1], [2], [5], [2]]
     )  # edge feat is simply summing the node IDs at two end points

--- a/tgm/_storage/backends/array_backend.py
+++ b/tgm/_storage/backends/array_backend.py
@@ -105,9 +105,9 @@ class DGStorageArrayBackend(DGStorageBase):
 
         B = len(seed_nodes)
         nbr_nids = torch.full(
-            (B, num_nbrs), PADDED_NODE_ID, dtype=torch.long, device=device
+            (B, num_nbrs), PADDED_NODE_ID, dtype=torch.int32, device=device
         )
-        nbr_times = torch.zeros(B, num_nbrs, dtype=torch.long, device=device)
+        nbr_times = torch.zeros(B, num_nbrs, dtype=torch.int32, device=device)
         nbr_feats = torch.zeros(B, num_nbrs, self.get_edge_feats_dim(), device=device)  # type: ignore
 
         for i, node in enumerate(unique_nodes.tolist()):
@@ -128,10 +128,12 @@ class DGStorageArrayBackend(DGStorageBase):
 
             nn = len(nbr_ids)
             mask = inverse_indices == i
-            nbr_nids[mask, :nn] = torch.tensor(nbr_ids, dtype=torch.long, device=device)
-            nbr_times[mask, :nn] = torch.tensor(times, dtype=torch.long, device=device)
+            nbr_nids[mask, :nn] = torch.tensor(
+                nbr_ids, dtype=torch.int32, device=device
+            )
+            nbr_times[mask, :nn] = torch.tensor(times, dtype=torch.int32, device=device)
             if self._data.edge_feats is not None:
-                nbr_feats[mask, :nn] = torch.stack(feats).to(device).float()
+                nbr_feats[mask, :nn] = torch.stack(feats).to(device)
 
         return nbr_nids, nbr_times, nbr_feats
 

--- a/tgm/_storage/backends/array_backend.py
+++ b/tgm/_storage/backends/array_backend.py
@@ -107,7 +107,7 @@ class DGStorageArrayBackend(DGStorageBase):
         nbr_nids = torch.full(
             (B, num_nbrs), PADDED_NODE_ID, dtype=torch.int32, device=device
         )
-        nbr_times = torch.zeros(B, num_nbrs, dtype=torch.int32, device=device)
+        nbr_times = torch.zeros(B, num_nbrs, dtype=torch.int64, device=device)
         nbr_feats = torch.zeros(B, num_nbrs, self.get_edge_feats_dim(), device=device)  # type: ignore
 
         for i, node in enumerate(unique_nodes.tolist()):
@@ -131,7 +131,7 @@ class DGStorageArrayBackend(DGStorageBase):
             nbr_nids[mask, :nn] = torch.tensor(
                 nbr_ids, dtype=torch.int32, device=device
             )
-            nbr_times[mask, :nn] = torch.tensor(times, dtype=torch.int32, device=device)
+            nbr_times[mask, :nn] = torch.tensor(times, dtype=torch.int64, device=device)
             if self._data.edge_feats is not None:
                 nbr_feats[mask, :nn] = torch.stack(feats).to(device)
 

--- a/tgm/data.py
+++ b/tgm/data.py
@@ -73,6 +73,8 @@ class DGData:
         def _assert_is_tensor(x: Any, name: str) -> None:
             if not isinstance(x, Tensor):
                 raise TypeError(f'{name} must be a Tensor, got: {type(x)}')
+            if torch.isnan(x).any():
+                raise ValueError(f'{name} contains NaN values')
 
         def _assert_tensor_is_integral(x: Tensor, name: str) -> None:
             int_types = [torch.int8, torch.int16, torch.int32, torch.int64, torch.uint8]

--- a/tgm/data.py
+++ b/tgm/data.py
@@ -108,7 +108,7 @@ class DGData:
             )
         self.timestamps = _maybe_downcast_tensor(self.timestamps, 'timestamps')
 
-        # Ensure our data does not overlow int32 capacity
+        # Ensure our data does not overflow int32 capacity
         if len(self.timestamps) > max_int32_capacity:
             raise ValueError(
                 f'Number of events ({len(self.timestamps)}) exceeds the int32 limit '
@@ -764,7 +764,7 @@ class DGData:
                 }
             else:
                 raise ValueError(
-                    f'Failed to construct TGB dataset. Try updating your TGB package: `pip isntall --upgrade py-tgb`'
+                    f'Failed to construct TGB dataset. Try updating your TGB package: `pip install --upgrade py-tgb`'
                 )
 
             if len(node_label_dict):

--- a/tgm/data.py
+++ b/tgm/data.py
@@ -86,9 +86,7 @@ class DGData:
                     UserWarning,
                 )
                 return x.to(torch.float32)
-            elif x.dtype != torch.float32:  # Upcast
-                return x.to(torch.float32)
-            return x
+            return x.to(torch.float32) if x.dtype != torch.float32 else x
 
         def _maybe_cast_integral_tensor(x: Tensor, name: str) -> Tensor:
             if x.dtype == torch.int64:
@@ -96,9 +94,7 @@ class DGData:
                     f'Downcasting {name} from torch.int64 to torch.int32', UserWarning
                 )
                 return x.to(torch.int32)
-            elif x.dtype != torch.int32:  # Upcast
-                return x.to(torch.int32)
-            return x
+            return x.to(torch.int32) if x.dtype != torch.int32 else x
 
         max_int32_capacity = torch.iinfo(torch.int32).max
 

--- a/tgm/data.py
+++ b/tgm/data.py
@@ -345,7 +345,8 @@ class DGData:
         # Note: If we simply return a new storage this will 2x our peak memory since the GC
         # won't be able to clean up the current graph storage while `self` is alive.
         time_factor = self.time_delta.convert(time_delta)  # type: ignore
-        buckets = (self.timestamps.float() * time_factor).floor().int()
+        # Doing time conversion in 64-bit to avoid numerical issues with float cast
+        buckets = (self.timestamps.to(torch.float64) * time_factor).floor().int()
 
         def _get_keep_indices(event_idx: Tensor, ids: Tensor) -> Tensor:
             event_buckets = buckets[event_idx]

--- a/tgm/hooks/hooks.py
+++ b/tgm/hooks/hooks.py
@@ -487,7 +487,7 @@ class RecencyNeighborHook(StatefulHook):
 
         # Increment write_pos per node
         num_writes = torch.ones_like(sorted_nodes, device=self._device)
-        self._write_pos.scatter_add_(0, sorted_nodes, num_writes)
+        self._write_pos.scatter_add_(0, sorted_nodes.long(), num_writes)
 
     def _move_queues_to_device_if_needed(self, device: torch.device) -> None:
         if device != self._device:

--- a/tgm/hooks/hooks.py
+++ b/tgm/hooks/hooks.py
@@ -63,7 +63,7 @@ class DeduplicationHook(StatelessHook):
         unique_nids = torch.unique(all_nids, sorted=True)
 
         batch.unique_nids = unique_nids  # type: ignore
-        batch.global_to_local = lambda x: torch.searchsorted(unique_nids, x)  # type: ignore
+        batch.global_to_local = lambda x: torch.searchsorted(unique_nids, x).int()  # type: ignore
 
         return batch
 

--- a/tgm/hooks/hooks.py
+++ b/tgm/hooks/hooks.py
@@ -94,7 +94,7 @@ class NegativeEdgeSamplerHook(StatelessHook):
     def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:
         size = (round(self.neg_ratio * batch.dst.size(0)),)
         batch.neg = torch.randint(  # type: ignore
-            self.low, self.high, size, dtype=torch.long, device=dg.device
+            self.low, self.high, size, dtype=torch.int32, device=dg.device
         )
         batch.neg_time = batch.time.clone()  # type: ignore
         return batch
@@ -155,7 +155,7 @@ class TGBNegativeEdgeSamplerHook(StatelessHook):
             ) from e
 
         batch.neg_batch_list = [  # type: ignore
-            torch.tensor(neg_batch, dtype=torch.long, device=dg.device)
+            torch.tensor(neg_batch, dtype=torch.int32, device=dg.device)
             for neg_batch in neg_batch_list
         ]
         batch.neg = torch.unique(torch.cat(batch.neg_batch_list))  # type: ignore
@@ -284,11 +284,11 @@ class RecencyNeighborHook(StatefulHook):
         self._seed_nodes_key = seed_nodes_key
 
         self._nbr_ids = torch.full(
-            (num_nodes, self._max_nbrs), PADDED_NODE_ID, dtype=torch.long
+            (num_nodes, self._max_nbrs), PADDED_NODE_ID, dtype=torch.int32
         )
-        self._nbr_times = torch.zeros((num_nodes, self._max_nbrs), dtype=torch.long)
+        self._nbr_times = torch.zeros((num_nodes, self._max_nbrs), dtype=torch.int32)
         self._nbr_feats = torch.zeros((num_nodes, self._max_nbrs, edge_feats_dim))
-        self._write_pos = torch.zeros(num_nodes, dtype=torch.long)
+        self._write_pos = torch.zeros(num_nodes, dtype=torch.int32)
 
     @property
     def num_nbrs(self) -> List[int]:
@@ -422,7 +422,7 @@ class RecencyNeighborHook(StatefulHook):
                 (len(batch.src), self._edge_feats_dim), device=self._device
             )
         else:
-            edge_feats = batch.edge_feats.float()
+            edge_feats = batch.edge_feats
 
         if self._directed:
             node_ids, nbr_nids, times = batch.src, batch.dst, batch.time

--- a/tgm/hooks/hooks.py
+++ b/tgm/hooks/hooks.py
@@ -286,7 +286,7 @@ class RecencyNeighborHook(StatefulHook):
         self._nbr_ids = torch.full(
             (num_nodes, self._max_nbrs), PADDED_NODE_ID, dtype=torch.int32
         )
-        self._nbr_times = torch.zeros((num_nodes, self._max_nbrs), dtype=torch.int32)
+        self._nbr_times = torch.zeros((num_nodes, self._max_nbrs), dtype=torch.int64)
         self._nbr_feats = torch.zeros((num_nodes, self._max_nbrs, edge_feats_dim))
         self._write_pos = torch.zeros(num_nodes, dtype=torch.int32)
 

--- a/tgm/nn/recurrent/gclstm.py
+++ b/tgm/nn/recurrent/gclstm.py
@@ -94,6 +94,7 @@ class GCLSTM(torch.nn.Module):
 
         Note: If edge weights are not present the forward pass defaults to an unweighted graph.
         """
+        edge_index = edge_index.to(torch.int64)
         H = self._set_hidden_state(X, H)
         C = self._set_cell_state(X, C)
         I = self._compute_input_gate(X, edge_index, edge_weight, H, lambda_max)

--- a/tgm/nn/recurrent/tgcn.py
+++ b/tgm/nn/recurrent/tgcn.py
@@ -58,6 +58,7 @@ class TGCN(torch.nn.Module):
 
         Note: If edge weights are not present the forward pass defaults to an unweighted graph.
         """
+        edge_index = edge_index.to(torch.int64)
         H = self._set_hidden_state(X, H)
 
         # Eq.3 (Section 3.3.3)

--- a/tgm/nn/recurrent/tgcn.py
+++ b/tgm/nn/recurrent/tgcn.py
@@ -6,7 +6,7 @@ from torch_geometric.nn import GCNConv
 
 
 class TGCN(torch.nn.Module):
-    r"""An implementation of Temporal Graph Convolutional Gated Reccurent Cell.
+    r"""An implementation of Temporal Graph Convolutional Gated Recurrent Cell.
 
     Args:
         in_channels (int): Number of input features.


### PR DESCRIPTION
### Summary / Description

The purpose of this PR is to consolidate and standardize our dtype management throughout the codebase.

I am going to use the following rules:

1. All features will be `torch.float32`
2. All integral ids will be `torch.int32` (~2B max)
3. All timestamps will be `torch.int64`

#### Composite Keys
We use radix/lexigraphical sort by node id and time twice
- In our DGData discretize
- In our recency sampler scatter

In both cases, the composite key is of the form: `node_ids * max_time + times` which can overflow `torch.int32`. Pytorch implicitly promotes to 64-bit integers here. We have tests for it.

**Related Issues:** #224 