### PR TITLE
Numerically Stable Decoders

### DIFF
--- a/examples/graphproppred/tgcn.py
+++ b/examples/graphproppred/tgcn.py
@@ -145,7 +145,7 @@ class GraphPredictor(torch.nn.Module):
         z_graph = self.graph_pooling(z_node)
         h = self.fc1(z_graph)
         h = h.relu()
-        return self.fc2(h).sigmoid()
+        return self.fc2(h)
 
 
 def train(
@@ -170,7 +170,9 @@ def train(
             z_node = z[torch.cat([batch.src, batch.dst])]
             pred = decoder(z_node)
 
-            loss = F.binary_cross_entropy(pred, labels[i].unsqueeze(0).float())
+            loss = F.binary_cross_entropy_with_logits(
+                pred, labels[i].unsqueeze(0).float()
+            )
             loss.backward()
             opt.step()
 

--- a/examples/graphproppred/tgcn.py
+++ b/examples/graphproppred/tgcn.py
@@ -203,7 +203,7 @@ def eval(
         if i != len(loader) - 1:  # Skip last snapshot as we don't have labels for it
             z, h_0 = encoder(batch, static_node_feats, h_0)
             z_node = z[torch.cat([batch.src, batch.dst])]
-            y_pred[i] = decoder(z_node)
+            y_pred[i] = decoder(z_node).sigmoid()
 
     indexes = torch.zeros(y_pred.size(0), dtype=torch.long, device=y_pred.device)
     metrics(y_pred, y_true, indexes=indexes)

--- a/examples/linkproppred/dygformer.py
+++ b/examples/linkproppred/dygformer.py
@@ -230,6 +230,7 @@ def eval(
             copy_batch.nbr_feats = [batch.nbr_feats[0][all_idx]]
 
             pos_out, neg_out = model(copy_batch, static_node_feat)
+            pos_out, neg_out = pos_out.sigmoid(), neg_out.sigmoid()
 
             input_dict = {
                 'y_pred_pos': pos_out,

--- a/examples/linkproppred/dygformer.py
+++ b/examples/linkproppred/dygformer.py
@@ -65,7 +65,7 @@ class LinkPredictor(nn.Module):
     def forward(self, z_src: torch.Tensor, z_dst: torch.Tensor) -> torch.Tensor:
         h = self.fc1(torch.cat([z_src, z_dst], dim=1))
         h = h.relu()
-        return self.fc2(h).sigmoid().view(-1)
+        return self.fc2(h).view(-1)
 
 
 class DyGFormer_LinkPrediction(nn.Module):
@@ -188,8 +188,8 @@ def train(
         opt.zero_grad()
         pos_out, neg_out = model(batch, static_node_feat)
 
-        loss = F.binary_cross_entropy(pos_out, torch.ones_like(pos_out))
-        loss += F.binary_cross_entropy(neg_out, torch.zeros_like(neg_out))
+        loss = F.binary_cross_entropy_with_logits(pos_out, torch.ones_like(pos_out))
+        loss += F.binary_cross_entropy_with_logits(neg_out, torch.zeros_like(neg_out))
         loss.backward()
         opt.step()
         total_loss += float(loss)

--- a/examples/linkproppred/gclstm.py
+++ b/examples/linkproppred/gclstm.py
@@ -96,7 +96,7 @@ def train(
         pos_out = decoder(z[batch.src], z[batch.dst])
         neg_out = decoder(z[batch.src], z[batch.neg])
 
-        loss = F.binary_cross_entopy_with_logits(pos_out, torch.ones_like(pos_out))
+        loss = F.binary_cross_entropy_with_logits(pos_out, torch.ones_like(pos_out))
         loss += F.binary_cross_entropy_with_logits(neg_out, torch.zeros_like(neg_out))
         loss.backward()
         opt.step()

--- a/examples/linkproppred/gclstm.py
+++ b/examples/linkproppred/gclstm.py
@@ -69,7 +69,7 @@ class LinkPredictor(nn.Module):
     def forward(self, z_src: torch.Tensor, z_dst: torch.Tensor) -> torch.Tensor:
         h = self.fc1(torch.cat([z_src, z_dst], dim=1))
         h = h.relu()
-        return self.fc2(h).sigmoid().view(-1)
+        return self.fc2(h).view(-1)
 
 
 def train(
@@ -96,8 +96,8 @@ def train(
         pos_out = decoder(z[batch.src], z[batch.dst])
         neg_out = decoder(z[batch.src], z[batch.neg])
 
-        loss = F.mse_loss(pos_out, torch.ones_like(pos_out))
-        loss += F.mse_loss(neg_out, torch.zeros_like(neg_out))
+        loss = F.binary_cross_entopy_with_logits(pos_out, torch.ones_like(pos_out))
+        loss += F.binary_cross_entropy_with_logits(neg_out, torch.zeros_like(neg_out))
         loss.backward()
         opt.step()
         total_loss += float(loss) / batch.src.shape[0]

--- a/examples/linkproppred/gclstm.py
+++ b/examples/linkproppred/gclstm.py
@@ -140,7 +140,7 @@ def eval(
             query_src = batch.src[idx].repeat(len(neg_batch) + 1)
             query_dst = torch.cat([batch.dst[idx].unsqueeze(0), neg_batch])
 
-            y_pred = decoder(z[query_src], z[query_dst])
+            y_pred = decoder(z[query_src], z[query_dst]).sigmoid()
             input_dict = {
                 'y_pred_pos': y_pred[0],
                 'y_pred_neg': y_pred[1:],

--- a/examples/linkproppred/gcn.py
+++ b/examples/linkproppred/gcn.py
@@ -159,7 +159,7 @@ def eval(
             query_src = batch.src[idx].repeat(len(neg_batch) + 1)
             query_dst = torch.cat([batch.dst[idx].unsqueeze(0), neg_batch])
 
-            y_pred = decoder(z[query_src], z[query_dst])
+            y_pred = decoder(z[query_src], z[query_dst]).sigmoid()
             input_dict = {
                 'y_pred_pos': y_pred[0],
                 'y_pred_neg': y_pred[1:],

--- a/examples/linkproppred/gcn.py
+++ b/examples/linkproppred/gcn.py
@@ -90,7 +90,7 @@ class LinkPredictor(nn.Module):
     def forward(self, z_src: torch.Tensor, z_dst: torch.Tensor) -> torch.Tensor:
         h = self.fc1(torch.cat([z_src, z_dst], dim=1))
         h = h.relu()
-        return self.fc2(h).sigmoid().view(-1)
+        return self.fc2(h).view(-1)
 
 
 def train(
@@ -117,8 +117,8 @@ def train(
         pos_out = decoder(z[batch.src], z[batch.dst])
         neg_out = decoder(z[batch.src], z[batch.neg])
 
-        loss = F.mse_loss(pos_out, torch.ones_like(pos_out))
-        loss += F.mse_loss(neg_out, torch.zeros_like(neg_out))
+        loss = F.binary_cross_entopy_with_logits(pos_out, torch.ones_like(pos_out))
+        loss += F.binary_cross_entropy_with_logits(neg_out, torch.zeros_like(neg_out))
         loss.backward()
         opt.step()
         total_loss += float(loss) / batch.src.shape[0]

--- a/examples/linkproppred/gcn.py
+++ b/examples/linkproppred/gcn.py
@@ -117,7 +117,7 @@ def train(
         pos_out = decoder(z[batch.src], z[batch.dst])
         neg_out = decoder(z[batch.src], z[batch.neg])
 
-        loss = F.binary_cross_entopy_with_logits(pos_out, torch.ones_like(pos_out))
+        loss = F.binary_cross_entropy_with_logits(pos_out, torch.ones_like(pos_out))
         loss += F.binary_cross_entropy_with_logits(neg_out, torch.zeros_like(neg_out))
         loss.backward()
         opt.step()

--- a/examples/linkproppred/graphmixer.py
+++ b/examples/linkproppred/graphmixer.py
@@ -236,7 +236,7 @@ def eval(
             dst_idx = torch.tensor([id_map[n.item()] for n in dst_ids], device=z.device)
             z_src = z[src_idx]
             z_dst = z[dst_idx]
-            y_pred = decoder(z_src, z_dst)
+            y_pred = decoder(z_src, z_dst).sigmoid()
 
             input_dict = {
                 'y_pred_pos': y_pred[0],

--- a/examples/linkproppred/graphmixer.py
+++ b/examples/linkproppred/graphmixer.py
@@ -182,7 +182,7 @@ class LinkPredictor(nn.Module):
     def forward(self, z_src: torch.Tensor, z_dst: torch.Tensor) -> torch.Tensor:
         h = self.fc1(torch.cat([z_src, z_dst], dim=1))
         h = h.relu()
-        return self.fc2(h).sigmoid().view(-1)
+        return self.fc2(h).view(-1)
 
 
 def train(
@@ -205,8 +205,8 @@ def train(
         pos_out = decoder(z_src, z_dst)
         neg_out = decoder(z_src, z_neg)
 
-        loss = F.binary_cross_entropy(pos_out, torch.ones_like(pos_out))
-        loss += F.binary_cross_entropy(neg_out, torch.zeros_like(neg_out))
+        loss = F.binary_cross_entopy_with_logits(pos_out, torch.ones_like(pos_out))
+        loss += F.binary_cross_entropy_with_logits(neg_out, torch.zeros_like(neg_out))
         loss.backward()
         opt.step()
         total_loss += float(loss)

--- a/examples/linkproppred/graphmixer.py
+++ b/examples/linkproppred/graphmixer.py
@@ -205,7 +205,7 @@ def train(
         pos_out = decoder(z_src, z_dst)
         neg_out = decoder(z_src, z_neg)
 
-        loss = F.binary_cross_entopy_with_logits(pos_out, torch.ones_like(pos_out))
+        loss = F.binary_cross_entropy_with_logits(pos_out, torch.ones_like(pos_out))
         loss += F.binary_cross_entropy_with_logits(neg_out, torch.zeros_like(neg_out))
         loss.backward()
         opt.step()

--- a/examples/linkproppred/tgat.py
+++ b/examples/linkproppred/tgat.py
@@ -190,7 +190,7 @@ def eval(
             dst_idx = torch.tensor([id_map[n.item()] for n in dst_ids], device=z.device)
             z_src = z[src_idx]
             z_dst = z[dst_idx]
-            y_pred = decoder(z_src, z_dst)
+            y_pred = decoder(z_src, z_dst).sigmoid()
 
             input_dict = {
                 'y_pred_pos': y_pred[0],

--- a/examples/linkproppred/tgat.py
+++ b/examples/linkproppred/tgat.py
@@ -136,7 +136,7 @@ class LinkPredictor(nn.Module):
     def forward(self, z_src: torch.Tensor, z_dst: torch.Tensor) -> torch.Tensor:
         h = self.fc1(torch.cat([z_src, z_dst], dim=1))
         h = h.relu()
-        return self.fc2(h).sigmoid().view(-1)
+        return self.fc2(h).view(-1)
 
 
 def train(
@@ -159,8 +159,8 @@ def train(
         pos_out = decoder(z_src, z_dst)
         neg_out = decoder(z_src, z_neg)
 
-        loss = F.binary_cross_entropy(pos_out, torch.ones_like(pos_out))
-        loss += F.binary_cross_entropy(neg_out, torch.zeros_like(neg_out))
+        loss = F.binary_cross_entopy_with_logits(pos_out, torch.ones_like(pos_out))
+        loss += F.binary_cross_entropy_with_logits(neg_out, torch.zeros_like(neg_out))
         loss.backward()
         opt.step()
         total_loss += float(loss)

--- a/examples/linkproppred/tgat.py
+++ b/examples/linkproppred/tgat.py
@@ -159,7 +159,7 @@ def train(
         pos_out = decoder(z_src, z_dst)
         neg_out = decoder(z_src, z_neg)
 
-        loss = F.binary_cross_entopy_with_logits(pos_out, torch.ones_like(pos_out))
+        loss = F.binary_cross_entropy_with_logits(pos_out, torch.ones_like(pos_out))
         loss += F.binary_cross_entropy_with_logits(neg_out, torch.zeros_like(neg_out))
         loss.backward()
         opt.step()

--- a/examples/linkproppred/tgn.py
+++ b/examples/linkproppred/tgn.py
@@ -57,7 +57,7 @@ class LinkPredictor(nn.Module):
     def forward(self, z_src: torch.Tensor, z_dst: torch.Tensor) -> torch.Tensor:
         h = self.fc1(torch.cat([z_src, z_dst], dim=1))
         h = h.relu()
-        return self.fc2(h).sigmoid().view(-1)
+        return self.fc2(h).view(-1)
 
 
 class GraphAttentionEmbedding(torch.nn.Module):

--- a/examples/linkproppred/tgn.py
+++ b/examples/linkproppred/tgn.py
@@ -323,7 +323,6 @@ def eval(
     memory: nn.Module,
     encoder: nn.Module,
     decoder: nn.Module,
-    eval_metric: str,
     evaluator: Evaluator,
 ) -> float:
     memory.eval()
@@ -371,9 +370,9 @@ def eval(
             input_dict = {
                 'y_pred_pos': y_pred[0],
                 'y_pred_neg': y_pred[1:],
-                'eval_metric': [eval_metric],
+                'eval_metric': [METRIC_TGB_LINKPROPPRED],
             }
-            perf_list.append(evaluator.eval(input_dict)[eval_metric])
+            perf_list.append(evaluator.eval(input_dict)[METRIC_TGB_LINKPROPPRED])
 
         # Update memory with ground-truth state.
         memory.update_state(batch.src, batch.dst, batch.time, batch.edge_feats.float())
@@ -437,7 +436,7 @@ for epoch in range(1, args.epochs + 1):
         latency = end_time - start_time
 
     with hm.activate(val_key):
-        val_mrr = eval(val_loader, memory, encoder, decoder, eval_metric, evaluator)
+        val_mrr = eval(val_loader, memory, encoder, decoder, evaluator)
     print(
         f'Epoch={epoch:02d} Latency={latency:.4f} Loss={loss:.4f} Validation {METRIC_TGB_LINKPROPPRED}={val_mrr:.4f}'
     )
@@ -447,5 +446,5 @@ for epoch in range(1, args.epochs + 1):
 
 
 with hm.activate(test_key):
-    test_mrr = eval(test_loader, memory, encoder, decoder, eval_metric, evaluator)
+    test_mrr = eval(test_loader, memory, encoder, decoder, evaluator)
     print(f'Test {METRIC_TGB_LINKPROPPRED}={test_mrr:.4f}')

--- a/examples/linkproppred/tgn.py
+++ b/examples/linkproppred/tgn.py
@@ -366,7 +366,7 @@ def eval(
 
             inv_src = batch.global_to_local(src_ids)
             inv_dst = batch.global_to_local(dst_ids)
-            y_pred = decoder(z[inv_src], z[inv_dst])
+            y_pred = decoder(z[inv_src], z[inv_dst]).sigmoid()
 
             input_dict = {
                 'y_pred_pos': y_pred[0],

--- a/examples/linkproppred/tpnet.py
+++ b/examples/linkproppred/tpnet.py
@@ -237,6 +237,7 @@ def eval(
             copy_batch.nbr_feats = [batch.nbr_feats[0][all_idx]]
 
             pos_out, neg_out = model(copy_batch, static_node_feat)
+            pos_out, neg_out = pos_out.sigmoid(), neg_out.sigmoid()
 
             input_dict = {
                 'y_pred_pos': pos_out,

--- a/examples/linkproppred/tpnet.py
+++ b/examples/linkproppred/tpnet.py
@@ -195,7 +195,7 @@ def train(
         opt.zero_grad()
         pos_out, neg_out = model(batch, static_node_feat)
 
-        loss = F.binary_cross_entopy_with_logits(pos_out, torch.ones_like(pos_out))
+        loss = F.binary_cross_entropy_with_logits(pos_out, torch.ones_like(pos_out))
         loss += F.binary_cross_entropy_with_logits(neg_out, torch.zeros_like(neg_out))
         loss.backward()
         opt.step()

--- a/examples/linkproppred/tpnet.py
+++ b/examples/linkproppred/tpnet.py
@@ -76,7 +76,7 @@ class LinkPredictor(nn.Module):
     def forward(self, z_src: torch.Tensor, z_dst: torch.Tensor) -> torch.Tensor:
         h = self.fc1(torch.cat([z_src, z_dst], dim=1))
         h = h.relu()
-        return self.fc2(h).sigmoid().view(-1)
+        return self.fc2(h).view(-1)
 
 
 class TPNet_LinkPrediction(nn.Module):
@@ -195,8 +195,8 @@ def train(
         opt.zero_grad()
         pos_out, neg_out = model(batch, static_node_feat)
 
-        loss = F.binary_cross_entropy(pos_out, torch.ones_like(pos_out))
-        loss += F.binary_cross_entropy(neg_out, torch.zeros_like(neg_out))
+        loss = F.binary_cross_entopy_with_logits(pos_out, torch.ones_like(pos_out))
+        loss += F.binary_cross_entropy_with_logits(neg_out, torch.zeros_like(neg_out))
         loss.backward()
         opt.step()
         total_loss += float(loss)


### PR DESCRIPTION
### Summary / Description

Make all our decoders output logits for numerically stable binary cross entropy loss.

**Note**: Our TGN convergence is **much** better. Previously, we had a bug where we were doing `sigmoid()` twice, effectively. 

Close #176 

| Model   |  MSE / master |  BCE / dev |
|---------|----------------|----------------|
| GCLSTM (10 epochs)  |       0.2283 Test MRR        |      0.2598   Test MRR       |
| GCN  (10 epochs)   |         0.4072 Test MRR      |     0.4586 Test MRR          |
| TGN  (5 epochs)   |         0.0501 Test MRR      |     0.3441 Test MRR          |