### PR TITLE
adding node only batch unit test for hooks

### DIFF
--- a/test/unit/test_hooks/test_negative_edge_sampler_hook.py
+++ b/test/unit/test_hooks/test_negative_edge_sampler_hook.py
@@ -3,7 +3,8 @@ import torch
 
 from tgm import DGBatch, DGraph
 from tgm.data import DGData
-from tgm.hooks import NegativeEdgeSamplerHook
+from tgm.hooks import HookManager, NegativeEdgeSamplerHook
+from tgm.loader import DGDataLoader
 
 
 @pytest.fixture
@@ -40,3 +41,41 @@ def test_negative_edge_sampler(data):
     assert torch.is_tensor(batch.neg_time)
     assert batch.neg.shape == batch.dst.shape
     assert batch.neg_time.shape == batch.neg.shape
+
+
+@pytest.fixture
+def node_only_data():
+    edge_index = torch.LongTensor([[1, 2], [2, 3], [3, 4]])
+    edge_timestamps = torch.LongTensor([1, 2, 3])
+    dynamic_node_feats = torch.rand(2, 5)
+    node_timestamps = torch.LongTensor([4, 5])
+    node_ids = torch.LongTensor([5, 6])
+    return DGData.from_raw(
+        edge_timestamps,
+        edge_index,
+        dynamic_node_feats=dynamic_node_feats,
+        node_timestamps=node_timestamps,
+        node_ids=node_ids,
+    )
+
+
+def test_node_only_batch_negative_edge_sampler(node_only_data):
+    dg = DGraph(node_only_data)
+    hm = HookManager(keys=['unit'])
+    hm.register('unit', NegativeEdgeSamplerHook(low=0, high=6))
+    loader = DGDataLoader(dg, batch_size=3, hook_manager=hm)
+    with hm.activate('unit'):
+        batch_iter = iter(loader)
+        batch_1 = next(batch_iter)
+        assert isinstance(batch_1, DGBatch)
+        assert torch.is_tensor(batch_1.neg)
+        assert torch.is_tensor(batch_1.neg_time)
+        assert batch_1.neg.shape == batch_1.dst.shape
+        assert batch_1.neg_time.shape == batch_1.neg.shape
+
+        batch_2 = next(batch_iter)
+        assert isinstance(batch_2, DGBatch)
+        assert torch.is_tensor(batch_2.neg)
+        assert len(batch_2.neg) == 0
+        assert torch.is_tensor(batch_2.neg_time)
+        assert len(batch_2.neg_time) == 0

--- a/test/unit/test_hooks/test_tgb_negative_sampling_hook.py
+++ b/test/unit/test_hooks/test_tgb_negative_sampling_hook.py
@@ -5,7 +5,8 @@ import torch
 
 from tgm import DGBatch, DGraph
 from tgm.data import DGData
-from tgm.hooks import TGBNegativeEdgeSamplerHook
+from tgm.hooks import HookManager, TGBNegativeEdgeSamplerHook
+from tgm.loader import DGDataLoader
 
 
 @pytest.fixture
@@ -52,3 +53,49 @@ def test_negative_edge_sampler(MockNegSampler, data):
     assert torch.is_tensor(batch.neg_time)
     assert len(batch.neg_batch_list) == batch.src.shape[0]
     assert batch.neg_time.shape == batch.neg.shape
+
+
+@pytest.fixture
+def node_only_data():
+    edge_index = torch.LongTensor([[1, 2], [2, 3], [3, 4]])
+    edge_timestamps = torch.LongTensor([1, 2, 3])
+    dynamic_node_feats = torch.rand(2, 5)
+    node_timestamps = torch.LongTensor([4, 5])
+    node_ids = torch.LongTensor([5, 6])
+    return DGData.from_raw(
+        edge_timestamps,
+        edge_index,
+        dynamic_node_feats=dynamic_node_feats,
+        node_timestamps=node_timestamps,
+        node_ids=node_ids,
+    )
+
+
+@patch('tgb.linkproppred.negative_sampler.NegativeEdgeSampler')
+def test_node_only_batch_negative_edge_sampler(MockNegSampler, node_only_data):
+    dg = DGraph(node_only_data)
+    mock_sampler = Mock()
+    mock_sampler.eval_set = {'val': {'cool'}, 'test': {'cool'}}
+    mock_sampler.query_batch.return_value = [[0] for _ in range(3)]
+    MockNegSampler.return_value = mock_sampler
+
+    hm = HookManager(keys=['val', 'test'])
+    hm.register(
+        'val', hook=TGBNegativeEdgeSamplerHook(dataset_name='foo', split_mode='val')
+    )
+    loader = DGDataLoader(dg, batch_size=3, hook_manager=hm)
+    with hm.activate('val'):
+        batch_iter = iter(loader)
+        batch_1 = next(batch_iter)
+        assert isinstance(batch_1, DGBatch)
+        assert torch.is_tensor(batch_1.neg)
+        assert torch.is_tensor(batch_1.neg_time)
+        assert len(batch_1.neg_batch_list) == batch_1.src.shape[0]
+        assert batch_1.neg_time.shape == batch_1.neg.shape
+
+        batch_2 = next(batch_iter)
+        assert isinstance(batch_2, DGBatch)
+        assert torch.is_tensor(batch_2.neg)
+        assert len(batch_2.neg) == 0
+        assert torch.is_tensor(batch_2.neg_time)
+        assert len(batch_2.neg_time) == 0


### PR DESCRIPTION

### Summary / Description

Adding node event only batches to hook unit test 

**Related Issues:** #249 

#### Type of Change

- [x] Bug fix


#### Questions / Discussion Points
 
Found undefined behavior for recency sampler when edge feature not defined
