### PR TITLE
Fixed init assumption for RandomProjectionModule

### DIFF
--- a/tgm/nn/model/tpnet.py
+++ b/tgm/nn/model/tpnet.py
@@ -225,9 +225,7 @@ class RandomProjectionModule(nn.Module):
 
         Returns:
         """
-        assert (
-            len(random_projections) == 2
-        ), (
+        assert len(random_projections) == 2, (
             'Expect a tuple of (now_time,random_projections)'
         )  # @TODO: Need to raise custom exception
         now_time, random_projections = random_projections
@@ -239,9 +237,7 @@ class RandomProjectionModule(nn.Module):
 
         self.now_time.data = now_time.clone()
         for i in range(1, self.num_layer + 1):
-            assert torch.is_tensor(
-                random_projections[i - 1]
-            ), (
+            assert torch.is_tensor(random_projections[i - 1]), (
                 'Not a valid state of random projection'
             )  # @TODO: Need to raise custom exception
             self.random_projections[i].data = random_projections[i - 1].clone()


### PR DESCRIPTION
### Summary / Description

An issue was found when experimenting with `TPNet` for recent submission: current logic in `__init__` in `RandomProjectionModule` fails when trying to set `use_matrix` to false due to incorrect logic. 
