### PR TITLE
Fixed edge_event_idx and node_event_idx bugs

### DIFF
--- a/test/unit/test_data/test_data.py
+++ b/test/unit/test_data/test_data.py
@@ -152,11 +152,11 @@ def test_init_dg_data_sort_required():
     torch.testing.assert_close(data.edge_index, exp_edge_index)
     torch.testing.assert_close(data.timestamps, torch.LongTensor([1, 5, 6, 7, 8]))
     torch.testing.assert_close(data.edge_feats, exp_edge_feats)
-    torch.testing.assert_close(data.edge_event_idx, torch.IntTensor([1, 0]))
+    torch.testing.assert_close(data.edge_event_idx, torch.IntTensor([0, 1]))
     torch.testing.assert_close(
         data.node_event_idx,
         torch.IntTensor(
-            [4, 3, 2],
+            [2, 3, 4],
         ),
     )
     torch.testing.assert_close(data.node_ids, exp_node_ids)

--- a/tgm/data/dg_data.py
+++ b/tgm/data/dg_data.py
@@ -298,6 +298,7 @@ class DGData:
 
             # Reorder edge-specific data
             edge_order = torch.argsort(self.edge_event_idx)
+            self.edge_event_idx = self.edge_event_idx[edge_order]
             self.edge_index = self.edge_index[edge_order]
             if self.edge_feats is not None:
                 self.edge_feats = self.edge_feats[edge_order]
@@ -305,6 +306,7 @@ class DGData:
             # Reorder node-specific data
             if self.node_event_idx is not None:
                 node_order = torch.argsort(self.node_event_idx)
+                self.node_event_idx = self.node_event_idx[node_order]
                 self.node_ids = self.node_ids[node_order]  # type: ignore
                 if self.dynamic_node_feats is not None:
                     self.dynamic_node_feats = self.dynamic_node_feats[node_order]


### PR DESCRIPTION
### Summary / Description

As suggested by @shenyangHuang, I made this as a separate PR. I believe this is quite critical and needs to go soon.

It are about [updating `edge_event_idx` ](https://github.com/tgm-team/tgm/blob/5e0c4c7d2e9adbc8aa8f77374c88b221654df5ec/tgm/data/dg_data.py#L301) and [updating `node_event_idx`](https://github.com/tgm-team/tgm/blob/5e0c4c7d2e9adbc8aa8f77374c88b221654df5ec/tgm/data/dg_data.py#L312). If we check 1 line above, we will see that we call `torch.argsort` and update edge_idx and node_ids but we forgot to update `edge_event_idx` and `node_event_idx`. 

**Related Issues:** #372

#### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking Change
- [ ] Refactoring
- [ ] Documentation update

#### Test Evidence

Describe how this PR has been tested.

- [x] Unit tests
- [ ] Integration tests
- [ ] Performance tests

#### Questions / Discussion Points

List any areas where you’d like reviewer input or have open questions.
