### PR TITLE
Generic Seed Nodes Sampler API

### DIFF
--- a/examples/linkproppred/dygformer.py
+++ b/examples/linkproppred/dygformer.py
@@ -277,6 +277,8 @@ else:
 nbr_hook = RecencyNeighborHook(
     num_nbrs=[args.max_sequence_length - 1],  # 1 remaining for seed node itself
     num_nodes=num_nodes,
+    seed_nodes_keys=['src', 'dst', 'neg'],
+    seed_times_keys=['time', 'time', 'neg_time'],
 )
 
 hm = RecipeRegistry.build(

--- a/examples/linkproppred/graphmixer.py
+++ b/examples/linkproppred/graphmixer.py
@@ -343,7 +343,12 @@ hm = RecipeRegistry.build(
 train_key, val_key, test_key = hm.keys
 hm.register_shared(GraphMixerHook(args.time_gap))
 hm.register_shared(
-    RecencyNeighborHook(num_nbrs=[args.n_nbrs], num_nodes=test_dg.num_nodes)
+    RecencyNeighborHook(
+        num_nbrs=[args.n_nbrs],
+        num_nodes=test_dg.num_nodes,
+        seed_nodes_keys=['src', 'dst', 'neg'],
+        seed_times_keys=['time', 'time', 'neg_time'],
+    )
 )
 
 train_loader = DGDataLoader(train_dg, args.bsize, hook_manager=hm)

--- a/examples/linkproppred/tgat.py
+++ b/examples/linkproppred/tgat.py
@@ -227,11 +227,17 @@ else:
     static_node_feats = torch.zeros((test_dg.num_nodes, 1), device=args.device)
 
 if args.sampling == 'uniform':
-    nbr_hook = NeighborSamplerHook(num_nbrs=args.n_nbrs)
+    nbr_hook = NeighborSamplerHook(
+        num_nbrs=args.n_nbrs,
+        seed_nodes_keys=['src', 'dst', 'neg'],
+        seed_times_keys=['time', 'time', 'neg_time'],
+    )
 elif args.sampling == 'recency':
     nbr_hook = RecencyNeighborHook(
         num_nbrs=args.n_nbrs,
         num_nodes=test_dg.num_nodes,  # Assuming node ids at test set > train/val set
+        seed_nodes_keys=['src', 'dst', 'neg'],
+        seed_times_keys=['time', 'time', 'neg_time'],
     )
 else:
     raise ValueError(f'Unknown sampling type: {args.sampling}')

--- a/examples/linkproppred/tgn.py
+++ b/examples/linkproppred/tgn.py
@@ -402,6 +402,8 @@ test_dg = DGraph(test_data, device=args.device)
 nbr_hook = RecencyNeighborHook(
     num_nbrs=args.n_nbrs,
     num_nodes=test_dg.num_nodes,  # Assuming node ids at test set > train/val set
+    seed_nodes_keys=['src', 'dst', 'neg'],
+    seed_times_keys=['time', 'time', 'neg_time'],
 )
 
 hm = RecipeRegistry.build(

--- a/examples/linkproppred/tpnet.py
+++ b/examples/linkproppred/tpnet.py
@@ -280,7 +280,12 @@ hm = RecipeRegistry.build(
     RECIPE_TGB_LINK_PRED, dataset_name=args.dataset, train_dg=train_dg
 )
 hm.register_shared(
-    RecencyNeighborHook(num_nbrs=[args.num_neighbors], num_nodes=test_dg.num_nodes)
+    RecencyNeighborHook(
+        num_nbrs=[args.num_neighbors],
+        num_nodes=test_dg.num_nodes,
+        seed_nodes_keys=['src', 'dst', 'neg'],
+        seed_times_keys=['time', 'time', 'neg_time'],
+    )
 )
 train_key, val_key, test_key = hm.keys
 

--- a/examples/nodeproppred/dygformer.py
+++ b/examples/nodeproppred/dygformer.py
@@ -263,6 +263,8 @@ test_dg = DGraph(test_data, device=args.device)
 nbr_hook = RecencyNeighborHook(
     num_nbrs=[args.max_sequence_length - 1],  # Keep 1 slot for seed node itself
     num_nodes=num_nodes,
+    seed_nodes_keys=['src', 'dst'],
+    seed_times_keys=['time', 'time'],
 )
 
 hm = HookManager(keys=['train', 'val', 'test'])

--- a/examples/nodeproppred/tgn.py
+++ b/examples/nodeproppred/tgn.py
@@ -409,7 +409,8 @@ num_classes = train_dg.dynamic_node_feats_dim
 nbr_hook = RecencyNeighborHook(
     num_nbrs=args.n_nbrs,
     num_nodes=test_dg.num_nodes,  # Assuming node ids at test set > train/val set
-    seed_nodes_key='node_ids',
+    seed_nodes_keys=['node_ids'],
+    seed_times_keys=['node_times'],
 )
 
 hm = HookManager(keys=['train', 'val', 'test'])

--- a/test/unit/test_hooks/test_neighbor_sampler_hook.py
+++ b/test/unit/test_hooks/test_neighbor_sampler_hook.py
@@ -66,12 +66,24 @@ def test_sample_with_node_events_seeds(node_only_data):
     torch.testing.assert_close(batch.times[0], batch.node_times)
 
 
-def test_sample_with_non_existent_seeds(data):
+def test_bad_sample_with_non_existent_seeds(data):
     dg = DGraph(data)
     hook = NeighborSamplerHook(
         num_nbrs=[1], seed_nodes_keys=['foo'], seed_times_keys=['bar']
     )
     batch = dg.materialize()
+
+    with pytest.raises(ValueError):
+        _ = hook(dg, batch)
+
+
+def test_sample_with_none_seeds(data):
+    dg = DGraph(data)
+    hook = NeighborSamplerHook(
+        num_nbrs=[1], seed_nodes_keys=['foo'], seed_times_keys=['bar']
+    )
+    batch = dg.materialize()
+    batch.foo, batch.bar = None, None
 
     with pytest.warns(UserWarning):
         batch = hook(dg, batch)

--- a/test/unit/test_hooks/test_neighbor_sampler_hook.py
+++ b/test/unit/test_hooks/test_neighbor_sampler_hook.py
@@ -35,16 +35,13 @@ def test_hook_reset_state():
 
 def test_bad_neighbor_sampler_init():
     with pytest.raises(ValueError):
-        NeighborSamplerHook(num_nbrs=[])
+        NeighborSamplerHook(
+            num_nbrs=[], seed_nodes_keys=['foo'], seed_times_keys=['bar']
+        )
     with pytest.raises(ValueError):
-        NeighborSamplerHook(num_nbrs=[1, 0])
-
-
-def test_bad_neighbor_sampler_init_bad_seed_keys():
-    with pytest.raises(ValueError):
-        NeighborSamplerHook(num_nbrs=[1], seed_nodes_keys=['foo'])
-    with pytest.raises(ValueError):
-        NeighborSamplerHook(num_nbrs=[1], seed_times_keys=['foo'])
+        NeighborSamplerHook(
+            num_nbrs=[1, 0], seed_nodes_keys=['foo'], seed_times_keys=['bar']
+        )
     with pytest.raises(ValueError):
         NeighborSamplerHook(
             num_nbrs=[1], seed_nodes_keys=['foo', 'bar'], seed_times_keys=['foo']
@@ -143,7 +140,11 @@ def test_bad_sample_with_seeds_time_out_of_range(data):
 
 def test_neighbor_sampler_hook_link_pred(data):
     dg = DGraph(data)
-    hook = NeighborSamplerHook(num_nbrs=[2])
+    hook = NeighborSamplerHook(
+        num_nbrs=[2],
+        seed_nodes_keys=['src', 'dst'],
+        seed_times_keys=['time', 'time'],
+    )
     batch = dg.materialize()
 
     # Link Prediction will add negative edges to seed nodes for sampling
@@ -159,7 +160,11 @@ def test_neighbor_sampler_hook_link_pred(data):
 
 def test_neighbor_sampler_hook_node_pred(data):
     dg = DGraph(data)
-    hook = NeighborSamplerHook(num_nbrs=[2])
+    hook = NeighborSamplerHook(
+        num_nbrs=[2],
+        seed_nodes_keys=['src', 'dst'],
+        seed_times_keys=['time', 'time'],
+    )
     batch = hook(dg, dg.materialize())
     assert isinstance(batch, DGBatch)
     assert hasattr(batch, 'nids')
@@ -218,7 +223,11 @@ def basic_sample_graph():
 def test_init_basic_sampled_graph_1_hop(basic_sample_graph):
     dg = DGraph(basic_sample_graph)
     n_nbrs = [3]  # 3 neighbor for each node
-    uniform_hook = NeighborSamplerHook(num_nbrs=n_nbrs)
+    uniform_hook = NeighborSamplerHook(
+        num_nbrs=n_nbrs,
+        seed_nodes_keys=['src', 'dst'],
+        seed_times_keys=['time', 'time'],
+    )
     hm = HookManager(keys=['unit'])
     hm.register_shared(uniform_hook)
     loader = DGDataLoader(dg, batch_size=1, hook_manager=hm)
@@ -298,7 +307,12 @@ def test_init_basic_sampled_graph_1_hop(basic_sample_graph):
 def test_init_basic_sampled_graph_directed_1_hop(basic_sample_graph):
     dg = DGraph(basic_sample_graph)
     n_nbrs = [3]  # 3 neighbor for each node
-    uniform_hook = NeighborSamplerHook(num_nbrs=n_nbrs, directed=True)
+    uniform_hook = NeighborSamplerHook(
+        num_nbrs=n_nbrs,
+        seed_nodes_keys=['src', 'dst'],
+        seed_times_keys=['time', 'time'],
+        directed=True,
+    )
     hm = HookManager(keys=['unit'])
     hm.register_shared(uniform_hook)
     loader = DGDataLoader(dg, batch_size=1, hook_manager=hm)
@@ -388,7 +402,11 @@ def no_edge_feat_data():
 def test_no_edge_feat_data_neighbor_sampler(no_edge_feat_data):
     dg = DGraph(no_edge_feat_data)
     n_nbrs = [1]
-    uniform_hook = NeighborSamplerHook(num_nbrs=n_nbrs)
+    uniform_hook = NeighborSamplerHook(
+        num_nbrs=n_nbrs,
+        seed_nodes_keys=['src', 'dst'],
+        seed_times_keys=['time', 'time'],
+    )
     hm = HookManager(keys=['unit'])
     hm.register_shared(uniform_hook)
     loader = DGDataLoader(dg, batch_size=3, hook_manager=hm)
@@ -425,7 +443,11 @@ def test_node_only_batch_recency_nbr_sampler(node_only_data):
     dg = DGraph(node_only_data)
     hm = HookManager(keys=['unit'])
     n_nbrs = [1]  # 1 neighbor for each node
-    uniform_hook = NeighborSamplerHook(num_nbrs=n_nbrs)
+    uniform_hook = NeighborSamplerHook(
+        num_nbrs=n_nbrs,
+        seed_nodes_keys=['src', 'dst'],
+        seed_times_keys=['time', 'time'],
+    )
     hm = HookManager(keys=['unit'])
     hm.register_shared(uniform_hook)
     loader = DGDataLoader(dg, batch_size=3, hook_manager=hm)

--- a/test/unit/test_hooks/test_neighbor_sampler_hook.py
+++ b/test/unit/test_hooks/test_neighbor_sampler_hook.py
@@ -51,39 +51,82 @@ def test_bad_neighbor_sampler_init_bad_seed_keys():
         )
 
 
-@pytest.mark.skip('TODO')
-def test_sample_with_node_events_seeds():
-    pass
+def test_sample_with_node_events_seeds(node_only_data):
+    dg = DGraph(node_only_data)
+    hook = NeighborSamplerHook(
+        num_nbrs=[1],
+        seed_nodes_keys=['node_ids'],
+        seed_times_keys=['node_times'],
+    )
+    batch = dg.materialize()
+    batch = hook(dg, batch)
+    assert len(batch.nids) == 1
+    assert len(batch.times) == 1
+    torch.testing.assert_close(batch.nids[0], batch.node_ids)
+    torch.testing.assert_close(batch.times[0], batch.node_times)
 
 
-@pytest.mark.skip('TODO')
-def test_sample_with_None_seeds():
-    pass
+def test_sample_with_non_existent_seeds(data):
+    dg = DGraph(data)
+    hook = NeighborSamplerHook(
+        num_nbrs=[1], seed_nodes_keys=['foo'], seed_times_keys=['bar']
+    )
+    batch = dg.materialize()
+
+    with pytest.warns(UserWarning):
+        batch = hook(dg, batch)
 
 
-@pytest.mark.skip('TODO')
-def test_sample_with_non_existent_seeds():
-    pass
+def test_bad_sample_with_non_tensor_non_None_seeds(data):
+    dg = DGraph(data)
+    hook = NeighborSamplerHook(
+        num_nbrs=[1], seed_nodes_keys=['foo'], seed_times_keys=['bar']
+    )
+    batch = dg.materialize()
+    batch.foo = 'should_be_1d_tensor'
+    batch.bar = 'should_be_1d_tensor'
+
+    with pytest.raises(ValueError):
+        batch = hook(dg, batch)
 
 
-@pytest.mark.skip('TODO')
-def test_bad_sample_with_non_tensor_non_None_seeds():
-    pass
+def test_bad_sample_with_non_1d_tensor_seeds(data):
+    dg = DGraph(data)
+    hook = NeighborSamplerHook(
+        num_nbrs=[1], seed_nodes_keys=['foo'], seed_times_keys=['bar']
+    )
+    batch = dg.materialize()
+    batch.foo = torch.rand(2, 3)  # should be 1-d
+    batch.bar = torch.rand(2, 3)  # should be 1-d
+
+    with pytest.raises(ValueError):
+        batch = hook(dg, batch)
 
 
-@pytest.mark.skip('TODO')
-def test_bad_sample_with_non_1d_tensor_seeds():
-    pass
+def test_bad_sample_with_seeds_id_out_of_range(data):
+    dg = DGraph(data)
+    hook = NeighborSamplerHook(
+        num_nbrs=[1], seed_nodes_keys=['foo'], seed_times_keys=['bar']
+    )
+    batch = dg.materialize()
+    batch.foo = torch.IntTensor([-1])  # should be positive
+    batch.bar = torch.LongTensor([1])
+
+    with pytest.raises(ValueError):
+        batch = hook(dg, batch)
 
 
-@pytest.mark.skip('TODO')
-def test_bad_sample_with_seeds_id_out_of_range():
-    pass
+def test_bad_sample_with_seeds_time_out_of_range(data):
+    dg = DGraph(data)
+    hook = NeighborSamplerHook(
+        num_nbrs=[1], seed_nodes_keys=['foo'], seed_times_keys=['bar']
+    )
+    batch = dg.materialize()
+    batch.foo = torch.IntTensor([1])
+    batch.bar = torch.LongTensor([-1])  # should be positive
 
-
-@pytest.mark.skip('TODO')
-def test_bad_sample_with_seeds_time_out_of_range():
-    pass
+    with pytest.raises(ValueError):
+        batch = hook(dg, batch)
 
 
 def test_neighbor_sampler_hook_link_pred(data):

--- a/test/unit/test_hooks/test_neighbor_sampler_hook.py
+++ b/test/unit/test_hooks/test_neighbor_sampler_hook.py
@@ -51,6 +51,41 @@ def test_bad_neighbor_sampler_init_bad_seed_keys():
         )
 
 
+@pytest.mark.skip('TODO')
+def test_sample_with_node_events_seeds():
+    pass
+
+
+@pytest.mark.skip('TODO')
+def test_sample_with_None_seeds():
+    pass
+
+
+@pytest.mark.skip('TODO')
+def test_sample_with_non_existent_seeds():
+    pass
+
+
+@pytest.mark.skip('TODO')
+def test_bad_sample_with_non_tensor_non_None_seeds():
+    pass
+
+
+@pytest.mark.skip('TODO')
+def test_bad_sample_with_non_1d_tensor_seeds():
+    pass
+
+
+@pytest.mark.skip('TODO')
+def test_bad_sample_with_seeds_id_out_of_range():
+    pass
+
+
+@pytest.mark.skip('TODO')
+def test_bad_sample_with_seeds_time_out_of_range():
+    pass
+
+
 def test_neighbor_sampler_hook_link_pred(data):
     dg = DGraph(data)
     hook = NeighborSamplerHook(num_nbrs=[2])

--- a/test/unit/test_hooks/test_neighbor_sampler_hook.py
+++ b/test/unit/test_hooks/test_neighbor_sampler_hook.py
@@ -40,6 +40,17 @@ def test_bad_neighbor_sampler_init():
         NeighborSamplerHook(num_nbrs=[1, 0])
 
 
+def test_bad_neighbor_sampler_init_bad_seed_keys():
+    with pytest.raises(ValueError):
+        NeighborSamplerHook(num_nbrs=[1], seed_nodes_keys=['foo'])
+    with pytest.raises(ValueError):
+        NeighborSamplerHook(num_nbrs=[1], seed_times_keys=['foo'])
+    with pytest.raises(ValueError):
+        NeighborSamplerHook(
+            num_nbrs=[1], seed_nodes_keys=['foo', 'bar'], seed_times_keys=['foo']
+        )
+
+
 def test_neighbor_sampler_hook_link_pred(data):
     dg = DGraph(data)
     hook = NeighborSamplerHook(num_nbrs=[2])

--- a/test/unit/test_hooks/test_recency_nbr_hook.py
+++ b/test/unit/test_hooks/test_recency_nbr_hook.py
@@ -179,12 +179,24 @@ def test_sample_with_node_events_seeds(node_only_data):
     torch.testing.assert_close(batch.times[0], batch.node_times)
 
 
+def test_bad_sample_with_non_existent_seeds(basic_sample_graph):
+    dg = DGraph(basic_sample_graph)
+    hook = RecencyNeighborHook(
+        num_nbrs=[1], num_nodes=2, seed_nodes_keys=['foo'], seed_times_keys=['bar']
+    )
+    batch = dg.materialize()
+
+    with pytest.raises(ValueError):
+        _ = hook(dg, batch)
+
+
 def test_sample_with_none_seeds(basic_sample_graph):
     dg = DGraph(basic_sample_graph)
     hook = RecencyNeighborHook(
         num_nbrs=[1], num_nodes=2, seed_nodes_keys=['foo'], seed_times_keys=['bar']
     )
     batch = dg.materialize()
+    batch.foo, batch.bar = None, None
 
     with pytest.warns(UserWarning):
         batch = hook(dg, batch)

--- a/test/unit/test_hooks/test_recency_nbr_hook.py
+++ b/test/unit/test_hooks/test_recency_nbr_hook.py
@@ -149,6 +149,20 @@ def test_bad_neighbor_sampler_init():
         RecencyNeighborHook(num_nbrs=[], num_nodes=2)
 
 
+def test_bad_neighbor_sampler_init_bad_seed_keys():
+    with pytest.raises(ValueError):
+        RecencyNeighborHook(num_nbrs=[1], num_nodes=2, seed_nodes_keys=['foo'])
+    with pytest.raises(ValueError):
+        RecencyNeighborHook(num_nbrs=[1], num_nodes=2, seed_times_keys=['foo'])
+    with pytest.raises(ValueError):
+        RecencyNeighborHook(
+            num_nbrs=[1],
+            num_nodes=2,
+            seed_nodes_keys=['foo', 'bar'],
+            seed_times_keys=['foo'],
+        )
+
+
 def _nbrs_2_np(batch: DGBatch) -> List[np.ndarray]:
     assert isinstance(batch, DGBatch)
     assert hasattr(batch, 'nids')

--- a/test/unit/test_hooks/test_recency_nbr_hook.py
+++ b/test/unit/test_hooks/test_recency_nbr_hook.py
@@ -65,7 +65,12 @@ def test_hook_reset_state(basic_sample_graph):
 
     dg = DGraph(basic_sample_graph)
     n_nbrs = [1]  # 1 neighbor for each node
-    recency_hook = RecencyNeighborHook(num_nbrs=n_nbrs, num_nodes=dg.num_nodes)
+    recency_hook = RecencyNeighborHook(
+        num_nbrs=n_nbrs,
+        num_nodes=dg.num_nodes,
+        seed_nodes_keys=['src', 'dst'],
+        seed_times_keys=['time', 'time'],
+    )
     hm = HookManager(keys=['unit'])
     hm.register('unit', recency_hook)
     hm.set_active_hooks('unit')
@@ -142,18 +147,17 @@ def test_hook_reset_state(basic_sample_graph):
 
 def test_bad_neighbor_sampler_init():
     with pytest.raises(ValueError):
-        RecencyNeighborHook(num_nbrs=[0], num_nodes=2)
+        RecencyNeighborHook(
+            num_nbrs=[0], num_nodes=2, seed_nodes_keys=['foo'], seed_times_keys=['bar']
+        )
     with pytest.raises(ValueError):
-        RecencyNeighborHook(num_nbrs=[-1], num_nodes=2)
+        RecencyNeighborHook(
+            num_nbrs=[-1], num_nodes=2, seed_nodes_keys=['foo'], seed_times_keys=['bar']
+        )
     with pytest.raises(ValueError):
-        RecencyNeighborHook(num_nbrs=[], num_nodes=2)
-
-
-def test_bad_neighbor_sampler_init_bad_seed_keys():
-    with pytest.raises(ValueError):
-        RecencyNeighborHook(num_nbrs=[1], num_nodes=2, seed_nodes_keys=['foo'])
-    with pytest.raises(ValueError):
-        RecencyNeighborHook(num_nbrs=[1], num_nodes=2, seed_times_keys=['foo'])
+        RecencyNeighborHook(
+            num_nbrs=[], num_nodes=2, seed_nodes_keys=['foo'], seed_times_keys=['bar']
+        )
     with pytest.raises(ValueError):
         RecencyNeighborHook(
             num_nbrs=[1],
@@ -275,7 +279,12 @@ def _nbrs_2_np(batch: DGBatch) -> List[np.ndarray]:
 def test_init_basic_sampled_graph_1_hop(basic_sample_graph):
     dg = DGraph(basic_sample_graph)
     n_nbrs = [1]  # 1 neighbor for each node
-    recency_hook = RecencyNeighborHook(num_nbrs=n_nbrs, num_nodes=dg.num_nodes)
+    recency_hook = RecencyNeighborHook(
+        num_nbrs=n_nbrs,
+        num_nodes=dg.num_nodes,
+        seed_nodes_keys=['src', 'dst'],
+        seed_times_keys=['time', 'time'],
+    )
     hm = HookManager(keys=['unit'])
     hm.register('unit', recency_hook)
     hm.set_active_hooks('unit')
@@ -347,7 +356,11 @@ def test_init_basic_sampled_graph_directed_1_hop(basic_sample_graph):
     dg = DGraph(basic_sample_graph)
     n_nbrs = [1]  # 1 neighbor for each node
     recency_hook = RecencyNeighborHook(
-        num_nbrs=n_nbrs, num_nodes=dg.num_nodes, directed=True
+        num_nbrs=n_nbrs,
+        num_nodes=dg.num_nodes,
+        seed_nodes_keys=['src', 'dst'],
+        seed_times_keys=['time', 'time'],
+        directed=True,
     )
     hm = HookManager(keys=['unit'])
     hm.register('unit', recency_hook)
@@ -443,7 +456,12 @@ def recency_buffer_graph():
 def test_recency_exceed_buffer(recency_buffer_graph):
     dg = DGraph(recency_buffer_graph)
     n_nbrs = [2]  # 2 neighbors for each node
-    recency_hook = RecencyNeighborHook(num_nbrs=n_nbrs, num_nodes=dg.num_nodes)
+    recency_hook = RecencyNeighborHook(
+        num_nbrs=n_nbrs,
+        num_nodes=dg.num_nodes,
+        seed_nodes_keys=['src', 'dst'],
+        seed_times_keys=['time', 'time'],
+    )
     hm = HookManager(keys=['unit'])
     hm.register('unit', recency_hook)
     hm.set_active_hooks('unit')
@@ -510,7 +528,12 @@ def two_hop_basic_graph():
 def test_2_hop_graph(two_hop_basic_graph):
     dg = DGraph(two_hop_basic_graph)
     n_nbrs = [1, 1]  # 1 neighbor for each node
-    recency_hook = RecencyNeighborHook(num_nbrs=n_nbrs, num_nodes=dg.num_nodes)
+    recency_hook = RecencyNeighborHook(
+        num_nbrs=n_nbrs,
+        num_nodes=dg.num_nodes,
+        seed_nodes_keys=['src', 'dst'],
+        seed_times_keys=['time', 'time'],
+    )
     hm = HookManager(keys=['unit'])
     hm.register('unit', recency_hook)
     hm.set_active_hooks('unit')
@@ -594,7 +617,11 @@ def test_2_hop_directed_graph(two_hop_basic_graph):
     dg = DGraph(two_hop_basic_graph)
     n_nbrs = [1, 1]  # 1 neighbor for each node
     recency_hook = RecencyNeighborHook(
-        num_nbrs=n_nbrs, num_nodes=dg.num_nodes, directed=True
+        num_nbrs=n_nbrs,
+        num_nodes=dg.num_nodes,
+        seed_nodes_keys=['src', 'dst'],
+        seed_times_keys=['time', 'time'],
+        directed=True,
     )
     hm = HookManager(keys=['unit'])
     hm.register('unit', recency_hook)
@@ -688,7 +715,12 @@ def test_tgb_non_time_respecting_negative_neighbor_sampling_test(
     tgb_hook = TGBNegativeEdgeSamplerHook(dataset_name='foo', split_mode='val')
 
     n_nbrs = [1, 1]  # 1 neighbor for each node
-    recency_hook = RecencyNeighborHook(num_nbrs=n_nbrs, num_nodes=dg.num_nodes)
+    recency_hook = RecencyNeighborHook(
+        num_nbrs=n_nbrs,
+        num_nodes=dg.num_nodes,
+        seed_nodes_keys=['src', 'dst', 'neg'],
+        seed_times_keys=['time', 'time', 'neg_time'],
+    )
     hm = HookManager(keys=['unit'])
     hm.register('unit', tgb_hook)
     hm.register('unit', recency_hook)
@@ -805,6 +837,8 @@ def test_no_edge_feat_recency_nbr_sampler(no_edge_feat_data):
     recency_hook = RecencyNeighborHook(
         num_nbrs=n_nbrs,
         num_nodes=dg.num_nodes,
+        seed_nodes_keys=['src', 'dst'],
+        seed_times_keys=['time', 'time'],
         directed=True,
     )
     hm = HookManager(keys=['unit'])
@@ -846,6 +880,8 @@ def test_node_only_batch_recency_nbr_sampler(node_only_data):
     recency_hook = RecencyNeighborHook(
         num_nbrs=n_nbrs,
         num_nodes=dg.num_nodes,
+        seed_nodes_keys=['src', 'dst'],
+        seed_times_keys=['time', 'time'],
         directed=True,
     )
     hm = HookManager(keys=['unit'])

--- a/test/unit/test_hooks/test_recency_nbr_hook.py
+++ b/test/unit/test_hooks/test_recency_nbr_hook.py
@@ -163,6 +163,41 @@ def test_bad_neighbor_sampler_init_bad_seed_keys():
         )
 
 
+@pytest.mark.skip('TODO')
+def test_sample_with_node_events_seeds():
+    pass
+
+
+@pytest.mark.skip('TODO')
+def test_sample_with_None_seeds():
+    pass
+
+
+@pytest.mark.skip('TODO')
+def test_sample_with_non_existent_seeds():
+    pass
+
+
+@pytest.mark.skip('TODO')
+def test_bad_sample_with_non_tensor_non_None_seeds():
+    pass
+
+
+@pytest.mark.skip('TODO')
+def test_bad_sample_with_non_1d_tensor_seeds():
+    pass
+
+
+@pytest.mark.skip('TODO')
+def test_bad_sample_with_seeds_id_out_of_range():
+    pass
+
+
+@pytest.mark.skip('TODO')
+def test_bad_sample_with_seeds_time_out_of_range():
+    pass
+
+
 def _nbrs_2_np(batch: DGBatch) -> List[np.ndarray]:
     assert isinstance(batch, DGBatch)
     assert hasattr(batch, 'nids')

--- a/tgm/hooks/hooks.py
+++ b/tgm/hooks/hooks.py
@@ -209,7 +209,7 @@ class NeighborSamplerHook(StatelessHook):
                                                If not specified, defaults to batch times: ['time', 'time']
 
     Note:
-        The order of the ouput tensors respect the order of seed_nodes_keys.
+        The order of the output tensors respect the order of seed_nodes_keys.
         For instance, the default keys ['src', 'dst', 'neg'] will have the first output index (hop 0) contain the concatenation
         of batch.src, batch.dst, batch.neg (in that order). The next index (hop 1) will contain first-hop neighbors of batch.src
         followed by first-hop neighbors of batch.dst, and then those of batch.neg. This pattern repeats for deeper hops.
@@ -384,7 +384,7 @@ class RecencyNeighborHook(StatefulHook):
                                                If not specified, defaults to batch times: ['time', 'time']
 
     Note:
-        The order of the ouput tensors respect the order of seed_nodes_keys.
+        The order of the output tensors respect the order of seed_nodes_keys.
         For instance, the default keys ['src', 'dst'] will have the first output index (hop 0) contain the concatenation
         of batch.src, batch.dst, (in that order). The next index (hop 1) will contain first-hop neighbors of batch.src
         followed by first-hop neighbors of batch.dst. This pattern repeats for deeper hops.

--- a/tgm/hooks/hooks.py
+++ b/tgm/hooks/hooks.py
@@ -208,6 +208,12 @@ class NeighborSamplerHook(StatelessHook):
         seed_times_keys (Optional[List[str]]): List of batch attribute keys to identify the initial seed times to sample for.
                                                If not specified, defaults to batch times: ['time', 'time', 'neg_time']
 
+    Note:
+        The order of the ouput tensors respect the order of seed_nodes_keys.
+        For instance, the default keys ['src', 'dst', 'neg'] will have the first output index (hop 0) contain the concatenation
+        of batch.src, batch.dst, batch.neg (in that order). The next index (hop 1) will contain first-hop neighbors of batch.src
+        followed by first-hop neighbors of batch.dst, and then those of batch.neg. This pattern repeats for deeper hops.
+
     Raises:
         ValueError: If the num_nbrs list is empty or has non-positive entries.
         ValueError: If len(seed_nodes_keys) != len(seed_times_keys).
@@ -371,6 +377,12 @@ class RecencyNeighborHook(StatefulHook):
                                                If not specified, defaults to batch edges: ['src', 'dst', 'neg']
         seed_times_keys (Optional[List[str]]): List of batch attribute keys to identify the initial seed times to sample for.
                                                If not specified, defaults to batch times: ['time', 'time', 'neg_time']
+
+    Note:
+        The order of the ouput tensors respect the order of seed_nodes_keys.
+        For instance, the default keys ['src', 'dst', 'neg'] will have the first output index (hop 0) contain the concatenation
+        of batch.src, batch.dst, batch.neg (in that order). The next index (hop 1) will contain first-hop neighbors of batch.src
+        followed by first-hop neighbors of batch.dst, and then those of batch.neg. This pattern repeats for deeper hops.
 
     Raises:
         ValueError: If the num_nbrs list is empty or has non-positive entries.

--- a/tgm/hooks/hooks.py
+++ b/tgm/hooks/hooks.py
@@ -291,6 +291,7 @@ class NeighborSamplerHook(StatelessHook):
 
         seed_nodes, seed_times = self._get_seed_tensors(batch)
         if not seed_nodes.numel():
+            logger.debug('No seed_nodes found, appending empty hop information')
             for _ in self.num_nbrs:
                 _append_empty_hop()
             return batch
@@ -331,8 +332,16 @@ class NeighborSamplerHook(StatelessHook):
         # Implicitly add negatives to seed nodes and query times if they exist
         seed_nodes_keys, seed_times_keys = self._seed_nodes_keys, self._seed_times_keys
         if hasattr(batch, 'neg'):
+            logger.debug(
+                'Found negative edges in the batch, adding "neg" and "neg_time" to '
+                'seed_nodes_keys and seed_times_keys, respectively'
+            )
             seed_nodes_keys.append('neg')
             seed_times_keys.append('neg_time')
+
+        logger.debug(
+            'Seed nodes keys: %s, Seed times keys: %s', seed_nodes_keys, seed_times_keys
+        )
 
         for node_attr, time_attr in zip(seed_nodes_keys, seed_times_keys):
             missing = [
@@ -349,6 +358,9 @@ class NeighborSamplerHook(StatelessHook):
                 # be missing certain attributes (e.g. dynamic node events), but for
                 # non-Tensor and non-None attrs we explicitly raise
                 if tensor is None:
+                    logger.debug(
+                        'Seed attribute %s is None on this batch, skipping', name
+                    )
                     warnings.warn(
                         f'Seed attribute {name} is None on this batch, skipping',
                         UserWarning,
@@ -493,6 +505,7 @@ class RecencyNeighborHook(StatefulHook):
 
         seed_nodes, seed_times = self._get_seed_tensors(batch)
         if not seed_nodes.numel():
+            logger.debug('No seed_nodes found, appending empty hop information')
             for _ in self.num_nbrs:
                 _append_empty_hop()
             return batch
@@ -530,8 +543,16 @@ class RecencyNeighborHook(StatefulHook):
         # Implicitly add negatives to seed nodes and query times if they exist
         seed_nodes_keys, seed_times_keys = self._seed_nodes_keys, self._seed_times_keys
         if hasattr(batch, 'neg'):
+            logger.debug(
+                'Found negative edges in the batch, adding "neg" and "neg_time" to '
+                'seed_nodes_keys and seed_times_keys, respectively'
+            )
             seed_nodes_keys.append('neg')
             seed_times_keys.append('neg_time')
+
+        logger.debug(
+            'Seed nodes keys: %s, Seed times keys: %s', seed_nodes_keys, seed_times_keys
+        )
 
         for node_attr, time_attr in zip(seed_nodes_keys, seed_times_keys):
             missing = [
@@ -548,6 +569,9 @@ class RecencyNeighborHook(StatefulHook):
                 # be missing certain attributes (e.g. dynamic node events), but for
                 # non-Tensor and non-None attrs we explicitly raise
                 if tensor is None:
+                    logger.debug(
+                        'Seed attribute %s is None on this batch, skipping', name
+                    )
                     warnings.warn(
                         f'Seed attribute {name} is None on this batch, skipping',
                         UserWarning,

--- a/tgm/hooks/hooks.py
+++ b/tgm/hooks/hooks.py
@@ -256,20 +256,23 @@ class NeighborSamplerHook(StatelessHook):
         batch.nbr_nids, batch.nbr_times = [], []  # type: ignore
         batch.nbr_feats = []  # type: ignore
 
+        def _append_empty_hop() -> None:
+            batch.nids.append(torch.empty(0, dtype=torch.int32))  # type: ignore
+            batch.times.append(torch.empty(0, dtype=torch.int64))  # type: ignore
+            batch.nbr_nids.append(torch.empty(0, dtype=torch.int32))  # type: ignore
+            batch.nbr_times.append(torch.empty(0, dtype=torch.int64))  # type: ignore
+            batch.nbr_feats.append(  # type: ignore
+                torch.empty(0, dg.edge_feats_dim).float()  # type: ignore
+            )
+
+        seed_nodes, seed_times = self._get_seed_tensors(batch)
+        if not seed_nodes.numel():
+            for _ in self.num_nbrs:
+                _append_empty_hop()
+            return batch
+
         for hop, num_nbrs in enumerate(self.num_nbrs):
-            if hop == 0:
-                seed_nodes, seed_times = self._get_seed_tensors(batch)
-                if seed_nodes.numel() == 0:
-                    for hop in range(len(self.num_nbrs)):
-                        batch.nids.append(torch.empty(0, dtype=torch.int32))  # type: ignore
-                        batch.times.append(torch.empty(0, dtype=torch.int64))  # type: ignore
-                        batch.nbr_nids.append(torch.empty(0, dtype=torch.int32))  # type: ignore
-                        batch.nbr_times.append(torch.empty(0, dtype=torch.int64))  # type: ignore
-                        batch.nbr_feats.append(  # type: ignore
-                            torch.empty(0, dg.edge_feats_dim).float()  # type: ignore
-                        )
-                    return batch
-            else:
+            if hop > 0:
                 seed_nodes = batch.nbr_nids[hop - 1].flatten()  # type: ignore
                 seed_times = batch.nbr_times[hop - 1].flatten()  # type: ignore
 
@@ -414,20 +417,23 @@ class RecencyNeighborHook(StatefulHook):
         batch.nbr_nids, batch.nbr_times = [], []  # type: ignore
         batch.nbr_feats = []  # type: ignore
 
+        def _append_empty_hop() -> None:
+            batch.nids.append(torch.empty(0, dtype=torch.int32))  # type: ignore
+            batch.times.append(torch.empty(0, dtype=torch.int64))  # type: ignore
+            batch.nbr_nids.append(torch.empty(0, dtype=torch.int32))  # type: ignore
+            batch.nbr_times.append(torch.empty(0, dtype=torch.int64))  # type: ignore
+            batch.nbr_feats.append(  # type: ignore
+                torch.empty(0, dg.edge_feats_dim).float()  # type: ignore
+            )
+
+        seed_nodes, seed_times = self._get_seed_tensors(batch)
+        if not seed_nodes.numel():
+            for _ in self.num_nbrs:
+                _append_empty_hop()
+            return batch
+
         for hop, num_nbrs in enumerate(self.num_nbrs):
-            if hop == 0:
-                seed_nodes, seed_times = self._get_seed_tensors(batch)
-                if seed_nodes.numel() == 0:
-                    for hop in range(len(self.num_nbrs)):
-                        batch.nids.append(torch.empty(0, dtype=torch.int32))  # type: ignore
-                        batch.times.append(torch.empty(0, dtype=torch.int64))  # type: ignore
-                        batch.nbr_nids.append(torch.empty(0, dtype=torch.int32))  # type: ignore
-                        batch.nbr_times.append(torch.empty(0, dtype=torch.int64))  # type: ignore
-                        batch.nbr_feats.append(  # type: ignore
-                            torch.empty(0, self._edge_feats_dim).float()  # type: ignore
-                        )
-                    return batch
-            else:
+            if hop > 0:
                 seed_nodes = batch.nbr_nids[hop - 1].flatten()  # type: ignore
                 seed_times = batch.nbr_times[hop - 1].flatten()  # type: ignore
 

--- a/tgm/hooks/hooks.py
+++ b/tgm/hooks/hooks.py
@@ -5,8 +5,6 @@ from dataclasses import is_dataclass
 from pathlib import Path
 from typing import Any, List, Set, Tuple
 
-warnings.simplefilter('once', UserWarning)  # Only emit each warning in this module once
-
 import torch
 
 from tgm import DGBatch, DGraph
@@ -260,6 +258,7 @@ class NeighborSamplerHook(StatelessHook):
             self._seed_nodes_keys,
             self._seed_times_keys,
         )
+        self._warned_seed_None = False
 
     @property
     def num_nbrs(self) -> List[int]:
@@ -337,10 +336,13 @@ class NeighborSamplerHook(StatelessHook):
                     logger.debug(
                         'Seed attribute %s is None on this batch, skipping', name
                     )
-                    warnings.warn(
-                        f'Seed attribute {name} is None on this batch, skipping',
-                        UserWarning,
-                    )
+                    if not self._warned_seed_None:
+                        warnings.warn(
+                            f'Seed attribute {name} is None on this batch, skipping this batch. '
+                            'Future occurences will also be skipped but the warning will be suppressed',
+                            UserWarning,
+                        )
+                        self._warned_seed_None = True
                     break
                 if not isinstance(tensor, torch.Tensor):
                     raise ValueError(f'{name} must be a Tensor, got {type(tensor)}')
@@ -431,6 +433,7 @@ class RecencyNeighborHook(StatefulHook):
             self._seed_nodes_keys,
             self._seed_times_keys,
         )
+        self._warned_seed_None = False
 
         self._nbr_ids = torch.full(
             (num_nodes, self._max_nbrs), PADDED_NODE_ID, dtype=torch.int32
@@ -527,10 +530,13 @@ class RecencyNeighborHook(StatefulHook):
                     logger.debug(
                         'Seed attribute %s is None on this batch, skipping', name
                     )
-                    warnings.warn(
-                        f'Seed attribute {name} is None on this batch, skipping',
-                        UserWarning,
-                    )
+                    if not self._warned_seed_None:
+                        warnings.warn(
+                            f'Seed attribute {name} is None on this batch, skipping this batch. '
+                            'Future occurences will also be skipped but the warning will be suppressed',
+                            UserWarning,
+                        )
+                        self._warned_seed_None = True
                     break
                 if not isinstance(tensor, torch.Tensor):
                     raise ValueError(f'{name} must be a Tensor, got {type(tensor)}')

--- a/tgm/hooks/hooks.py
+++ b/tgm/hooks/hooks.py
@@ -249,7 +249,6 @@ class NeighborSamplerHook(StatelessHook):
             raise ValueError('num_nbrs must be non-empty')
         if not all([isinstance(x, int) and (x > 0) for x in num_nbrs]):
             raise ValueError('Each value in num_nbrs must be a positive integer')
-
         self._num_nbrs = num_nbrs
         self._directed = directed
 

--- a/tgm/hooks/hooks.py
+++ b/tgm/hooks/hooks.py
@@ -308,7 +308,6 @@ class NeighborSamplerHook(StatelessHook):
         return batch
 
     def _get_seed_tensors(self, batch: DGBatch) -> Tuple[torch.Tensor, torch.Tensor]:
-        # TODO: Need a bounds check on seed nodes and seed times
         device = batch.src.device
         seeds, times = [], []
 

--- a/tgm/hooks/hooks.py
+++ b/tgm/hooks/hooks.py
@@ -349,8 +349,11 @@ class NeighborSamplerHook(StatelessHook):
             seeds.append(seed.to(device))
             times.append(time.to(device))
 
-        seed_nodes = torch.cat(seeds)
-        seed_times = torch.cat(times)
+        if seeds and times:
+            seed_nodes, seed_times = torch.cat(seeds), torch.cat(times)
+        else:
+            seed_nodes = torch.empty(0, dtype=torch.int32, device=device)
+            seed_times = torch.empty(0, dtype=torch.int64, device=device)
         return seed_nodes, seed_times
 
 
@@ -524,8 +527,11 @@ class RecencyNeighborHook(StatefulHook):
             seeds.append(seed.to(device))
             times.append(time.to(device))
 
-        seed_nodes = torch.cat(seeds)
-        seed_times = torch.cat(times)
+        if seeds and times:
+            seed_nodes, seed_times = torch.cat(seeds), torch.cat(times)
+        else:
+            seed_nodes = torch.empty(0, dtype=torch.int32, device=device)
+            seed_times = torch.empty(0, dtype=torch.int64, device=device)
         return seed_nodes, seed_times
 
     def _get_recency_neighbors(

--- a/tgm/hooks/hooks.py
+++ b/tgm/hooks/hooks.py
@@ -339,7 +339,7 @@ class NeighborSamplerHook(StatelessHook):
                     if not self._warned_seed_None:
                         warnings.warn(
                             f'Seed attribute {name} is None on this batch, skipping this batch. '
-                            'Future occurences will also be skipped but the warning will be suppressed',
+                            'Future occurrences will also be skipped but the warning will be suppressed',
                             UserWarning,
                         )
                         self._warned_seed_None = True
@@ -533,7 +533,7 @@ class RecencyNeighborHook(StatefulHook):
                     if not self._warned_seed_None:
                         warnings.warn(
                             f'Seed attribute {name} is None on this batch, skipping this batch. '
-                            'Future occurences will also be skipped but the warning will be suppressed',
+                            'Future occurrences will also be skipped but the warning will be suppressed',
                             UserWarning,
                         )
                         self._warned_seed_None = True

--- a/tgm/hooks/hooks.py
+++ b/tgm/hooks/hooks.py
@@ -273,7 +273,7 @@ class NeighborSamplerHook(StatelessHook):
                 seed_nodes = batch.nbr_nids[hop - 1].flatten()  # type: ignore
                 seed_times = batch.nbr_times[hop - 1].flatten()  # type: ignore
 
-            # TODO: Device management
+            # TODO: Storage needs to use the right device
 
             # We slice on batch.start_time so that we only consider neighbor events
             # that occurred strictly before this batch

--- a/tgm/hooks/hooks.py
+++ b/tgm/hooks/hooks.py
@@ -298,6 +298,7 @@ class NeighborSamplerHook(StatelessHook):
         return batch
 
     def _get_seed_tensors(self, batch: DGBatch) -> Tuple[torch.Tensor, torch.Tensor]:
+        # TODO: Need a bounds check on seed nodes and seed times
         device = batch.src.device
         seeds, times = [], []
 
@@ -461,6 +462,7 @@ class RecencyNeighborHook(StatefulHook):
         return batch
 
     def _get_seed_tensors(self, batch: DGBatch) -> Tuple[torch.Tensor, torch.Tensor]:
+        # TODO: Need a bounds check on seed nodes and seed times
         device = batch.src.device
         seeds, times = [], []
 


### PR DESCRIPTION
#### Overview
The purpose of this PR is to enable customization of the seed node and query times to start your neighbor sampling; i.e. the query on the first hop. Subsequent hops bootstrap from this (assuming it's not empty).

This involves paramaterizing two fields:
1. `seed_nodes_keys`: The node ids to start sampling from
2. `seed_times_keys`: The query times to sample from

#### Notes
- by default, we will use the link prediction seed set (`seed_nodes_keys` = ['src', 'dst', 'neg'], `seed_times_keys` = ['time', 'time', 'neg_time']
- TGN node prop is the only current use case that switches it up, using the dyamic node events as it's sampling seeds
- did some clean up of the recent additions to the nbr hooks which were messy
- unified more of the api across samplers so that in the future we can merge their API completely (or create base nbr sampling hook interface)

#### Corner cases
The user could technically specify atrbitrary attrs on the batch. These are the rules I followed
- If a batch is missing the attributes requested, we emit a _1-time UserWarning_ to signal to the user, something could be off. Keep in mind, it could very well be that an attribute does not exist on a given batch (but this is unlikely, it would probably be set to `None` in that case). We _could_ consider raising an exception here.
- If the batch attribute is there, but is `None` (e.g. dynamic node events exist, but not on the current batch), then we emit a _1-time_ UserWarning.
- If the batch attribute is not an `Optional[Tensor]` or is a tensor, but is not 1-dimensional, we raise a ValueError. We can't reasonable recover from these
- If the batch attribute is a 1d tensor, but has value out of range, we raise a ValueError as we can't recover. Bad seed times are any negative timestamps. Bad seed node ids are any ids that are either negative, or > than number of nodes on the graph. (Technically, we could bypass this by just considering this an empty batch instead of throwing a runtimeerorr....)

If after these filters we end up with no seed nodes, we return empty tensors as per the convention established in #150. 

#### Out of scope
- If we really want to support generic ids / times, we should also handle upcasting/downcasting dtypes, device transfer, and potentially more to ensure our sampler doesn't raise an uncaught exception. 
- Uniform sampler does not direclty have knowledge of number of nodes in the graph. I'm considering dropping `num_nodes` from recnecy API, and have both samplers dynamically infer it on the first batch (similar to edge feats dim #278 ). To be discussed since you may want to in fact run recency on a subset of nodes (in which case, it should be a default argument in _both_ samplers).

**To be discussed**
- Consider raising an exception on missing attribute. Users should follow our convention and use None if it's not present on the batch.
- Whether we want to make the `num_nodes` api change for beta.

Close #250 