### PR TITLE
Make hooks seedable and added instance-level properties

### DIFF
--- a/examples/linkproppred/tgn.py
+++ b/examples/linkproppred/tgn.py
@@ -205,7 +205,7 @@ hm = RecipeRegistry.build(
 )
 train_key, val_key, test_key = hm.keys
 hm.register_shared(nbr_hook)
-hm.register_shared(DeduplicationHook(seed_nodes_keys=['neg','nbr_nids']))
+hm.register_shared(DeduplicationHook(seed_nodes_keys=['neg', 'nbr_nids']))
 
 train_loader = DGDataLoader(train_dg, args.bsize, hook_manager=hm)
 val_loader = DGDataLoader(val_dg, args.bsize, hook_manager=hm)

--- a/examples/linkproppred/tgn.py
+++ b/examples/linkproppred/tgn.py
@@ -205,7 +205,7 @@ hm = RecipeRegistry.build(
 )
 train_key, val_key, test_key = hm.keys
 hm.register_shared(nbr_hook)
-hm.register_shared(DeduplicationHook())
+hm.register_shared(DeduplicationHook(seed_nodes_keys=['neg','nbr_nids']))
 
 train_loader = DGDataLoader(train_dg, args.bsize, hook_manager=hm)
 val_loader = DGDataLoader(val_dg, args.bsize, hook_manager=hm)

--- a/test/unit/test_hooks/test_batch_analytics_hook.py
+++ b/test/unit/test_hooks/test_batch_analytics_hook.py
@@ -83,8 +83,6 @@ def test_basic_analytics_num_events_and_timestamps(dg):
     batch = dg.materialize()
     processed_batch = hook(dg, batch)
 
-    # assert batch.node_x_nids is not None
-
     # edge and node events
     assert processed_batch.num_edge_events == 3
     assert processed_batch.num_node_events == 3
@@ -144,3 +142,24 @@ def test_basic_analytics_empty_edges_and_nodes(dg):
 
     # _count_repeated_node_events: node_x_nids.numel() == 0 -> 0
     assert processed_batch.num_repeated_node_events == 0
+
+
+def test_hook_with_id(dg):
+    hook = BatchAnalyticsHook(id='foo')
+    batch = dg.materialize()
+
+    batch = dg.materialize()
+    processed_batch = hook(dg, batch)
+
+    expected_produce = [
+        'num_edge_events_foo',
+        'num_node_events_foo',
+        'num_unique_timestamps_foo',
+        'num_unique_nodes_foo',
+        'avg_degree_foo',
+        'num_repeated_edge_events_foo',
+        'num_repeated_node_events_foo',
+    ]
+
+    for produce in expected_produce:
+        assert hasattr(processed_batch, produce)

--- a/test/unit/test_hooks/test_batch_analytics_hook.py
+++ b/test/unit/test_hooks/test_batch_analytics_hook.py
@@ -69,6 +69,11 @@ def test_hook_dependancies():
     }
 
 
+def test_hook_repre():
+    hook_with_id = BatchAnalyticsHook(id='foo')
+    assert 'foo' in hook_with_id.__repr__()
+
+
 def test_hook_reset_state():
     assert BatchAnalyticsHook.has_state is False
 

--- a/test/unit/test_hooks/test_batch_analytics_hook.py
+++ b/test/unit/test_hooks/test_batch_analytics_hook.py
@@ -50,6 +50,24 @@ def test_hook_dependancies():
         'num_repeated_node_events',
     }
 
+    hook_with_id = BatchAnalyticsHook(id='foo')
+    assert hook_with_id.requires == {
+        'edge_src',
+        'edge_dst',
+        'edge_time',
+        'node_x_time',
+        'node_x_nids',
+    }
+    assert hook_with_id.produces == {
+        'num_edge_events_foo',
+        'num_node_events_foo',
+        'num_unique_timestamps_foo',
+        'num_unique_nodes_foo',
+        'avg_degree_foo',
+        'num_repeated_edge_events_foo',
+        'num_repeated_node_events_foo',
+    }
+
 
 def test_hook_reset_state():
     assert BatchAnalyticsHook.has_state is False

--- a/test/unit/test_hooks/test_deduplication_hook.py
+++ b/test/unit/test_hooks/test_deduplication_hook.py
@@ -49,6 +49,21 @@ def test_dedup(dg):
     )
 
 
+def test_dedup_with_id(dg):
+    hook = DeduplicationHook(id='foo')
+    batch = dg.materialize()
+    processed_batch = hook(dg, batch)
+    torch.testing.assert_close(
+        processed_batch.unique_nids_foo, torch.IntTensor([1, 2, 4, 8])
+    )
+    torch.testing.assert_close(
+        processed_batch.global_to_local_foo(batch.edge_src), torch.IntTensor([1, 1, 0])
+    )
+    torch.testing.assert_close(
+        processed_batch.global_to_local_foo(batch.edge_dst), torch.IntTensor([1, 2, 3])
+    )
+
+
 def test_dedup_with_negatives(dg):
     hook = DeduplicationHook(seed_nodes_keys=['neg'])
     batch = dg.materialize()

--- a/test/unit/test_hooks/test_deduplication_hook.py
+++ b/test/unit/test_hooks/test_deduplication_hook.py
@@ -25,6 +25,11 @@ def test_hook_dependancies():
     assert hook_with_id.produces == {'unique_nids_foo', 'global_to_local_foo'}
 
 
+def test_hook_repre():
+    hook_with_id = DeduplicationHook(id='foo')
+    assert 'foo' in hook_with_id.__repr__()
+
+
 def test_hook_reset_state():
     assert DeduplicationHook.has_state == False
 

--- a/test/unit/test_hooks/test_deduplication_hook.py
+++ b/test/unit/test_hooks/test_deduplication_hook.py
@@ -41,7 +41,7 @@ def test_dedup(dg):
 
 
 def test_dedup_with_negatives(dg):
-    hook = DeduplicationHook()
+    hook = DeduplicationHook(seed_nodes_keys=['neg'])
     batch = dg.materialize()
     batch.neg = torch.IntTensor([1, 5, 10])  # add some mock negatives
 
@@ -61,7 +61,7 @@ def test_dedup_with_negatives(dg):
 
 
 def test_dedup_with_nbrs(dg):
-    hook = DeduplicationHook()
+    hook = DeduplicationHook(seed_nodes_keys=['nbr_nids'])
     batch = dg.materialize()
     batch.nbr_nids = [  # add some mock neighbours
         torch.IntTensor([1, 5]),  # First hop
@@ -108,7 +108,7 @@ def node_only_graph():
 
 def test_dedup_node_only_batch(node_only_graph):
     hm = HookManager(keys=['unit'])
-    hm.register('unit', DeduplicationHook())
+    hm.register('unit', DeduplicationHook(seed_nodes_keys=['node_x_nids']))
     loader = DGDataLoader(node_only_graph, batch_size=3, hook_manager=hm)
     with hm.activate('unit'):
         batch_iter = iter(loader)

--- a/test/unit/test_hooks/test_deduplication_hook.py
+++ b/test/unit/test_hooks/test_deduplication_hook.py
@@ -16,8 +16,9 @@ def dg():
 
 
 def test_hook_dependancies():
-    assert DeduplicationHook.requires == {'edge_src', 'edge_dst'}
-    assert DeduplicationHook.produces == {'unique_nids', 'global_to_local'}
+    hook = DeduplicationHook()
+    assert hook.requires == {'edge_src', 'edge_dst'}
+    assert hook.produces == {'unique_nids', 'global_to_local'}
 
 
 def test_hook_reset_state():

--- a/test/unit/test_hooks/test_deduplication_hook.py
+++ b/test/unit/test_hooks/test_deduplication_hook.py
@@ -20,6 +20,10 @@ def test_hook_dependancies():
     assert hook.requires == {'edge_src', 'edge_dst'}
     assert hook.produces == {'unique_nids', 'global_to_local'}
 
+    hook_with_id = DeduplicationHook(id='foo')
+    assert hook_with_id.requires == {'edge_src', 'edge_dst'}
+    assert hook_with_id.produces == {'unique_nids_foo', 'global_to_local_foo'}
+
 
 def test_hook_reset_state():
     assert DeduplicationHook.has_state == False

--- a/test/unit/test_hooks/test_device_transfer_hook.py
+++ b/test/unit/test_hooks/test_device_transfer_hook.py
@@ -15,8 +15,9 @@ def dg():
 
 
 def test_hook_dependancies():
-    assert DeviceTransferHook.requires == set()
-    assert DeviceTransferHook.produces == set()
+    hook = DeviceTransferHook('cpu')
+    assert hook.requires == set()
+    assert hook.produces == set()
 
 
 def test_hook_reset_state():

--- a/test/unit/test_hooks/test_hook_manager.py
+++ b/test/unit/test_hooks/test_hook_manager.py
@@ -11,10 +11,11 @@ from tgm.hooks import HookManager, StatefulHook, StatelessHook
 
 
 class MockHook(StatelessHook):
+    _cls_produces = {'foo'}
+
     def __init__(self, id: str = None):
         super().__init__()
-        self.id = id
-        self.produces = {'foo'}
+        self._id = id
         self.__post_init__()
 
     def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:
@@ -23,10 +24,11 @@ class MockHook(StatelessHook):
 
 
 class MockHookRequires(StatelessHook):
+    _cls_requires = {'foo'}
+
     def __init__(self, id: str = None):
         super().__init__()
-        self.id = id
-        self.requires = {'foo'}
+        self._id = id
         self.__post_init__()
 
     def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:
@@ -34,10 +36,11 @@ class MockHookRequires(StatelessHook):
 
 
 class MockHookRequiresWoof(StatelessHook):
+    _cls_requires = {'foo_woof'}
+
     def __init__(self, id: str = None):
         super().__init__()
-        self.id = id
-        self.requires = {'foo_woof'}
+        self._id = id
         self.__post_init__()
 
     def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:
@@ -47,7 +50,7 @@ class MockHookRequiresWoof(StatelessHook):
 class MockHookWithState(StatefulHook):
     def __init__(self, id: str = None) -> None:
         super().__init__()
-        self.id = id
+        self._id = id
         self.has_state = True
         self.x = 0
 
@@ -180,8 +183,8 @@ def test_resolve_hooks_by_key():
 def test_resolve_hooks_no_solution_no_dag():
     h1 = MockHook()
     h2 = MockHook()
-    h1.requires, h1.produces = {'x'}, {'y'}
-    h2.requires, h2.produces = {'y'}, {'x'}
+    h1._requires, h1._produces = {'x'}, {'y'}
+    h2._requires, h2._produces = {'y'}, {'x'}
 
     # Cycle-like missing dependency
     hm = HookManager(keys=['train'])
@@ -225,8 +228,8 @@ def test_topo_sort_cached(dg, monkeypatch):
     hm = HookManager(keys=['train'])
 
     h1, h2 = MockHook(), MockHook()
-    h1.requires, h1.produces = set(), {'x'}
-    h2.requires, h2.produces = {'x'}, {'y'}
+    h1._requires, h1._produces = set(), {'x'}
+    h2._requires, h2._produces = {'x'}, {'y'}
 
     hm.register('train', h1)
     hm.register('train', h2)
@@ -252,7 +255,7 @@ def test_topo_sort_cached_invalidated(dg, monkeypatch):
     hm = HookManager(keys=['train'])
 
     h1 = MockHook()
-    h1.requires, h1.produces = set(), {'x'}
+    h1._requires, h1._produces = set(), {'x'}
 
     hm.register('train', h1)
     call_count = {'n': 0}
@@ -281,8 +284,8 @@ def test_topo_sort_cached_invalidated(dg, monkeypatch):
 def test_topo_sort_no_solution_no_dag(dg):
     h1 = MockHook()
     h2 = MockHook()
-    h1.requires, h1.produces = {'x'}, {'y'}
-    h2.requires, h2.produces = {'y'}, {'x'}
+    h1._requires, h1._produces = {'x'}, {'y'}
+    h2._requires, h2._produces = {'y'}, {'x'}
 
     # Cycle-like missing dependency
     hm = HookManager(keys=['train'])
@@ -377,8 +380,8 @@ def test_activate_ctx():
 
 def test_topo_sort_neg_before_nbr():
     mock_neg_hook, mock_nbr_hook = MockHook(), MockHook()
-    mock_neg_hook.requires, mock_neg_hook.produces = set(), {'neg'}
-    mock_nbr_hook.requires, mock_nbr_hook.produces = set(), {'nbr_nids'}
+    mock_neg_hook._requires, mock_neg_hook._produces = set(), {'neg'}
+    mock_nbr_hook._requires, mock_nbr_hook._produces = set(), {'nbr_nids'}
 
     # Register neg first in foo, nbr first in bar
     hm = HookManager(keys=['foo', 'bar'])

--- a/test/unit/test_hooks/test_hook_manager.py
+++ b/test/unit/test_hooks/test_hook_manager.py
@@ -11,7 +11,11 @@ from tgm.hooks import HookManager, StatefulHook, StatelessHook
 
 
 class MockHook(StatelessHook):
-    produces = {'foo'}
+    def __init__(self, id: str = None):
+        super().__init__()
+        self.id = id
+        self.produces = {'foo'}
+        self.__post_init__()
 
     def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:
         batch.edge_time *= 2
@@ -19,16 +23,32 @@ class MockHook(StatelessHook):
 
 
 class MockHookRequires(StatelessHook):
-    requires = {'foo'}
+    def __init__(self, id: str = None):
+        super().__init__()
+        self.id = id
+        self.requires = {'foo'}
+        self.__post_init__()
+
+    def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:
+        return batch
+
+
+class MockHookRequiresWoof(StatelessHook):
+    def __init__(self, id: str = None):
+        super().__init__()
+        self.id = id
+        self.requires = {'foo_woof'}
+        self.__post_init__()
 
     def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:
         return batch
 
 
 class MockHookWithState(StatefulHook):
-    has_state: bool = True
-
-    def __init__(self) -> None:
+    def __init__(self, id: str = None) -> None:
+        super().__init__()
+        self.id = id
+        self.has_state = True
         self.x = 0
 
     def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:
@@ -375,3 +395,15 @@ def test_topo_sort_neg_before_nbr():
     assert foo_hooks.index(mock_neg_hook) < foo_hooks.index(mock_nbr_hook)
     assert bar_hooks.index(mock_neg_hook) < bar_hooks.index(mock_nbr_hook)
 
+
+def test_resolve_hooks_with_id_by_key():
+    h1 = MockHook(id='woof')  # MockHook produces with _woof suffix
+    h2 = MockHookRequiresWoof()
+
+    hm = HookManager(keys=['train'])
+    hm.register('train', h2)
+    hm.register('train', h1)
+
+    hm.resolve_hooks('train')
+    assert len(hm._key_to_hooks['train']) == 2
+    assert hm._key_to_hooks['train'].index(h1) < hm._key_to_hooks['train'].index(h2)

--- a/test/unit/test_hooks/test_hook_manager.py
+++ b/test/unit/test_hooks/test_hook_manager.py
@@ -25,11 +25,6 @@ class MockHookRequires(StatelessHook):
         return batch
 
 
-class DeduplicationMockHook(StatelessHook):
-    def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:
-        return batch
-
-
 class MockHookWithState(StatefulHook):
     has_state: bool = True
 
@@ -380,26 +375,3 @@ def test_topo_sort_neg_before_nbr():
     assert foo_hooks.index(mock_neg_hook) < foo_hooks.index(mock_nbr_hook)
     assert bar_hooks.index(mock_neg_hook) < bar_hooks.index(mock_nbr_hook)
 
-
-def test_force_last_dedup_hook():
-    # @TODO: Dedup hook is temporarily forced to run at the end.
-    # This test potentially needs to be updated once instance-level require is introduced to DGHook.
-    h1 = MockHook()
-    h2 = MockHookRequires()
-    h3 = DeduplicationMockHook()
-
-    hm = HookManager(keys=['train', 'val'])
-    hm.register('train', h3)
-    hm.register('train', h2)
-    hm.register('train', h1)
-    hm.register('val', h3)
-    hm.register('val', h2)
-    hm.register('val', h1)
-
-    hm.resolve_hooks()
-    assert len(hm._key_to_hooks['train']) == 3
-    assert len(hm._key_to_hooks['val']) == 3
-    assert hm._key_to_hooks['train'].index(h1) < hm._key_to_hooks['train'].index(h2)
-    assert hm._key_to_hooks['val'].index(h1) < hm._key_to_hooks['val'].index(h2)
-    assert hm._key_to_hooks['train'].index(h2) < hm._key_to_hooks['train'].index(h3)
-    assert hm._key_to_hooks['val'].index(h2) < hm._key_to_hooks['val'].index(h3)

--- a/test/unit/test_hooks/test_negative_edge_sampler_hook.py
+++ b/test/unit/test_hooks/test_negative_edge_sampler_hook.py
@@ -14,8 +14,9 @@ def data():
 
 
 def test_hook_dependancies():
-    assert NegativeEdgeSamplerHook.requires == {'edge_src', 'edge_dst', 'edge_time'}
-    assert NegativeEdgeSamplerHook.produces == {'neg', 'neg_time'}
+    hook = NegativeEdgeSamplerHook(low=0, high=10)
+    assert hook.requires == {'edge_src', 'edge_dst', 'edge_time'}
+    assert hook.produces == {'neg', 'neg_time'}
 
 
 def test_hook_reset_state():

--- a/test/unit/test_hooks/test_negative_edge_sampler_hook.py
+++ b/test/unit/test_hooks/test_negative_edge_sampler_hook.py
@@ -23,6 +23,11 @@ def test_hook_dependancies():
     assert hook_with_id.produces == {'neg_foo', 'neg_time_foo'}
 
 
+def test_hook_repre():
+    hook_with_id = NegativeEdgeSamplerHook(low=0, high=10, id='foo')
+    assert 'foo' in hook_with_id.__repr__()
+
+
 def test_hook_reset_state():
     assert NegativeEdgeSamplerHook.has_state == False
 

--- a/test/unit/test_hooks/test_negative_edge_sampler_hook.py
+++ b/test/unit/test_hooks/test_negative_edge_sampler_hook.py
@@ -52,6 +52,17 @@ def test_negative_edge_sampler(data):
     assert batch.neg_time.shape == batch.neg.shape
 
 
+def test_negative_edge_sampler_with_id(data):
+    dg = DGraph(data)
+    hook = NegativeEdgeSamplerHook(low=0, high=10, id='foo')
+    batch = hook(dg, dg.materialize())
+    assert isinstance(batch, DGBatch)
+    assert torch.is_tensor(batch.neg_foo)
+    assert torch.is_tensor(batch.neg_time_foo)
+    assert batch.neg_foo.shape == batch.edge_dst.shape
+    assert batch.neg_time_foo.shape == batch.neg_foo.shape
+
+
 @pytest.fixture
 def node_only_data():
     edge_index = torch.IntTensor([[1, 2], [2, 3], [3, 4]])

--- a/test/unit/test_hooks/test_negative_edge_sampler_hook.py
+++ b/test/unit/test_hooks/test_negative_edge_sampler_hook.py
@@ -18,6 +18,10 @@ def test_hook_dependancies():
     assert hook.requires == {'edge_src', 'edge_dst', 'edge_time'}
     assert hook.produces == {'neg', 'neg_time'}
 
+    hook_with_id = NegativeEdgeSamplerHook(low=0, high=10, id='foo')
+    assert hook_with_id.requires == {'edge_src', 'edge_dst', 'edge_time'}
+    assert hook_with_id.produces == {'neg_foo', 'neg_time_foo'}
+
 
 def test_hook_reset_state():
     assert NegativeEdgeSamplerHook.has_state == False

--- a/test/unit/test_hooks/test_neighbor_sampler_hook.py
+++ b/test/unit/test_hooks/test_neighbor_sampler_hook.py
@@ -19,8 +19,13 @@ def data():
 
 
 def test_hook_dependancies():
-    assert NeighborSamplerHook.requires == {'edge_src', 'edge_dst', 'edge_time'}
-    assert NeighborSamplerHook.produces == {
+    hook = NeighborSamplerHook(
+        num_nbrs=[1],
+        seed_nodes_keys=['node_x_nids'],
+        seed_times_keys=['node_x_time'],
+    )
+    assert hook.requires == {'edge_src', 'edge_dst', 'edge_time'}
+    assert hook.produces == {
         'seed_nids',
         'seed_times',
         'nbr_nids',

--- a/test/unit/test_hooks/test_neighbor_sampler_hook.py
+++ b/test/unit/test_hooks/test_neighbor_sampler_hook.py
@@ -95,6 +95,22 @@ def test_sample_with_node_events_seeds(node_only_data):
     torch.testing.assert_close(batch.seed_times[0], batch.node_x_time)
 
 
+def test_sample_with_id(node_only_data):
+    dg = DGraph(node_only_data)
+    hook = NeighborSamplerHook(
+        num_nbrs=[1],
+        seed_nodes_keys=['node_x_nids'],
+        seed_times_keys=['node_x_time'],
+        id='foo',
+    )
+    batch = dg.materialize()
+    batch = hook(dg, batch)
+    assert len(batch.seed_nids_foo) == 1
+    assert len(batch.seed_times_foo) == 1
+    torch.testing.assert_close(batch.seed_nids_foo[0], batch.node_x_nids)
+    torch.testing.assert_close(batch.seed_times_foo[0], batch.node_x_time)
+
+
 def test_bad_sample_with_non_existent_seeds(data):
     dg = DGraph(data)
     hook = NeighborSamplerHook(
@@ -190,6 +206,27 @@ def test_neighbor_sampler_hook_link_pred(data):
     assert hasattr(batch, 'nbr_edge_x')
 
 
+def test_neighbor_sampler_hook_link_pred_with_hook_id(data):
+    dg = DGraph(data)
+    hook = NeighborSamplerHook(
+        num_nbrs=[2],
+        seed_nodes_keys=['edge_src', 'edge_dst'],
+        seed_times_keys=['edge_time', 'edge_time'],
+        id='foo',
+    )
+    batch = dg.materialize()
+
+    # Link Prediction will add negative edges to seed nodes for sampling
+    batch.neg = torch.IntTensor([0] * len(batch.edge_dst))
+    batch.neg_time = torch.IntTensor([0] * len(batch.edge_dst))
+    batch = hook(dg, batch)
+    assert isinstance(batch, DGBatch)
+    assert hasattr(batch, 'seed_nids_foo')
+    assert hasattr(batch, 'nbr_nids_foo')
+    assert hasattr(batch, 'nbr_edge_time_foo')
+    assert hasattr(batch, 'nbr_edge_x_foo')
+
+
 def test_neighbor_sampler_hook_node_pred(data):
     dg = DGraph(data)
     hook = NeighborSamplerHook(
@@ -203,6 +240,22 @@ def test_neighbor_sampler_hook_node_pred(data):
     assert hasattr(batch, 'nbr_nids')
     assert hasattr(batch, 'nbr_edge_time')
     assert hasattr(batch, 'nbr_edge_x')
+
+
+def test_neighbor_sampler_hook_node_pred_with_hook_id(data):
+    dg = DGraph(data)
+    hook = NeighborSamplerHook(
+        num_nbrs=[2],
+        seed_nodes_keys=['edge_src', 'edge_dst'],
+        seed_times_keys=['edge_time', 'edge_time'],
+        id='foo',
+    )
+    batch = hook(dg, dg.materialize())
+    assert isinstance(batch, DGBatch)
+    assert hasattr(batch, 'seed_nids_foo')
+    assert hasattr(batch, 'nbr_nids_foo')
+    assert hasattr(batch, 'nbr_edge_time_foo')
+    assert hasattr(batch, 'nbr_edge_x_foo')
 
 
 def _nbrs_2_np(batch: DGBatch) -> List[np.ndarray]:

--- a/test/unit/test_hooks/test_neighbor_sampler_hook.py
+++ b/test/unit/test_hooks/test_neighbor_sampler_hook.py
@@ -24,7 +24,7 @@ def test_hook_dependancies():
         seed_nodes_keys=['node_x_nids'],
         seed_times_keys=['node_x_time'],
     )
-    assert hook.requires == {'edge_src', 'edge_dst', 'edge_time','node_x_nids'}
+    assert hook.requires == {'edge_src', 'edge_dst', 'edge_time', 'node_x_nids'}
     assert hook.produces == {
         'seed_nids',
         'seed_times',
@@ -32,6 +32,22 @@ def test_hook_dependancies():
         'nbr_edge_time',
         'nbr_edge_x',
         'seed_node_nbr_mask',
+    }
+
+    hook_with_id = NeighborSamplerHook(
+        num_nbrs=[1],
+        seed_nodes_keys=['node_x_nids'],
+        seed_times_keys=['node_x_time'],
+        id='foo',
+    )
+    assert hook_with_id.requires == {'edge_src', 'edge_dst', 'edge_time', 'node_x_nids'}
+    assert hook_with_id.produces == {
+        'seed_nids_foo',
+        'seed_times_foo',
+        'nbr_nids_foo',
+        'nbr_edge_time_foo',
+        'nbr_edge_x_foo',
+        'seed_node_nbr_mask_foo',
     }
 
 

--- a/test/unit/test_hooks/test_neighbor_sampler_hook.py
+++ b/test/unit/test_hooks/test_neighbor_sampler_hook.py
@@ -24,7 +24,7 @@ def test_hook_dependancies():
         seed_nodes_keys=['node_x_nids'],
         seed_times_keys=['node_x_time'],
     )
-    assert hook.requires == {'edge_src', 'edge_dst', 'edge_time'}
+    assert hook.requires == {'edge_src', 'edge_dst', 'edge_time','node_x_nids'}
     assert hook.produces == {
         'seed_nids',
         'seed_times',

--- a/test/unit/test_hooks/test_neighbor_sampler_hook.py
+++ b/test/unit/test_hooks/test_neighbor_sampler_hook.py
@@ -51,6 +51,16 @@ def test_hook_dependancies():
     }
 
 
+def test_hook_repre():
+    hook_with_id = NeighborSamplerHook(
+        num_nbrs=[1],
+        seed_nodes_keys=['node_x_nids'],
+        seed_times_keys=['node_x_time'],
+        id='foo',
+    )
+    assert 'foo' in hook_with_id.__repr__()
+
+
 def test_hook_reset_state():
     assert NeighborSamplerHook.has_state == False
 

--- a/test/unit/test_hooks/test_node_analytics_hook.py
+++ b/test/unit/test_hooks/test_node_analytics_hook.py
@@ -454,3 +454,15 @@ def test_node_analytics_hook_multiple_batches_neighbor_accumulation(simple_dgrap
 
     # Should have new neighbor(s) since it's a different connection
     assert batch4.node_stats[0]['new_neighbors'] > 0
+
+
+def test_hook_with_id(simple_dgraph):
+    tracked_nodes = torch.tensor([0])
+    hook = NodeAnalyticsHook(tracked_nodes=tracked_nodes, num_nodes=5, id='foo')
+    batch1 = simple_dgraph.slice_events(0, 2).materialize()
+    processed_batch = hook(simple_dgraph, batch1)
+
+    expected_produce = ['node_stats_foo', 'node_macro_stats_foo', 'edge_stats_foo']
+
+    for produce in expected_produce:
+        assert hasattr(processed_batch, produce)

--- a/test/unit/test_hooks/test_pin_memory_hook.py
+++ b/test/unit/test_hooks/test_pin_memory_hook.py
@@ -17,8 +17,9 @@ def dg():
 
 
 def test_hook_dependancies():
-    assert PinMemoryHook.requires == set()
-    assert PinMemoryHook.produces == set()
+    hook = PinMemoryHook()
+    assert hook.requires == set()
+    assert hook.produces == set()
 
 
 def test_hook_reset_state():

--- a/test/unit/test_hooks/test_recency_nbr_hook.py
+++ b/test/unit/test_hooks/test_recency_nbr_hook.py
@@ -49,6 +49,12 @@ def basic_sample_graph():
 
 
 def test_hook_dependancies():
+    hook = RecencyNeighborHook(
+        num_nbrs=[1],
+        num_nodes=1,
+        seed_nodes_keys=['edge_src'],
+        seed_times_keys=['edge_time'],
+    )
     assert RecencyNeighborHook.requires == {'edge_src', 'edge_dst', 'edge_time'}
     assert RecencyNeighborHook.produces == {
         'seed_nids',

--- a/test/unit/test_hooks/test_recency_nbr_hook.py
+++ b/test/unit/test_hooks/test_recency_nbr_hook.py
@@ -55,8 +55,8 @@ def test_hook_dependancies():
         seed_nodes_keys=['edge_src'],
         seed_times_keys=['edge_time'],
     )
-    assert RecencyNeighborHook.requires == {'edge_src', 'edge_dst', 'edge_time'}
-    assert RecencyNeighborHook.produces == {
+    assert hook.requires == {'edge_src', 'edge_dst', 'edge_time'}
+    assert hook.produces == {
         'seed_nids',
         'nbr_nids',
         'nbr_edge_time',

--- a/test/unit/test_hooks/test_recency_nbr_hook.py
+++ b/test/unit/test_hooks/test_recency_nbr_hook.py
@@ -83,6 +83,17 @@ def test_hook_dependancies():
     }
 
 
+def test_hook_repre():
+    hook_with_id = RecencyNeighborHook(
+        num_nbrs=[1],
+        num_nodes=1,
+        seed_nodes_keys=['edge_src'],
+        seed_times_keys=['edge_time'],
+        id='foo',
+    )
+    assert 'foo' in hook_with_id.__repr__()
+
+
 def test_mock_move_queues_to_device(basic_sample_graph):
     dg = DGraph(basic_sample_graph)
     hook = RecencyNeighborHook(

--- a/test/unit/test_hooks/test_recency_nbr_hook.py
+++ b/test/unit/test_hooks/test_recency_nbr_hook.py
@@ -230,6 +230,23 @@ def test_sample_with_node_events_seeds(node_only_data):
     torch.testing.assert_close(batch.seed_times[0], batch.node_x_time)
 
 
+def test_sample_with_node_events_seeds_with_hook_id(node_only_data):
+    dg = DGraph(node_only_data)
+    hook = RecencyNeighborHook(
+        num_nbrs=[1],
+        num_nodes=dg.num_nodes,
+        seed_nodes_keys=['node_x_nids'],
+        seed_times_keys=['node_x_time'],
+        id='foo',
+    )
+    batch = dg.materialize()
+    batch = hook(dg, batch)
+    assert len(batch.seed_nids_foo) == 1
+    assert len(batch.seed_times_foo) == 1
+    torch.testing.assert_close(batch.seed_nids_foo[0], batch.node_x_nids)
+    torch.testing.assert_close(batch.seed_times_foo[0], batch.node_x_time)
+
+
 def test_bad_sample_with_non_existent_seeds(basic_sample_graph):
     dg = DGraph(basic_sample_graph)
     hook = RecencyNeighborHook(

--- a/test/unit/test_hooks/test_recency_nbr_hook.py
+++ b/test/unit/test_hooks/test_recency_nbr_hook.py
@@ -65,6 +65,23 @@ def test_hook_dependancies():
         'seed_node_nbr_mask',
     }
 
+    hook_with_id = RecencyNeighborHook(
+        num_nbrs=[1],
+        num_nodes=1,
+        seed_nodes_keys=['edge_src'],
+        seed_times_keys=['edge_time'],
+        id='foo',
+    )
+    assert hook_with_id.requires == {'edge_src', 'edge_dst', 'edge_time'}
+    assert hook_with_id.produces == {
+        'seed_nids_foo',
+        'nbr_nids_foo',
+        'nbr_edge_time_foo',
+        'nbr_edge_x_foo',
+        'seed_times_foo',
+        'seed_node_nbr_mask_foo',
+    }
+
 
 def test_mock_move_queues_to_device(basic_sample_graph):
     dg = DGraph(basic_sample_graph)

--- a/test/unit/test_hooks/test_seen_nodes_track_hook.py
+++ b/test/unit/test_hooks/test_seen_nodes_track_hook.py
@@ -34,6 +34,10 @@ def test_hook_dependancies():
     assert hook.requires == {'edge_src', 'edge_dst'}
     assert hook.produces == {'seen_nodes', 'batch_nodes_mask'}
 
+    hook_with_id = EdgeEventsSeenNodesTrackHook(1, id='foo')
+    assert hook_with_id.requires == {'edge_src', 'edge_dst'}
+    assert hook_with_id.produces == {'seen_nodes_foo', 'batch_nodes_mask_foo'}
+
 
 def test_seen_nodes_track_hook(dg):
     hm = HookManager(keys=['unit'])

--- a/test/unit/test_hooks/test_seen_nodes_track_hook.py
+++ b/test/unit/test_hooks/test_seen_nodes_track_hook.py
@@ -30,8 +30,9 @@ def dg():
 
 
 def test_hook_dependancies():
-    assert EdgeEventsSeenNodesTrackHook.requires == {'edge_src', 'edge_dst'}
-    assert EdgeEventsSeenNodesTrackHook.produces == {'seen_nodes', 'batch_nodes_mask'}
+    hook = EdgeEventsSeenNodesTrackHook(1)
+    assert hook.requires == {'edge_src', 'edge_dst'}
+    assert hook.produces == {'seen_nodes', 'batch_nodes_mask'}
 
 
 def test_seen_nodes_track_hook(dg):

--- a/test/unit/test_hooks/test_seen_nodes_track_hook.py
+++ b/test/unit/test_hooks/test_seen_nodes_track_hook.py
@@ -39,6 +39,11 @@ def test_hook_dependancies():
     assert hook_with_id.produces == {'seen_nodes_foo', 'batch_nodes_mask_foo'}
 
 
+def test_hook_repre():
+    hook_with_id = EdgeEventsSeenNodesTrackHook(1, id='foo')
+    assert 'foo' in hook_with_id.__repr__()
+
+
 def test_seen_nodes_track_hook(dg):
     hm = HookManager(keys=['unit'])
     seen_nodes_track_hook = EdgeEventsSeenNodesTrackHook(6)

--- a/test/unit/test_hooks/test_seen_nodes_track_hook.py
+++ b/test/unit/test_hooks/test_seen_nodes_track_hook.py
@@ -69,6 +69,31 @@ def test_seen_nodes_track_hook(dg):
     assert torch.equal(batch_4.batch_nodes_mask, torch.Tensor([0, 2]))
 
 
+def test_seen_nodes_track_hook_with_hook_id(dg):
+    hm = HookManager(keys=['unit'])
+    seen_nodes_track_hook = EdgeEventsSeenNodesTrackHook(6, id='foo')
+    hm.register('unit', seen_nodes_track_hook)
+    hm.set_active_hooks('unit')
+
+    loader = DGDataLoader(dg, batch_unit='s', hook_manager=hm)
+    batch_iter = iter(loader)
+    batch_1 = next(batch_iter)
+    assert len(batch_1.seen_nodes_foo) == 0
+
+    batch_2 = next(batch_iter)
+    assert len(batch_2.seen_nodes_foo) == 0
+
+    batch_3 = next(batch_iter)
+    assert len(batch_3.seen_nodes_foo) == 1
+    assert batch_3.seen_nodes_foo[0].item() == 2
+
+    batch_4 = next(batch_iter)
+    assert len(batch_4.seen_nodes_foo) == 2
+    assert batch_4.seen_nodes_foo[0].item() == 5
+    assert batch_4.seen_nodes_foo[1].item() == 2
+    assert torch.equal(batch_4.batch_nodes_mask_foo, torch.Tensor([0, 2]))
+
+
 def test_reset_state_seen_nodes_track_hook():
     hm = HookManager(keys=['unit'])
     seen_nodes_track_hook = EdgeEventsSeenNodesTrackHook(6)

--- a/test/unit/test_hooks/test_tgb_negative_sampling_hook.py
+++ b/test/unit/test_hooks/test_tgb_negative_sampling_hook.py
@@ -260,6 +260,25 @@ def test_negative_edge_sampler(MockNegSampler, data):
     assert batch.neg_time.shape == batch.neg.shape
 
 
+@patch('tgb.linkproppred.negative_sampler.NegativeEdgeSampler')
+def test_negative_edge_sampler_with_hook_id(MockNegSampler, data):
+    dg = DGraph(data)
+    mock_sampler = Mock()
+    mock_sampler.eval_set = {'val': {'cool'}, 'test': {'cool'}}
+    mock_sampler.query_batch.return_value = [[0] for _ in range(3)]
+    MockNegSampler.return_value = mock_sampler
+
+    hook = TGBNegativeEdgeSamplerHook(
+        dataset_name='tgbl-foo', split_mode='val', id='foo'
+    )
+    batch = hook(dg, dg.materialize())
+    assert isinstance(batch, DGBatch)
+    assert torch.is_tensor(batch.neg_foo)
+    assert torch.is_tensor(batch.neg_time_foo)
+    assert len(batch.neg_batch_list_foo) == batch.edge_src.shape[0]
+    assert batch.neg_time_foo.shape == batch.neg_foo.shape
+
+
 @patch('tgb.utils.info.DATA_VERSION_DICT', {'tgbl-foo': 1})
 @patch('tgb.linkproppred.negative_sampler.NegativeEdgeSampler')
 def test_negative_edge_sampler_with_version_info(MockNegSampler, data):
@@ -437,6 +456,34 @@ def test_thg_negative_edge_sampler(MockNegSampler, thg_data):
     assert torch.is_tensor(batch.neg_time)
     assert len(batch.neg_batch_list) == batch.edge_src.shape[0]
     assert batch.neg_time.shape == batch.neg.shape
+
+
+@patch('tgb.linkproppred.thg_negative_sampler.THGNegativeEdgeSampler')
+def test_thg_negative_edge_sampler_with_hook_id(MockNegSampler, thg_data):
+    dg = DGraph(thg_data)
+    mock_sampler = Mock()
+    mock_sampler.eval_set = {'val': {'cool'}, 'test': {'cool'}}
+    mock_sampler.query_batch.return_value = [[0] for _ in range(3)]
+    MockNegSampler.return_value = mock_sampler
+
+    min_id = 0
+    max_id = 10
+    node_type = torch.arange(max_id + 1, dtype=torch.int32)
+
+    hook = TGBTHGNegativeEdgeSamplerHook(
+        dataset_name='thgl-foo',
+        split_mode='val',
+        first_node_id=min_id,
+        last_node_id=max_id,
+        node_type=node_type,
+        id='foo',
+    )
+    batch = hook(dg, dg.materialize())
+    assert isinstance(batch, DGBatch)
+    assert torch.is_tensor(batch.neg_foo)
+    assert torch.is_tensor(batch.neg_time_foo)
+    assert len(batch.neg_batch_list_foo) == batch.edge_src.shape[0]
+    assert batch.neg_time_foo.shape == batch.neg_foo.shape
 
 
 @patch('tgb.utils.info.DATA_VERSION_DICT', {'thgl-foo': 1})
@@ -631,6 +678,32 @@ def test_tkg_negative_edge_sampler(MockNegSampler, tkg_data):
     assert torch.is_tensor(batch.neg_time)
     assert len(batch.neg_batch_list) == batch.edge_src.shape[0]
     assert batch.neg_time.shape == batch.neg.shape
+
+
+@patch('tgb.linkproppred.tkg_negative_sampler.TKGNegativeEdgeSampler')
+def test_tkg_negative_edge_sampler_with_hook_id(MockNegSampler, tkg_data):
+    dg = DGraph(tkg_data)
+    mock_sampler = Mock()
+    mock_sampler.eval_set = {'val': {'cool'}, 'test': {'cool'}}
+    mock_sampler.query_batch.return_value = [[0] for _ in range(3)]
+    MockNegSampler.return_value = mock_sampler
+
+    min_id = 0
+    max_id = 10
+
+    hook = TGBTKGNegativeEdgeSamplerHook(
+        dataset_name='tkgl-foo',
+        split_mode='val',
+        first_dst_id=min_id,
+        last_dst_id=max_id,
+        id='foo',
+    )
+    batch = hook(dg, dg.materialize())
+    assert isinstance(batch, DGBatch)
+    assert torch.is_tensor(batch.neg_foo)
+    assert torch.is_tensor(batch.neg_time_foo)
+    assert len(batch.neg_batch_list_foo) == batch.edge_src.shape[0]
+    assert batch.neg_time_foo.shape == batch.neg_foo.shape
 
 
 @patch('tgb.utils.info.DATA_VERSION_DICT', {'tkgl-foo': 1})

--- a/test/unit/test_hooks/test_tgb_negative_sampling_hook.py
+++ b/test/unit/test_hooks/test_tgb_negative_sampling_hook.py
@@ -58,6 +58,12 @@ def test_hook_dependancies_tgbl(MockNegSampler):
     assert hook.requires == {'edge_src', 'edge_dst', 'edge_time'}
     assert hook.produces == {'neg', 'neg_batch_list', 'neg_time'}
 
+    hook_with_id = TGBNegativeEdgeSamplerHook(
+        dataset_name='tgbl-foo', split_mode='val', id='foo'
+    )
+    assert hook_with_id.requires == {'edge_src', 'edge_dst', 'edge_time'}
+    assert hook_with_id.produces == {'neg_foo', 'neg_batch_list_foo', 'neg_time_foo'}
+
 
 @patch('tgb.linkproppred.thg_negative_sampler.THGNegativeEdgeSampler')
 def test_hook_dependancies_thgl(MockNegSampler):
@@ -89,6 +95,26 @@ def test_hook_dependancies_thgl(MockNegSampler):
         'neg_time',
     }
 
+    hook_with_id = TGBTHGNegativeEdgeSamplerHook(
+        dataset_name='thgl-foo',
+        split_mode='val',
+        first_node_id=min_id,
+        last_node_id=max_id,
+        node_type=node_type,
+        id='foo',
+    )
+    assert hook_with_id.requires == {
+        'edge_src',
+        'edge_dst',
+        'edge_time',
+        'edge_type',
+    }
+    assert hook_with_id.produces == {
+        'neg_foo',
+        'neg_batch_list_foo',
+        'neg_time_foo',
+    }
+
 
 @patch('tgb.linkproppred.tkg_negative_sampler.TKGNegativeEdgeSampler')
 def test_hook_dependancies_tkgl(MockNegSampler):
@@ -116,6 +142,25 @@ def test_hook_dependancies_tkgl(MockNegSampler):
         'neg',
         'neg_batch_list',
         'neg_time',
+    }
+
+    hook_with_id = TGBTKGNegativeEdgeSamplerHook(
+        dataset_name='tkgl-foo',
+        split_mode='val',
+        first_dst_id=min_id,
+        last_dst_id=max_id,
+        id='foo',
+    )
+    assert hook_with_id.requires == {
+        'edge_src',
+        'edge_dst',
+        'edge_time',
+        'edge_type',
+    }
+    assert hook_with_id.produces == {
+        'neg_foo',
+        'neg_batch_list_foo',
+        'neg_time_foo',
     }
 
 

--- a/test/unit/test_hooks/test_tgb_negative_sampling_hook.py
+++ b/test/unit/test_hooks/test_tgb_negative_sampling_hook.py
@@ -65,6 +65,19 @@ def test_hook_dependancies_tgbl(MockNegSampler):
     assert hook_with_id.produces == {'neg_foo', 'neg_batch_list_foo', 'neg_time_foo'}
 
 
+@patch('tgb.linkproppred.negative_sampler.NegativeEdgeSampler')
+def test_tgb_hook_repre(MockNegSampler):
+    mock_sampler = Mock()
+    mock_sampler.eval_set = {'val': {'cool'}, 'test': {'cool'}}
+    mock_sampler.query_batch.return_value = [[0] for _ in range(3)]
+    MockNegSampler.return_value = mock_sampler
+
+    hook_with_id = TGBNegativeEdgeSamplerHook(
+        dataset_name='tgbl-foo', split_mode='val', id='foo'
+    )
+    assert 'foo' in hook_with_id.__repr__()
+
+
 @patch('tgb.linkproppred.thg_negative_sampler.THGNegativeEdgeSampler')
 def test_hook_dependancies_thgl(MockNegSampler):
     mock_sampler = Mock()
@@ -116,6 +129,29 @@ def test_hook_dependancies_thgl(MockNegSampler):
     }
 
 
+@patch('tgb.linkproppred.thg_negative_sampler.THGNegativeEdgeSampler')
+def test_thg_hook_repre(MockNegSampler):
+    mock_sampler = Mock()
+    mock_sampler.eval_set = {'val': {'cool'}, 'test': {'cool'}}
+    mock_sampler.query_batch.return_value = [[0] for _ in range(3)]
+    MockNegSampler.return_value = mock_sampler
+
+    min_id = 0
+    max_id = 10
+    node_type = torch.arange(max_id + 1, dtype=torch.int32)
+
+    hook_with_id = TGBTHGNegativeEdgeSamplerHook(
+        dataset_name='thgl-foo',
+        split_mode='val',
+        first_node_id=min_id,
+        last_node_id=max_id,
+        node_type=node_type,
+        id='foo',
+    )
+
+    assert 'foo' in hook_with_id.__repr__()
+
+
 @patch('tgb.linkproppred.tkg_negative_sampler.TKGNegativeEdgeSampler')
 def test_hook_dependancies_tkgl(MockNegSampler):
     mock_sampler = Mock()
@@ -162,6 +198,26 @@ def test_hook_dependancies_tkgl(MockNegSampler):
         'neg_batch_list_foo',
         'neg_time_foo',
     }
+
+
+@patch('tgb.linkproppred.tkg_negative_sampler.TKGNegativeEdgeSampler')
+def test_tkg_hook_repre(MockNegSampler):
+    mock_sampler = Mock()
+    mock_sampler.eval_set = {'val': {'cool'}, 'test': {'cool'}}
+    mock_sampler.query_batch.return_value = [[0] for _ in range(3)]
+    MockNegSampler.return_value = mock_sampler
+
+    min_id = 0
+    max_id = 10
+
+    hook_with_id = TGBTKGNegativeEdgeSamplerHook(
+        dataset_name='tkgl-foo',
+        split_mode='val',
+        first_dst_id=min_id,
+        last_dst_id=max_id,
+        id='foo',
+    )
+    assert 'foo' in hook_with_id.__repr__()
 
 
 def test_hook_reset_state():

--- a/test/unit/test_hooks/test_tgb_negative_sampling_hook.py
+++ b/test/unit/test_hooks/test_tgb_negative_sampling_hook.py
@@ -46,28 +46,73 @@ def tkg_data():
     )
 
 
-def test_hook_dependancies():
-    assert TGBNegativeEdgeSamplerHook.requires == {'edge_src', 'edge_dst', 'edge_time'}
-    assert TGBNegativeEdgeSamplerHook.produces == {'neg', 'neg_batch_list', 'neg_time'}
-    assert TGBTHGNegativeEdgeSamplerHook.requires == {
+@patch('tgb.linkproppred.negative_sampler.NegativeEdgeSampler')
+def test_hook_dependancies_tgbl(MockNegSampler):
+    mock_sampler = Mock()
+    mock_sampler.eval_set = {'val': {'cool'}, 'test': {'cool'}}
+    mock_sampler.query_batch.return_value = [[0] for _ in range(3)]
+    MockNegSampler.return_value = mock_sampler
+
+    hook = TGBNegativeEdgeSamplerHook(dataset_name='tgbl-foo', split_mode='val')
+
+    assert hook.requires == {'edge_src', 'edge_dst', 'edge_time'}
+    assert hook.produces == {'neg', 'neg_batch_list', 'neg_time'}
+
+
+@patch('tgb.linkproppred.thg_negative_sampler.THGNegativeEdgeSampler')
+def test_hook_dependancies_thgl(MockNegSampler):
+    mock_sampler = Mock()
+    mock_sampler.eval_set = {'val': {'cool'}, 'test': {'cool'}}
+    mock_sampler.query_batch.return_value = [[0] for _ in range(3)]
+    MockNegSampler.return_value = mock_sampler
+
+    min_id = 0
+    max_id = 10
+    node_type = torch.arange(max_id + 1, dtype=torch.int32)
+
+    hook = TGBTHGNegativeEdgeSamplerHook(
+        dataset_name='thgl-foo',
+        split_mode='val',
+        first_node_id=min_id,
+        last_node_id=max_id,
+        node_type=node_type,
+    )
+    assert hook.requires == {
         'edge_src',
         'edge_dst',
         'edge_time',
         'edge_type',
     }
-    assert TGBTHGNegativeEdgeSamplerHook.produces == {
+    assert hook.produces == {
         'neg',
         'neg_batch_list',
         'neg_time',
     }
 
-    assert TGBTKGNegativeEdgeSamplerHook.requires == {
+
+@patch('tgb.linkproppred.tkg_negative_sampler.TKGNegativeEdgeSampler')
+def test_hook_dependancies_tkgl(MockNegSampler):
+    mock_sampler = Mock()
+    mock_sampler.eval_set = {'val': {'cool'}, 'test': {'cool'}}
+    mock_sampler.query_batch.return_value = [[0] for _ in range(3)]
+    MockNegSampler.return_value = mock_sampler
+
+    min_id = 0
+    max_id = 10
+
+    hook = TGBTKGNegativeEdgeSamplerHook(
+        dataset_name='tkgl-foo',
+        split_mode='val',
+        first_dst_id=min_id,
+        last_dst_id=max_id,
+    )
+    assert hook.requires == {
         'edge_src',
         'edge_dst',
         'edge_time',
         'edge_type',
     }
-    assert TGBTKGNegativeEdgeSamplerHook.produces == {
+    assert hook.produces == {
         'neg',
         'neg_batch_list',
         'neg_time',

--- a/tgm/hooks/__init__.py
+++ b/tgm/hooks/__init__.py
@@ -1,4 +1,4 @@
-from .base import DGHook, StatelessHook, StatefulHook, BaseDGHook
+from .base import DGHook, StatelessHook, StatefulHook, BaseDGHook, SeedableHook
 from .dedup import DeduplicationHook
 from .device import DeviceTransferHook, PinMemoryHook
 from .negatives import (

--- a/tgm/hooks/__init__.py
+++ b/tgm/hooks/__init__.py
@@ -1,4 +1,4 @@
-from .base import DGHook, StatelessHook, StatefulHook
+from .base import DGHook, StatelessHook, StatefulHook, BaseDGHook
 from .dedup import DeduplicationHook
 from .device import DeviceTransferHook, PinMemoryHook
 from .negatives import (

--- a/tgm/hooks/base.py
+++ b/tgm/hooks/base.py
@@ -66,8 +66,8 @@ class BaseDGHook(ABC):
     def reset_state(self) -> None:
         pass
 
-    def add_attribute_to_batch(self, batch: DGBatch, name: str, value: Any) -> None:
-        """Add a new attribute to providede batch.
+    def add_batch_attribute(self, batch: DGBatch, name: str, value: Any) -> None:
+        """Add a new attribute to provided batch.
 
         If `_id` is specified, the new attribute name will be appended with the given `id` as a suffix.
         """
@@ -90,6 +90,12 @@ class StatefulHook(BaseDGHook):
 
 @dataclass(eq=False)
 class SeedableHook(BaseDGHook):
+    """Base class for hooks that can take additional attributes.
+
+    Example hooks that are `seedable`: `DeduplicationHook` which finds set of unique nodes ID on `seed_keys` beyond `src` and `dst`.
+    `SeedableHook` are compatible with both `StatelessHook` and `StatefulHook`.
+    """
+
     seed_keys: List[str] | None = field(default_factory=list)
 
     def __post_init__(self) -> None:

--- a/tgm/hooks/base.py
+++ b/tgm/hooks/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, Protocol, Set, runtime_checkable
+from typing import Any, List, Protocol, Set, runtime_checkable
 
 from tgm import DGBatch, DGraph
 
@@ -11,9 +11,13 @@ from tgm import DGBatch, DGraph
 class DGHook(Protocol):
     r"""The behaviours to be executed on a DGraph before materializing."""
 
-    requires: Set[str]
-    produces: Set[str]
     has_state: bool
+
+    @property
+    def requires(self) -> Set[str]: ...
+
+    @property
+    def produces(self) -> Set[str]: ...
 
     def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch: ...
 
@@ -24,19 +28,35 @@ class DGHook(Protocol):
 class BaseDGHook(ABC):
     """Base class for hooks."""
 
-    requires: Set[str] = field(default_factory=set)
-    produces: Set[str] = field(default_factory=set)
-    id: str | None = None
+    _cls_requires: Set[str] = field(default_factory=set, init=False, repr=False)
+    _cls_produces: Set[str] = field(default_factory=set, init=False, repr=False)
+
+    _requires: Set[str] = field(default_factory=set)
+    _produces: Set[str] = field(default_factory=set)
+
+    _id: str | None = None
+
     has_state: bool = False
 
     def __post_init__(self) -> None:
-        if self.id:
-            self.produces = {f'{p}_{self.id}' for p in self.produces}
+        self._requires.update(type(self).__dict__.get('_cls_requires', set()))
+        self._produces.update(type(self).__dict__.get('_cls_produces', set()))
+
+    @property
+    def produces(self) -> Set[str]:
+        if self._id is None:
+            return self._produces
+        else:
+            return {f'{p}_{self._id}' for p in self._produces}
+
+    @property
+    def requires(self) -> Set[str]:
+        return self._requires
 
     def __repr__(self) -> str:
         cls_name = self.__class__.__name__
-        if self.id:
-            cls_name = f'{cls_name}_{self.id}'
+        if self._id:
+            cls_name = f'{cls_name}_{self._id}'
         return cls_name
 
     @abstractmethod
@@ -49,10 +69,10 @@ class BaseDGHook(ABC):
     def add_attribute_to_batch(self, batch: DGBatch, name: str, value: Any) -> None:
         """Add a new attribute to providede batch.
 
-        If `id` is specified, the new attribute name will be appended with the given `id` as a suffix.
+        If `_id` is specified, the new attribute name will be appended with the given `id` as a suffix.
         """
-        if self.id:
-            name = f'{name}_{self.id}'
+        if self._id:
+            name = f'{name}_{self._id}'
         setattr(batch, name, value)
 
 
@@ -66,3 +86,12 @@ class StatefulHook(BaseDGHook):
     """Base class for hooks that maintain internal state."""
 
     has_state: bool = True
+
+
+@dataclass(eq=False)
+class SeedableHook(BaseDGHook):
+    seed_keys: List[str] | None = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self._requires.update(self.seed_keys if self.seed_keys else [])

--- a/tgm/hooks/base.py
+++ b/tgm/hooks/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from typing import Protocol, Set, runtime_checkable
-
+from dataclasses import dataclass
 from tgm import DGBatch, DGraph
 
 
@@ -17,6 +17,19 @@ class DGHook(Protocol):
 
     def reset_state(self) -> None: ...
 
+
+@dataclass
+class BaseDGHook:
+    requires: Set[str]
+    produces: Set[str]
+    has_state: bool
+    id: str | None = None
+
+    def __post_init__(self):
+        if self.id and self.id.strip():
+            self.produces = {
+                f"{p}_{self.id}" for p in self.produces
+            }
 
 class StatelessHook:
     """Base class for hooks without internal state."""

--- a/tgm/hooks/base.py
+++ b/tgm/hooks/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Protocol, Set, runtime_checkable
+from typing import Any, Protocol, Set, runtime_checkable
 
 from tgm import DGBatch, DGraph
 
@@ -45,6 +45,15 @@ class BaseDGHook(ABC):
 
     def reset_state(self) -> None:
         pass
+
+    def add_attribute_to_batch(self, batch: DGBatch, name: str, value: Any) -> None:
+        """Add a new attribute to providede batch.
+
+        If `id` is specified, the new attribute name will be appended with the given `id` as a suffix.
+        """
+        if self.id:
+            name = f'{name}_{self.id}'
+        setattr(batch, name, value)
 
 
 class StatelessHook(BaseDGHook):

--- a/tgm/hooks/base.py
+++ b/tgm/hooks/base.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 from typing import Protocol, Set, runtime_checkable
-from dataclasses import dataclass
+
 from tgm import DGBatch, DGraph
 
 
@@ -18,26 +20,26 @@ class DGHook(Protocol):
     def reset_state(self) -> None: ...
 
 
-@dataclass
-class BaseDGHook:
-    requires: Set[str]
-    produces: Set[str]
-    has_state: bool
+@dataclass(eq=False)
+class BaseDGHook(ABC):
+    """Base class for hooks."""
+
+    requires: Set[str] = field(default_factory=set)
+    produces: Set[str] = field(default_factory=set)
     id: str | None = None
-
-    def __post_init__(self):
-        if self.id and self.id.strip():
-            self.produces = {
-                f"{p}_{self.id}" for p in self.produces
-            }
-
-class StatelessHook:
-    """Base class for hooks without internal state."""
-
-    requires: Set[str] = set()
-    produces: Set[str] = set()
     has_state: bool = False
 
+    def __post_init__(self) -> None:
+        if self.id:
+            self.produces = {f'{p}_{self.id}' for p in self.produces}
+
+    def __repr__(self) -> str:
+        cls_name = self.__class__.__name__
+        if self.id:
+            cls_name = f'{cls_name}_{self.id}'
+        return cls_name
+
+    @abstractmethod
     def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:
         raise NotImplementedError
 
@@ -45,9 +47,13 @@ class StatelessHook:
         pass
 
 
-class StatefulHook:
+class StatelessHook(BaseDGHook):
+    """Base class for hooks without internal state."""
+
+    has_state: bool = False
+
+
+class StatefulHook(BaseDGHook):
     """Base class for hooks that maintain internal state."""
 
-    requires: Set[str] = set()
-    produces: Set[str] = set()
     has_state: bool = True

--- a/tgm/hooks/batch_analytics.py
+++ b/tgm/hooks/batch_analytics.py
@@ -11,8 +11,9 @@ logger = _get_logger(__name__)
 class BatchAnalyticsHook(StatelessHook):
     """Compute simple batch-level statistics."""
 
-    def __init__(self) -> None:
+    def __init__(self, id: str | None = None) -> None:
         super().__init__()
+        self.id = id
         self.requires = {
             'edge_src',
             'edge_dst',
@@ -29,6 +30,7 @@ class BatchAnalyticsHook(StatelessHook):
             'num_repeated_edge_events',
             'num_repeated_node_events',
         }
+        self.__post_init__()
 
     def _count_edge_events(self, batch: DGBatch) -> int:
         return int(batch.edge_src.numel()) if batch.edge_src is not None else 0

--- a/tgm/hooks/batch_analytics.py
+++ b/tgm/hooks/batch_analytics.py
@@ -100,12 +100,26 @@ class BatchAnalyticsHook(StatelessHook):
         return int((node_counts - 1).clamp(min=0).sum().item())
 
     def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:
-        batch.num_edge_events = self._count_edge_events(batch)  # type: ignore[attr-defined]
-        batch.num_node_events = self._count_node_events(batch)  # type: ignore[attr-defined]
-        batch.num_unique_timestamps = self._count_unique_timestamps(batch)  # type: ignore[attr-defined]
-        batch.num_unique_nodes = self._compute_unique_nodes(batch)  # type: ignore[attr-defined]
-        batch.avg_degree = self._compute_avg_degree(batch)  # type: ignore[attr-defined]
-        batch.num_repeated_edge_events = self._count_repeated_edge_events(batch)  # type: ignore[attr-defined]
-        batch.num_repeated_node_events = self._count_repeated_node_events(batch)  # type: ignore[attr-defined]
+        self.add_attribute_to_batch(
+            batch, 'num_edge_events', self._count_edge_events(batch)
+        )
+        self.add_attribute_to_batch(
+            batch, 'num_node_events', self._count_node_events(batch)
+        )
+        self.add_attribute_to_batch(
+            batch, 'num_unique_timestamps', self._count_unique_timestamps(batch)
+        )
+        self.add_attribute_to_batch(
+            batch, 'num_unique_nodes', self._compute_unique_nodes(batch)
+        )
+        self.add_attribute_to_batch(
+            batch, 'avg_degree', self._compute_avg_degree(batch)
+        )
+        self.add_attribute_to_batch(
+            batch, 'num_repeated_edge_events', self._count_repeated_edge_events(batch)
+        )
+        self.add_attribute_to_batch(
+            batch, 'num_repeated_node_events', self._count_repeated_node_events(batch)
+        )
 
         return batch

--- a/tgm/hooks/batch_analytics.py
+++ b/tgm/hooks/batch_analytics.py
@@ -11,22 +11,24 @@ logger = _get_logger(__name__)
 class BatchAnalyticsHook(StatelessHook):
     """Compute simple batch-level statistics."""
 
-    requires = {
-        'edge_src',
-        'edge_dst',
-        'edge_time',
-        'node_x_time',
-        'node_x_nids',
-    }
-    produces = {
-        'num_edge_events',
-        'num_node_events',
-        'num_unique_timestamps',
-        'num_unique_nodes',
-        'avg_degree',
-        'num_repeated_edge_events',
-        'num_repeated_node_events',
-    }
+    def __init__(self) -> None:
+        super().__init__()
+        self.requires = {
+            'edge_src',
+            'edge_dst',
+            'edge_time',
+            'node_x_time',
+            'node_x_nids',
+        }
+        self.produces = {
+            'num_edge_events',
+            'num_node_events',
+            'num_unique_timestamps',
+            'num_unique_nodes',
+            'avg_degree',
+            'num_repeated_edge_events',
+            'num_repeated_node_events',
+        }
 
     def _count_edge_events(self, batch: DGBatch) -> int:
         return int(batch.edge_src.numel()) if batch.edge_src is not None else 0

--- a/tgm/hooks/batch_analytics.py
+++ b/tgm/hooks/batch_analytics.py
@@ -11,25 +11,26 @@ logger = _get_logger(__name__)
 class BatchAnalyticsHook(StatelessHook):
     """Compute simple batch-level statistics."""
 
+    _cls_requires = {
+        'edge_src',
+        'edge_dst',
+        'edge_time',
+        'node_x_time',
+        'node_x_nids',
+    }
+    _cls_produces = {
+        'num_edge_events',
+        'num_node_events',
+        'num_unique_timestamps',
+        'num_unique_nodes',
+        'avg_degree',
+        'num_repeated_edge_events',
+        'num_repeated_node_events',
+    }
+
     def __init__(self, id: str | None = None) -> None:
         super().__init__()
-        self.id = id
-        self.requires = {
-            'edge_src',
-            'edge_dst',
-            'edge_time',
-            'node_x_time',
-            'node_x_nids',
-        }
-        self.produces = {
-            'num_edge_events',
-            'num_node_events',
-            'num_unique_timestamps',
-            'num_unique_nodes',
-            'avg_degree',
-            'num_repeated_edge_events',
-            'num_repeated_node_events',
-        }
+        self._id = id
         self.__post_init__()
 
     def _count_edge_events(self, batch: DGBatch) -> int:

--- a/tgm/hooks/batch_analytics.py
+++ b/tgm/hooks/batch_analytics.py
@@ -101,25 +101,23 @@ class BatchAnalyticsHook(StatelessHook):
         return int((node_counts - 1).clamp(min=0).sum().item())
 
     def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:
-        self.add_attribute_to_batch(
+        self.add_batch_attribute(
             batch, 'num_edge_events', self._count_edge_events(batch)
         )
-        self.add_attribute_to_batch(
+        self.add_batch_attribute(
             batch, 'num_node_events', self._count_node_events(batch)
         )
-        self.add_attribute_to_batch(
+        self.add_batch_attribute(
             batch, 'num_unique_timestamps', self._count_unique_timestamps(batch)
         )
-        self.add_attribute_to_batch(
+        self.add_batch_attribute(
             batch, 'num_unique_nodes', self._compute_unique_nodes(batch)
         )
-        self.add_attribute_to_batch(
-            batch, 'avg_degree', self._compute_avg_degree(batch)
-        )
-        self.add_attribute_to_batch(
+        self.add_batch_attribute(batch, 'avg_degree', self._compute_avg_degree(batch))
+        self.add_batch_attribute(
             batch, 'num_repeated_edge_events', self._count_repeated_edge_events(batch)
         )
-        self.add_attribute_to_batch(
+        self.add_batch_attribute(
             batch, 'num_repeated_node_events', self._count_repeated_node_events(batch)
         )
 

--- a/tgm/hooks/dedup.py
+++ b/tgm/hooks/dedup.py
@@ -51,8 +51,8 @@ class DeduplicationHook(StatelessHook, SeedableHook):
         all_nids = torch.cat(nids, dim=0)
         unique_nids = torch.unique(all_nids, sorted=True)
 
-        self.add_attribute_to_batch(batch, 'unique_nids', unique_nids)
-        self.add_attribute_to_batch(
+        self.add_batch_attribute(batch, 'unique_nids', unique_nids)
+        self.add_batch_attribute(
             batch, 'global_to_local', lambda x: torch.searchsorted(unique_nids, x).int()
         )
         logger.debug(

--- a/tgm/hooks/dedup.py
+++ b/tgm/hooks/dedup.py
@@ -47,8 +47,10 @@ class DeduplicationHook(StatelessHook):
         all_nids = torch.cat(nids, dim=0)
         unique_nids = torch.unique(all_nids, sorted=True)
 
-        batch.unique_nids = unique_nids  # type: ignore
-        batch.global_to_local = lambda x: torch.searchsorted(unique_nids, x).int()  # type: ignore
+        self.add_attribute_to_batch(batch, 'unique_nids', unique_nids)
+        self.add_attribute_to_batch(
+            batch, 'global_to_local', lambda x: torch.searchsorted(unique_nids, x).int()
+        )
         logger.debug(
             'Deduplicated batch: %d ids to %d unique ids',
             all_nids.numel(),

--- a/tgm/hooks/dedup.py
+++ b/tgm/hooks/dedup.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import torch
+from typing import List
 
 from tgm import DGBatch, DGraph
 from tgm.constants import PADDED_NODE_ID
@@ -16,29 +17,26 @@ class DeduplicationHook(StatelessHook):
     Note: Supports batches with or without negative samples and multi-hop neighbors.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, seed_nodes_keys: List[str] = []) -> None:
         super().__init__()
-        self.requires = {'edge_src', 'edge_dst'}
+        self.requires = {'edge_src', 'edge_dst'} | set(seed_nodes_keys)
         self.produces = {'unique_nids', 'global_to_local'}
 
     def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:
-        nids = [batch.edge_src, batch.edge_dst]
-        if hasattr(batch, 'neg'):
-            batch.neg = batch.neg.to(batch.edge_src.device)
-            nids.append(batch.neg)
-        if hasattr(batch, 'nbr_nids'):
-            for hop in range(len(batch.nbr_nids)):
-                nbr_nodes = batch.nbr_nids[hop].flatten()
-                nbr_mask = nbr_nodes != PADDED_NODE_ID
-                nids.append(nbr_nodes[nbr_mask].flatten().to(batch.edge_src.device))
-
-        nids.append(
-            batch.node_x_nids.to(batch.edge_src.device)
-        ) if batch.node_x_nids is not None else None
-
-        nids.append(
-            batch.node_y_nids.to(batch.edge_src.device)
-        ) if batch.node_y_nids is not None else None
+        nids = [batch.edge_src, batch.edge_dst] # TODO: Need to retrieve seed nodes. Have NodeSeedable?
+        for node_attr in self.requires:
+            if not hasattr(batch,node_attr):
+                raise ValueError(f'Missing seed node attribut {node_attr}')
+            
+            if  'nbr_nids' in node_attr :
+                for hop in range(len(batch.nbr_nids)):
+                    nbr_nodes = batch.nbr_nids[hop].flatten()
+                    nbr_mask = nbr_nodes != PADDED_NODE_ID
+                    nids.append(nbr_nodes[nbr_mask].flatten().to(batch.edge_src.device))
+            else:
+                seed_node = getattr(batch,node_attr)
+                if seed_node is not None:
+                    nids.append(seed_node)
 
         all_nids = torch.cat(nids, dim=0)
         unique_nids = torch.unique(all_nids, sorted=True)

--- a/tgm/hooks/dedup.py
+++ b/tgm/hooks/dedup.py
@@ -6,30 +6,34 @@ import torch
 
 from tgm import DGBatch, DGraph
 from tgm.constants import PADDED_NODE_ID
-from tgm.hooks import StatelessHook
+from tgm.hooks import SeedableHook, StatelessHook
 from tgm.util.logging import _get_logger
 
 logger = _get_logger(__name__)
 
 
-class DeduplicationHook(StatelessHook):
+class DeduplicationHook(StatelessHook, SeedableHook):
     """Deduplicate node IDs from batch fields and create index mappings to unique node embeddings.
 
     Note: Supports batches with or without negative samples and multi-hop neighbors.
     """
 
-    def __init__(self, seed_nodes_keys: List[str] = [], id: str | None = None) -> None:
+    _cls_requires = {'edge_src', 'edge_dst'}
+    _cls_produces = {'unique_nids', 'global_to_local'}
+
+    def __init__(
+        self, seed_nodes_keys: List[str] | None = None, id: str | None = None
+    ) -> None:
         super().__init__()
-        self.id = id
-        self.requires = {'edge_src', 'edge_dst'} | set(seed_nodes_keys)
-        self.produces = {'unique_nids', 'global_to_local'}
+        self._id = id
+        self.seed_keys = seed_nodes_keys
         self.__post_init__()
 
     def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:
         nids = [
             batch.edge_src,
             batch.edge_dst,
-        ]  # TODO: Need to retrieve seed nodes. Have NodeSeedable?
+        ]
         for node_attr in self.requires:
             if not hasattr(batch, node_attr):
                 raise ValueError(f'Missing seed node attribut {node_attr}')

--- a/tgm/hooks/dedup.py
+++ b/tgm/hooks/dedup.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import torch
 from typing import List
+
+import torch
 
 from tgm import DGBatch, DGraph
 from tgm.constants import PADDED_NODE_ID
@@ -17,24 +18,29 @@ class DeduplicationHook(StatelessHook):
     Note: Supports batches with or without negative samples and multi-hop neighbors.
     """
 
-    def __init__(self, seed_nodes_keys: List[str] = []) -> None:
+    def __init__(self, seed_nodes_keys: List[str] = [], id: str | None = None) -> None:
         super().__init__()
+        self.id = id
         self.requires = {'edge_src', 'edge_dst'} | set(seed_nodes_keys)
         self.produces = {'unique_nids', 'global_to_local'}
+        self.__post_init__()
 
     def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:
-        nids = [batch.edge_src, batch.edge_dst] # TODO: Need to retrieve seed nodes. Have NodeSeedable?
+        nids = [
+            batch.edge_src,
+            batch.edge_dst,
+        ]  # TODO: Need to retrieve seed nodes. Have NodeSeedable?
         for node_attr in self.requires:
-            if not hasattr(batch,node_attr):
+            if not hasattr(batch, node_attr):
                 raise ValueError(f'Missing seed node attribut {node_attr}')
-            
-            if  'nbr_nids' in node_attr :
-                for hop in range(len(batch.nbr_nids)):
-                    nbr_nodes = batch.nbr_nids[hop].flatten()
+
+            if 'nbr_nids' in node_attr:
+                for hop in range(len(batch.nbr_nids)):  # type: ignore[attr-defined]
+                    nbr_nodes = batch.nbr_nids[hop].flatten()  # type: ignore[attr-defined]
                     nbr_mask = nbr_nodes != PADDED_NODE_ID
                     nids.append(nbr_nodes[nbr_mask].flatten().to(batch.edge_src.device))
             else:
-                seed_node = getattr(batch,node_attr)
+                seed_node = getattr(batch, node_attr)
                 if seed_node is not None:
                     nids.append(seed_node)
 

--- a/tgm/hooks/dedup.py
+++ b/tgm/hooks/dedup.py
@@ -16,8 +16,10 @@ class DeduplicationHook(StatelessHook):
     Note: Supports batches with or without negative samples and multi-hop neighbors.
     """
 
-    requires = {'edge_src', 'edge_dst'}
-    produces = {'unique_nids', 'global_to_local'}
+    def __init__(self) -> None:
+        super().__init__()
+        self.requires = {'edge_src', 'edge_dst'}
+        self.produces = {'unique_nids', 'global_to_local'}
 
     def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:
         nids = [batch.edge_src, batch.edge_dst]

--- a/tgm/hooks/dedup.py
+++ b/tgm/hooks/dedup.py
@@ -36,7 +36,7 @@ class DeduplicationHook(StatelessHook, SeedableHook):
         ]
         for node_attr in self.requires:
             if not hasattr(batch, node_attr):
-                raise ValueError(f'Missing seed node attribut {node_attr}')
+                raise ValueError(f'Missing seed node attribute {node_attr}')
 
             if 'nbr_nids' in node_attr:
                 for hop in range(len(batch.nbr_nids)):  # type: ignore[attr-defined]

--- a/tgm/hooks/device.py
+++ b/tgm/hooks/device.py
@@ -29,6 +29,7 @@ class DeviceTransferHook(StatelessHook):
     """Moves all tensors in the DGBatch to the specified device."""
 
     def __init__(self, device: str | torch.device) -> None:
+        super().__init__()
         self.device = torch.device(device)
 
     def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:

--- a/tgm/hooks/hook_manager.py
+++ b/tgm/hooks/hook_manager.py
@@ -187,19 +187,8 @@ class HookManager:
             hooks = self._shared_hooks + [
                 h for h in self._key_to_hooks[k] if h not in self._shared_hooks
             ]
-
-            # @TODO: Need a better solution when requirement at instance-level is introduced to DGHook
-            filter_hooks = [h for h in hooks if not self._is_dedup(h)]
-            dedups = list(set(hooks) - set(filter_hooks))
-            hooks = filter_hooks
-
             logger.debug('Running topological sort to resolve hooks for key: %s', k)
             self._key_to_hooks[k] = self._topological_sort_hooks(hooks)
-            if len(dedups) > 0:
-                logger.debug(
-                    'Identify DeduplicationHook. Enforce DeduplicationHook to run at the end.'
-                )
-                self._key_to_hooks[k].extend(dedups)
             self._dirty[k] = False
 
     @contextmanager
@@ -318,6 +307,3 @@ class HookManager:
             logger.debug(f'  - {h.__class__.__name__}')
 
         return ordered
-
-    def _is_dedup(self, hook: DGHook) -> bool:
-        return 'Deduplication' in hook.__class__.__name__

--- a/tgm/hooks/hook_manager.py
+++ b/tgm/hooks/hook_manager.py
@@ -51,7 +51,9 @@ class HookManager:
 
     def __str__(self) -> str:
         def _stringify_hook(h: DGHook) -> str:
-            return f'    - {h.__class__.__name__} (requires={h.requires}, produces={h.produces})'
+            return (
+                f'    - {h.__repr__()} (requires={h.requires}, produces={h.produces})'
+            )
 
         lines = ['HookManager:']
         lines.append('  Shared hooks:')

--- a/tgm/hooks/negatives.py
+++ b/tgm/hooks/negatives.py
@@ -125,47 +125,52 @@ class TGBNegativeEdgeSamplerHook(StatelessHook):
 
     def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:
         if batch.edge_src.size(0) == 0:
-            batch.neg = torch.empty(  # type: ignore
+            batch_neg = torch.empty(
                 batch.edge_src.size(0), dtype=torch.int32, device=dg.device
             )
-            batch.neg_time = torch.empty(  # type: ignore
+            batch_neg_time = torch.empty(
                 batch.edge_src.size(0), dtype=torch.int64, device=dg.device
             )
-            batch.neg_batch_list = []  # type: ignore
-            return batch  # empty batch
-        try:
-            neg_batch_list = self.neg_sampler.query_batch(
-                batch.edge_src,
-                batch.edge_dst,
-                batch.edge_time,
-                split_mode=self.split_mode,
+            batch_neg_batch_list = []
+            # return batch  # empty batch
+        else:
+            try:
+                neg_batch_list = self.neg_sampler.query_batch(
+                    batch.edge_src,
+                    batch.edge_dst,
+                    batch.edge_time,
+                    split_mode=self.split_mode,
+                )
+            except ValueError as e:
+                raise ValueError(
+                    f'Negative sampling failed for split_mode={self.split_mode}. Try updating your TGB package: `pip install --upgrade py-tgb`'
+                ) from e
+
+            batch_neg_batch_list = [
+                torch.tensor(neg_batch, dtype=torch.int32, device=dg.device)
+                for neg_batch in neg_batch_list
+            ]
+            batch_neg = torch.unique(torch.cat(batch_neg_batch_list))
+
+            # This is a heuristic. For our fake (negative) link times,
+            # we pick random time stamps within [batch.start_time, batch.end_time].
+            # Using random times on the whole graph will likely produce information
+            # leakage, making the prediction easier than it should be.
+
+            # Use generator to local constrain rng for reproducibility
+            gen = torch.Generator(device=dg.device)
+            gen.manual_seed(0)
+            batch_neg_time = torch.randint(
+                int(batch.edge_time.min().item()),
+                int(batch.edge_time.max().item()) + 1,
+                (batch_neg.size(0),),
+                device=dg.device,
+                generator=gen,
             )
-        except ValueError as e:
-            raise ValueError(
-                f'Negative sampling failed for split_mode={self.split_mode}. Try updating your TGB package: `pip install --upgrade py-tgb`'
-            ) from e
 
-        batch.neg_batch_list = [  # type: ignore
-            torch.tensor(neg_batch, dtype=torch.int32, device=dg.device)
-            for neg_batch in neg_batch_list
-        ]
-        batch.neg = torch.unique(torch.cat(batch.neg_batch_list))  # type: ignore
-
-        # This is a heuristic. For our fake (negative) link times,
-        # we pick random time stamps within [batch.start_time, batch.end_time].
-        # Using random times on the whole graph will likely produce information
-        # leakage, making the prediction easier than it should be.
-
-        # Use generator to local constrain rng for reproducibility
-        gen = torch.Generator(device=dg.device)
-        gen.manual_seed(0)
-        batch.neg_time = torch.randint(  # type: ignore
-            int(batch.edge_time.min().item()),
-            int(batch.edge_time.max().item()) + 1,
-            (batch.neg.size(0),),  # type: ignore
-            device=dg.device,
-            generator=gen,
-        )
+        self.add_attribute_to_batch(batch, 'neg', batch_neg)
+        self.add_attribute_to_batch(batch, 'neg_batch_list', batch_neg_batch_list)
+        self.add_attribute_to_batch(batch, 'neg_time', batch_neg_time)
         return batch
 
 
@@ -260,48 +265,52 @@ class TGBTHGNegativeEdgeSamplerHook(StatelessHook):
 
     def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:
         if batch.edge_src.size(0) == 0:
-            batch.neg = torch.empty(  # type: ignore
+            batch_neg = torch.empty(
                 batch.edge_src.size(0), dtype=torch.int32, device=dg.device
             )
-            batch.neg_time = torch.empty(  # type: ignore
+            batch_neg_time = torch.empty(
                 batch.edge_src.size(0), dtype=torch.int64, device=dg.device
             )
-            batch.neg_batch_list = []  # type: ignore
-            return batch  # empty batch
-        try:
-            neg_batch_list = self.neg_sampler.query_batch(
-                batch.edge_src,
-                batch.edge_dst,
-                batch.edge_time,
-                batch.edge_type,
-                split_mode=self.split_mode,
+            batch_neg_batch_list = []
+        else:
+            try:
+                neg_batch_list = self.neg_sampler.query_batch(
+                    batch.edge_src,
+                    batch.edge_dst,
+                    batch.edge_time,
+                    batch.edge_type,
+                    split_mode=self.split_mode,
+                )
+            except ValueError as e:
+                raise ValueError(
+                    f'THGL Negative sampling failed for split_mode={self.split_mode}. Try updating your TGB package: `pip install --upgrade py-tgb`'
+                ) from e
+
+            batch_neg_batch_list = [
+                torch.tensor(neg_batch, dtype=torch.int32, device=dg.device)
+                for neg_batch in neg_batch_list
+            ]
+            batch_neg = torch.unique(torch.cat(batch_neg_batch_list))
+
+            # This is a heuristic. For our fake (negative) link times,
+            # we pick random time stamps within [batch.start_time, batch.end_time].
+            # Using random times on the whole graph will likely produce information
+            # leakage, making the prediction easier than it should be.
+
+            # Use generator to local constrain rng for reproducibility
+            gen = torch.Generator(device=dg.device)
+            gen.manual_seed(0)
+            batch_neg_time = torch.randint(
+                int(batch.edge_time.min().item()),
+                int(batch.edge_time.max().item()) + 1,
+                (batch_neg.size(0),),
+                device=dg.device,
+                generator=gen,
             )
-        except ValueError as e:
-            raise ValueError(
-                f'THGL Negative sampling failed for split_mode={self.split_mode}. Try updating your TGB package: `pip install --upgrade py-tgb`'
-            ) from e
 
-        batch.neg_batch_list = [  # type: ignore
-            torch.tensor(neg_batch, dtype=torch.int32, device=dg.device)
-            for neg_batch in neg_batch_list
-        ]
-        batch.neg = torch.unique(torch.cat(batch.neg_batch_list))  # type: ignore
-
-        # This is a heuristic. For our fake (negative) link times,
-        # we pick random time stamps within [batch.start_time, batch.end_time].
-        # Using random times on the whole graph will likely produce information
-        # leakage, making the prediction easier than it should be.
-
-        # Use generator to local constrain rng for reproducibility
-        gen = torch.Generator(device=dg.device)
-        gen.manual_seed(0)
-        batch.neg_time = torch.randint(  # type: ignore
-            int(batch.edge_time.min().item()),
-            int(batch.edge_time.max().item()) + 1,
-            (batch.neg.size(0),),  # type: ignore
-            device=dg.device,
-            generator=gen,
-        )
+        self.add_attribute_to_batch(batch, 'neg', batch_neg)
+        self.add_attribute_to_batch(batch, 'neg_batch_list', batch_neg_batch_list)
+        self.add_attribute_to_batch(batch, 'neg_time', batch_neg_time)
         return batch
 
 
@@ -384,46 +393,49 @@ class TGBTKGNegativeEdgeSamplerHook(StatelessHook):
 
     def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:
         if batch.edge_src.size(0) == 0:
-            batch.neg = torch.empty(  # type: ignore
+            batch_neg = torch.empty(
                 batch.edge_src.size(0), dtype=torch.int32, device=dg.device
             )
-            batch.neg_time = torch.empty(  # type: ignore
+            batch_neg_time = torch.empty(
                 batch.edge_src.size(0), dtype=torch.int64, device=dg.device
             )
-            batch.neg_batch_list = []  # type: ignore
-            return batch  # empty batch
-        try:
-            neg_batch_list = self.neg_sampler.query_batch(
-                batch.edge_src,
-                batch.edge_dst,
-                batch.edge_time,
-                batch.edge_type,
-                split_mode=self.split_mode,
+            batch_neg_batch_list = []
+        else:
+            try:
+                neg_batch_list = self.neg_sampler.query_batch(
+                    batch.edge_src,
+                    batch.edge_dst,
+                    batch.edge_time,
+                    batch.edge_type,
+                    split_mode=self.split_mode,
+                )
+            except ValueError as e:
+                raise ValueError(
+                    f'TKGL Negative sampling failed for split_mode={self.split_mode}. Try updating your TGB package: `pip install --upgrade py-tgb`'
+                ) from e
+
+            batch_neg_batch_list = [
+                torch.tensor(neg_batch, dtype=torch.int32, device=dg.device)
+                for neg_batch in neg_batch_list
+            ]
+            batch_neg = torch.unique(torch.cat(batch_neg_batch_list))
+            # This is a heuristic. For our fake (negative) link times,
+            # we pick random time stamps within [batch.start_time, batch.end_time].
+            # Using random times on the whole graph will likely produce information
+            # leakage, making the prediction easier than it should be.
+
+            # Use generator to local constrain rng for reproducibility
+            gen = torch.Generator(device=dg.device)
+            gen.manual_seed(0)
+            batch_neg_time = torch.randint(
+                int(batch.edge_time.min().item()),
+                int(batch.edge_time.max().item()) + 1,
+                (batch_neg.size(0),),
+                device=dg.device,
+                generator=gen,
             )
-        except ValueError as e:
-            raise ValueError(
-                f'TKGL Negative sampling failed for split_mode={self.split_mode}. Try updating your TGB package: `pip install --upgrade py-tgb`'
-            ) from e
 
-        batch.neg_batch_list = [  # type: ignore
-            torch.tensor(neg_batch, dtype=torch.int32, device=dg.device)
-            for neg_batch in neg_batch_list
-        ]
-        batch.neg = torch.unique(torch.cat(batch.neg_batch_list))  # type: ignore
-
-        # This is a heuristic. For our fake (negative) link times,
-        # we pick random time stamps within [batch.start_time, batch.end_time].
-        # Using random times on the whole graph will likely produce information
-        # leakage, making the prediction easier than it should be.
-
-        # Use generator to local constrain rng for reproducibility
-        gen = torch.Generator(device=dg.device)
-        gen.manual_seed(0)
-        batch.neg_time = torch.randint(  # type: ignore
-            int(batch.edge_time.min().item()),
-            int(batch.edge_time.max().item()) + 1,
-            (batch.neg.size(0),),  # type: ignore
-            device=dg.device,
-            generator=gen,
-        )
+        self.add_attribute_to_batch(batch, 'neg', batch_neg)
+        self.add_attribute_to_batch(batch, 'neg_batch_list', batch_neg_batch_list)
+        self.add_attribute_to_batch(batch, 'neg_time', batch_neg_time)
         return batch

--- a/tgm/hooks/negatives.py
+++ b/tgm/hooks/negatives.py
@@ -19,12 +19,12 @@ class NegativeEdgeSamplerHook(StatelessHook):
         high (int) : The maximum node id to sample
         neg_ratio (float): The ratio of sampled negative destination nodes
             to the number of positive destination nodes (default = 1.0).
+        id (str): A unique identifier for the hook. The hook’s name and all attributes it produces will be suffixed with this `id`.
     """
 
-    requires = {'edge_src', 'edge_dst', 'edge_time'}
-    produces = {'neg', 'neg_time'}
-
-    def __init__(self, low: int, high: int, neg_ratio: float = 1.0) -> None:
+    def __init__(
+        self, low: int, high: int, neg_ratio: float = 1.0, id: str | None = None
+    ) -> None:
         if not 0 < neg_ratio <= 1:
             raise ValueError(f'neg_ratio must be in (0, 1], got: {neg_ratio}')
         if not low < high:
@@ -32,6 +32,10 @@ class NegativeEdgeSamplerHook(StatelessHook):
         self.low = low
         self.high = high
         self.neg_ratio = neg_ratio
+        self.id = id
+        self.requires = {'edge_src', 'edge_dst', 'edge_time'}
+        self.produces = {'neg', 'neg_time'}
+        self.__post_init__()
 
     # TODO: Historical vs. random
     def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:
@@ -54,6 +58,7 @@ class TGBNegativeEdgeSamplerHook(StatelessHook):
     Args:
         dataset_name (str): The name of the TGB dataset to produce sampler for.
         split_mode (str): The split mode to use for sampling, either 'val' or 'test'.
+        id (str): A unique identifier for the hook. The hook’s name and all attributes it produces will be suffixed with this `id`.
 
     Raises:
         ValueError: If neg_sampler is not provided.
@@ -62,7 +67,9 @@ class TGBNegativeEdgeSamplerHook(StatelessHook):
     requires = {'edge_src', 'edge_dst', 'edge_time'}
     produces = {'neg', 'neg_batch_list', 'neg_time'}
 
-    def __init__(self, dataset_name: str, split_mode: str) -> None:
+    def __init__(
+        self, dataset_name: str, split_mode: str, id: str | None = None
+    ) -> None:
         if split_mode not in ['val', 'test']:
             raise ValueError(f'split_mode must be "val" or "test", got: {split_mode}')
 
@@ -100,6 +107,10 @@ class TGBNegativeEdgeSamplerHook(StatelessHook):
 
         self.neg_sampler = neg_sampler
         self.split_mode = split_mode
+        self.id = id
+        self.requires = {'edge_src', 'edge_dst', 'edge_time'}
+        self.produces = {'neg', 'neg_batch_list', 'neg_time'}
+        self.__post_init__()
 
     def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:
         if batch.edge_src.size(0) == 0:
@@ -157,6 +168,8 @@ class TGBTHGNegativeEdgeSamplerHook(StatelessHook):
         first_node_id (int): identity of the first node
         last_node_id (int): identity of the last destination node
         node_type (Tensor): the node type of each node
+        id (str): A unique identifier for the hook. The hook’s name and all attributes it produces will be suffixed with this `id`.
+
 
 
     Raises:
@@ -170,10 +183,8 @@ class TGBTHGNegativeEdgeSamplerHook(StatelessHook):
         first_node_id: int,
         last_node_id: int,
         node_type: torch.Tensor,
+        id: str | None = None,
     ) -> None:
-        self.requires = {'edge_src', 'edge_dst', 'edge_time', 'edge_type'}
-        self.produces = {'neg', 'neg_batch_list', 'neg_time'}
-
         if split_mode not in ['val', 'test']:
             raise ValueError(f'split_mode must be "val" or "test", got: {split_mode}')
 
@@ -227,6 +238,12 @@ class TGBTHGNegativeEdgeSamplerHook(StatelessHook):
 
         self.neg_sampler = neg_sampler
         self.split_mode = split_mode
+
+        self.id = id
+        self.requires = {'edge_src', 'edge_dst', 'edge_time', 'edge_type'}
+        self.produces = {'neg', 'neg_batch_list', 'neg_time'}
+
+        self.__post_init__()
 
     def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:
         if batch.edge_src.size(0) == 0:
@@ -284,14 +301,12 @@ class TGBTKGNegativeEdgeSamplerHook(StatelessHook):
         split_mode (str): The split mode to use for sampling, either 'val' or 'test'.
         first_dst_id (int): identity of the first destination node
         last_dst_id (int): identity of the last destination node
+        id (str): A unique identifier for the hook. The hook’s name and all attributes it produces will be suffixed with this `id`.
 
 
     Raises:
         ValueError: If neg_sampler is not provided.
     """
-
-    requires = {'edge_src', 'edge_dst', 'edge_time', 'edge_type'}
-    produces = {'neg', 'neg_batch_list', 'neg_time'}
 
     def __init__(
         self,
@@ -299,6 +314,7 @@ class TGBTKGNegativeEdgeSamplerHook(StatelessHook):
         split_mode: str,
         first_dst_id: int,
         last_dst_id: int,
+        id: str | None = None,
     ) -> None:
         if split_mode not in ['val', 'test']:
             raise ValueError(f'split_mode must be "val" or "test", got: {split_mode}')
@@ -346,6 +362,10 @@ class TGBTKGNegativeEdgeSamplerHook(StatelessHook):
 
         self.neg_sampler = neg_sampler
         self.split_mode = split_mode
+        self.id = id
+        self.requires = {'edge_src', 'edge_dst', 'edge_time', 'edge_type'}
+        self.produces = {'neg', 'neg_batch_list', 'neg_time'}
+        self.__post_init__()
 
     def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:
         if batch.edge_src.size(0) == 0:

--- a/tgm/hooks/negatives.py
+++ b/tgm/hooks/negatives.py
@@ -41,13 +41,23 @@ class NegativeEdgeSamplerHook(StatelessHook):
     def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:
         size = (round(self.neg_ratio * batch.edge_dst.size(0)),)
         if size[0] == 0:
-            batch.neg = torch.empty(size, dtype=torch.int32, device=dg.device)  # type: ignore
-            batch.neg_time = torch.empty(size, dtype=torch.int64, device=dg.device)  # type: ignore
-        else:
-            batch.neg = torch.randint(  # type: ignore
-                self.low, self.high, size, dtype=torch.int32, device=dg.device
+            self.add_attribute_to_batch(
+                batch, 'neg', torch.empty(size, dtype=torch.int32, device=dg.device)
             )
-            batch.neg_time = batch.edge_time.clone()  # type: ignore
+            self.add_attribute_to_batch(
+                batch,
+                'neg_time',
+                torch.empty(size, dtype=torch.int64, device=dg.device),
+            )
+        else:
+            self.add_attribute_to_batch(
+                batch,
+                'neg',
+                torch.randint(
+                    self.low, self.high, size, dtype=torch.int32, device=dg.device
+                ),
+            )
+            self.add_attribute_to_batch(batch, 'neg_time', batch.edge_time.clone())
         return batch
 
 

--- a/tgm/hooks/negatives.py
+++ b/tgm/hooks/negatives.py
@@ -22,9 +22,13 @@ class NegativeEdgeSamplerHook(StatelessHook):
         id (str): A unique identifier for the hook. The hook’s name and all attributes it produces will be suffixed with this `id`.
     """
 
+    _cls_requires = {'edge_src', 'edge_dst', 'edge_time'}
+    _cls_produces = {'neg', 'neg_time'}
+
     def __init__(
         self, low: int, high: int, neg_ratio: float = 1.0, id: str | None = None
     ) -> None:
+        super().__init__()
         if not 0 < neg_ratio <= 1:
             raise ValueError(f'neg_ratio must be in (0, 1], got: {neg_ratio}')
         if not low < high:
@@ -32,9 +36,7 @@ class NegativeEdgeSamplerHook(StatelessHook):
         self.low = low
         self.high = high
         self.neg_ratio = neg_ratio
-        self.id = id
-        self.requires = {'edge_src', 'edge_dst', 'edge_time'}
-        self.produces = {'neg', 'neg_time'}
+        self._id = id
         self.__post_init__()
 
     # TODO: Historical vs. random
@@ -74,12 +76,13 @@ class TGBNegativeEdgeSamplerHook(StatelessHook):
         ValueError: If neg_sampler is not provided.
     """
 
-    requires = {'edge_src', 'edge_dst', 'edge_time'}
-    produces = {'neg', 'neg_batch_list', 'neg_time'}
+    _cls_requires = {'edge_src', 'edge_dst', 'edge_time'}
+    _cls_produces = {'neg', 'neg_batch_list', 'neg_time'}
 
     def __init__(
         self, dataset_name: str, split_mode: str, id: str | None = None
     ) -> None:
+        super().__init__()
         if split_mode not in ['val', 'test']:
             raise ValueError(f'split_mode must be "val" or "test", got: {split_mode}')
 
@@ -117,9 +120,7 @@ class TGBNegativeEdgeSamplerHook(StatelessHook):
 
         self.neg_sampler = neg_sampler
         self.split_mode = split_mode
-        self.id = id
-        self.requires = {'edge_src', 'edge_dst', 'edge_time'}
-        self.produces = {'neg', 'neg_batch_list', 'neg_time'}
+        self._id = id
         self.__post_init__()
 
     def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:
@@ -186,6 +187,9 @@ class TGBTHGNegativeEdgeSamplerHook(StatelessHook):
         ValueError: If neg_sampler is not provided.
     """
 
+    _cls_requires = {'edge_src', 'edge_dst', 'edge_time', 'edge_type'}
+    _cls_produces = {'neg', 'neg_batch_list', 'neg_time'}
+
     def __init__(
         self,
         dataset_name: str,
@@ -195,6 +199,7 @@ class TGBTHGNegativeEdgeSamplerHook(StatelessHook):
         node_type: torch.Tensor,
         id: str | None = None,
     ) -> None:
+        super().__init__()
         if split_mode not in ['val', 'test']:
             raise ValueError(f'split_mode must be "val" or "test", got: {split_mode}')
 
@@ -249,9 +254,7 @@ class TGBTHGNegativeEdgeSamplerHook(StatelessHook):
         self.neg_sampler = neg_sampler
         self.split_mode = split_mode
 
-        self.id = id
-        self.requires = {'edge_src', 'edge_dst', 'edge_time', 'edge_type'}
-        self.produces = {'neg', 'neg_batch_list', 'neg_time'}
+        self._id = id
 
         self.__post_init__()
 
@@ -318,6 +321,9 @@ class TGBTKGNegativeEdgeSamplerHook(StatelessHook):
         ValueError: If neg_sampler is not provided.
     """
 
+    _cls_requires = {'edge_src', 'edge_dst', 'edge_time', 'edge_type'}
+    _cls_produces = {'neg', 'neg_batch_list', 'neg_time'}
+
     def __init__(
         self,
         dataset_name: str,
@@ -326,6 +332,7 @@ class TGBTKGNegativeEdgeSamplerHook(StatelessHook):
         last_dst_id: int,
         id: str | None = None,
     ) -> None:
+        super().__init__()
         if split_mode not in ['val', 'test']:
             raise ValueError(f'split_mode must be "val" or "test", got: {split_mode}')
 
@@ -372,9 +379,7 @@ class TGBTKGNegativeEdgeSamplerHook(StatelessHook):
 
         self.neg_sampler = neg_sampler
         self.split_mode = split_mode
-        self.id = id
-        self.requires = {'edge_src', 'edge_dst', 'edge_time', 'edge_type'}
-        self.produces = {'neg', 'neg_batch_list', 'neg_time'}
+        self._id = id
         self.__post_init__()
 
     def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:

--- a/tgm/hooks/negatives.py
+++ b/tgm/hooks/negatives.py
@@ -43,23 +43,23 @@ class NegativeEdgeSamplerHook(StatelessHook):
     def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:
         size = (round(self.neg_ratio * batch.edge_dst.size(0)),)
         if size[0] == 0:
-            self.add_attribute_to_batch(
+            self.add_batch_attribute(
                 batch, 'neg', torch.empty(size, dtype=torch.int32, device=dg.device)
             )
-            self.add_attribute_to_batch(
+            self.add_batch_attribute(
                 batch,
                 'neg_time',
                 torch.empty(size, dtype=torch.int64, device=dg.device),
             )
         else:
-            self.add_attribute_to_batch(
+            self.add_batch_attribute(
                 batch,
                 'neg',
                 torch.randint(
                     self.low, self.high, size, dtype=torch.int32, device=dg.device
                 ),
             )
-            self.add_attribute_to_batch(batch, 'neg_time', batch.edge_time.clone())
+            self.add_batch_attribute(batch, 'neg_time', batch.edge_time.clone())
         return batch
 
 
@@ -168,9 +168,9 @@ class TGBNegativeEdgeSamplerHook(StatelessHook):
                 generator=gen,
             )
 
-        self.add_attribute_to_batch(batch, 'neg', batch_neg)
-        self.add_attribute_to_batch(batch, 'neg_batch_list', batch_neg_batch_list)
-        self.add_attribute_to_batch(batch, 'neg_time', batch_neg_time)
+        self.add_batch_attribute(batch, 'neg', batch_neg)
+        self.add_batch_attribute(batch, 'neg_batch_list', batch_neg_batch_list)
+        self.add_batch_attribute(batch, 'neg_time', batch_neg_time)
         return batch
 
 
@@ -308,9 +308,9 @@ class TGBTHGNegativeEdgeSamplerHook(StatelessHook):
                 generator=gen,
             )
 
-        self.add_attribute_to_batch(batch, 'neg', batch_neg)
-        self.add_attribute_to_batch(batch, 'neg_batch_list', batch_neg_batch_list)
-        self.add_attribute_to_batch(batch, 'neg_time', batch_neg_time)
+        self.add_batch_attribute(batch, 'neg', batch_neg)
+        self.add_batch_attribute(batch, 'neg_batch_list', batch_neg_batch_list)
+        self.add_batch_attribute(batch, 'neg_time', batch_neg_time)
         return batch
 
 
@@ -435,7 +435,7 @@ class TGBTKGNegativeEdgeSamplerHook(StatelessHook):
                 generator=gen,
             )
 
-        self.add_attribute_to_batch(batch, 'neg', batch_neg)
-        self.add_attribute_to_batch(batch, 'neg_batch_list', batch_neg_batch_list)
-        self.add_attribute_to_batch(batch, 'neg_time', batch_neg_time)
+        self.add_batch_attribute(batch, 'neg', batch_neg)
+        self.add_batch_attribute(batch, 'neg_batch_list', batch_neg_batch_list)
+        self.add_batch_attribute(batch, 'neg_time', batch_neg_time)
         return batch

--- a/tgm/hooks/negatives.py
+++ b/tgm/hooks/negatives.py
@@ -163,9 +163,6 @@ class TGBTHGNegativeEdgeSamplerHook(StatelessHook):
         ValueError: If neg_sampler is not provided.
     """
 
-    requires = {'edge_src', 'edge_dst', 'edge_time', 'edge_type'}
-    produces = {'neg', 'neg_batch_list', 'neg_time'}
-
     def __init__(
         self,
         dataset_name: str,
@@ -174,6 +171,9 @@ class TGBTHGNegativeEdgeSamplerHook(StatelessHook):
         last_node_id: int,
         node_type: torch.Tensor,
     ) -> None:
+        self.requires = {'edge_src', 'edge_dst', 'edge_time', 'edge_type'}
+        self.produces = {'neg', 'neg_batch_list', 'neg_time'}
+
         if split_mode not in ['val', 'test']:
             raise ValueError(f'split_mode must be "val" or "test", got: {split_mode}')
 

--- a/tgm/hooks/neighbors.py
+++ b/tgm/hooks/neighbors.py
@@ -133,12 +133,12 @@ class NeighborSamplerHook(StatelessHook, SeedableHook):
                 batch_nbr_edge_time.append(nbr_edge_time)
                 batch_nbr_edge_x.append(nbr_edge_x)
 
-        self.add_attribute_to_batch(batch, 'seed_nids', batch_seed_nids)
-        self.add_attribute_to_batch(batch, 'seed_times', batch_seed_times)
-        self.add_attribute_to_batch(batch, 'nbr_nids', batch_nbr_nids)
-        self.add_attribute_to_batch(batch, 'nbr_edge_time', batch_nbr_edge_time)
-        self.add_attribute_to_batch(batch, 'nbr_edge_x', batch_nbr_edge_x)
-        self.add_attribute_to_batch(batch, 'seed_node_nbr_mask', seed_node_nbr_mask)
+        self.add_batch_attribute(batch, 'seed_nids', batch_seed_nids)
+        self.add_batch_attribute(batch, 'seed_times', batch_seed_times)
+        self.add_batch_attribute(batch, 'nbr_nids', batch_nbr_nids)
+        self.add_batch_attribute(batch, 'nbr_edge_time', batch_nbr_edge_time)
+        self.add_batch_attribute(batch, 'nbr_edge_x', batch_nbr_edge_x)
+        self.add_batch_attribute(batch, 'seed_node_nbr_mask', seed_node_nbr_mask)
 
         return batch
 
@@ -354,12 +354,12 @@ class RecencyNeighborHook(StatefulHook, SeedableHook):
                 logger.debug('Updating circular buffers')
                 self._update(batch)
 
-        self.add_attribute_to_batch(batch, 'seed_nids', batch_seed_nids)
-        self.add_attribute_to_batch(batch, 'seed_times', batch_seed_times)
-        self.add_attribute_to_batch(batch, 'nbr_nids', batch_nbr_nids)
-        self.add_attribute_to_batch(batch, 'nbr_edge_time', batch_nbr_edge_time)
-        self.add_attribute_to_batch(batch, 'nbr_edge_x', batch_nbr_edge_x)
-        self.add_attribute_to_batch(batch, 'seed_node_nbr_mask', seed_node_mask)
+        self.add_batch_attribute(batch, 'seed_nids', batch_seed_nids)
+        self.add_batch_attribute(batch, 'seed_times', batch_seed_times)
+        self.add_batch_attribute(batch, 'nbr_nids', batch_nbr_nids)
+        self.add_batch_attribute(batch, 'nbr_edge_time', batch_nbr_edge_time)
+        self.add_batch_attribute(batch, 'nbr_edge_x', batch_nbr_edge_x)
+        self.add_batch_attribute(batch, 'seed_node_nbr_mask', seed_node_mask)
         return batch
 
     def _get_seed_tensors(

--- a/tgm/hooks/neighbors.py
+++ b/tgm/hooks/neighbors.py
@@ -22,6 +22,8 @@ class NeighborSamplerHook(StatelessHook):
         directed (bool): If true, aggregates interactions in edge_src->edge_dst direction only (default=False).
         seed_nodes_keys ([List[str]): List of batch attribute keys to identify the initial seed nodes to sample for.
         seed_times_keys ([List[str]): List of batch attribute keys to identify the initial seed times to sample for.
+        id (str): A unique identifier for the hook. The hook’s name and all attributes it produces will be suffixed with this `id`.
+
 
     Note:
         The order of the output tensors respect the order of seed_nodes_keys.
@@ -40,17 +42,8 @@ class NeighborSamplerHook(StatelessHook):
         seed_nodes_keys: List[str],
         seed_times_keys: List[str],
         directed: bool = False,
+        id: str | None = None,
     ) -> None:
-        self.requires = {'edge_src', 'edge_dst', 'edge_time'} | set(seed_nodes_keys)
-        self.produces = {
-            'seed_nids',
-            'seed_times',
-            'nbr_nids',
-            'nbr_edge_time',
-            'nbr_edge_x',
-            'seed_node_nbr_mask',
-        }
-
         if not len(num_nbrs):
             raise ValueError('num_nbrs must be non-empty')
         if not all([isinstance(x, int) and (x > 0) for x in num_nbrs]):
@@ -73,6 +66,17 @@ class NeighborSamplerHook(StatelessHook):
             self._seed_times_keys,
         )
         self._warned_seed_None = False
+        self.id = id
+        self.requires = {'edge_src', 'edge_dst', 'edge_time'} | set(seed_nodes_keys)
+        self.produces = {
+            'seed_nids',
+            'seed_times',
+            'nbr_nids',
+            'nbr_edge_time',
+            'nbr_edge_x',
+            'seed_node_nbr_mask',
+        }
+        self.__post_init__()
 
     @property
     def num_nbrs(self) -> List[int]:
@@ -200,8 +204,6 @@ class NeighborSamplerHook(StatelessHook):
 
 
 class RecencyNeighborHook(StatefulHook):
-    
-
     """Load neighbors from DGraph using a recency sampling. Each node maintains a fixed number of recent neighbors.
 
     Args:
@@ -212,6 +214,7 @@ class RecencyNeighborHook(StatefulHook):
                                                If not specified, defaults to batch seed_times: ['time', 'time']
         seed_nodes_keys ([List[str]): List of batch attribute keys to identify the initial seed nodes to sample for.
         seed_times_keys ([List[str]): List of batch attribute keys to identify the initial seed times to sample for.
+        id (str): A unique identifier for the hook. The hook’s name and all attributes it produces will be suffixed with this `id`.
 
     Note:
         The order of the output tensors respect the order of seed_nodes_keys.
@@ -231,16 +234,8 @@ class RecencyNeighborHook(StatefulHook):
         seed_nodes_keys: List[str],
         seed_times_keys: List[str],
         directed: bool = False,
+        id: str | None = None,
     ) -> None:
-        self.requires = {'edge_src', 'edge_dst', 'edge_time'} | set(seed_nodes_keys)
-        self.produces = {
-            'seed_nids',
-            'seed_times',
-            'nbr_nids',
-            'nbr_edge_time',
-            'nbr_edge_x',
-            'seed_node_nbr_mask',
-        }
         if not len(num_nbrs):
             raise ValueError('num_nbrs must be non-empty')
         if not all([isinstance(x, int) and (x > 0) for x in num_nbrs]):
@@ -278,6 +273,17 @@ class RecencyNeighborHook(StatefulHook):
         self._need_to_initialize_nbr_feats = True
         self._edge_x_dim = None
         self._nbr_feats = None
+        self.id = id
+        self.requires = {'edge_src', 'edge_dst', 'edge_time'} | set(seed_nodes_keys)
+        self.produces = {
+            'seed_nids',
+            'seed_times',
+            'nbr_nids',
+            'nbr_edge_time',
+            'nbr_edge_x',
+            'seed_node_nbr_mask',
+        }
+        self.__post_init__()
 
     @property
     def num_nbrs(self) -> List[int]:

--- a/tgm/hooks/neighbors.py
+++ b/tgm/hooks/neighbors.py
@@ -79,15 +79,6 @@ class NeighborSamplerHook(StatelessHook, SeedableHook):
         self._warned_seed_None = False
         self._id = id
         self.seed_keys = seed_nodes_keys
-        # self.requires = {'edge_src', 'edge_dst', 'edge_time'} | set(seed_nodes_keys)
-        # self.produces = {
-        #     'seed_nids',
-        #     'seed_times',
-        #     'nbr_nids',
-        #     'nbr_edge_time',
-        #     'nbr_edge_x',
-        #     'seed_node_nbr_mask',
-        # }
         self.__post_init__()
 
     @property
@@ -95,16 +86,16 @@ class NeighborSamplerHook(StatelessHook, SeedableHook):
         return self._num_nbrs
 
     def __call__(self, dg: DGraph, batch: DGBatch) -> DGBatch:
-        batch.seed_nids, batch.seed_times = [], []  # type: ignore
-        batch.nbr_nids, batch.nbr_edge_time = [], []  # type: ignore
-        batch.nbr_edge_x = []  # type: ignore
+        batch_seed_nids, batch_seed_times = [], []
+        batch_nbr_nids, batch_nbr_edge_time = [], []
+        batch_nbr_edge_x = []
 
         def _append_empty_hop() -> None:
-            batch.seed_nids.append(torch.empty(0, dtype=torch.int32))  # type: ignore
-            batch.seed_times.append(torch.empty(0, dtype=torch.int64))  # type: ignore
-            batch.nbr_nids.append(torch.empty(0, dtype=torch.int32))  # type: ignore
-            batch.nbr_edge_time.append(torch.empty(0, dtype=torch.int64))  # type: ignore
-            batch.nbr_edge_x.append(  # type: ignore
+            batch_seed_nids.append(torch.empty(0, dtype=torch.int32))
+            batch_seed_times.append(torch.empty(0, dtype=torch.int64))
+            batch_nbr_nids.append(torch.empty(0, dtype=torch.int32))
+            batch_nbr_edge_time.append(torch.empty(0, dtype=torch.int64))
+            batch_nbr_edge_x.append(
                 torch.empty(0, dg.edge_x_dim).float()  # type: ignore
             )
 
@@ -113,37 +104,42 @@ class NeighborSamplerHook(StatelessHook, SeedableHook):
             logger.debug('No seed_nodes found, appending empty hop information')
             for _ in self.num_nbrs:
                 _append_empty_hop()
-            batch.seed_node_nbr_mask = seed_node_nbr_mask  # type: ignore
-            return batch
 
-        for hop, num_nbrs in enumerate(self.num_nbrs):
-            if hop > 0:
-                seed_nodes = batch.nbr_nids[hop - 1].flatten()  # type: ignore
-                seed_times = batch.nbr_edge_time[hop - 1].flatten()  # type: ignore
+        else:
+            for hop, num_nbrs in enumerate(self.num_nbrs):
+                if hop > 0:
+                    seed_nodes = batch_nbr_nids[hop - 1].flatten()
+                    seed_times = batch_nbr_edge_time[hop - 1].flatten()
 
-            # TODO: Storage needs to use the right device
+                # TODO: Storage needs to use the right device
 
-            # We slice on batch.start_time so that we only consider neighbor events
-            # that occurred strictly before this batch
-            logger.debug(
-                'Getting uniform nbrs for hop %d with %d seed nodes',
-                hop,
-                seed_nodes.numel(),
-            )
-            nbr_nids, nbr_edge_time, nbr_edge_x = dg._storage.get_nbrs(
-                seed_nodes,
-                num_nbrs=num_nbrs,
-                slice=DGSliceTracker(end_time=int(batch.edge_time.min()) - 1),
-                directed=self._directed,
-            )
+                # We slice on batch.start_time so that we only consider neighbor events
+                # that occurred strictly before this batch
+                logger.debug(
+                    'Getting uniform nbrs for hop %d with %d seed nodes',
+                    hop,
+                    seed_nodes.numel(),
+                )
+                nbr_nids, nbr_edge_time, nbr_edge_x = dg._storage.get_nbrs(
+                    seed_nodes,
+                    num_nbrs=num_nbrs,
+                    slice=DGSliceTracker(end_time=int(batch.edge_time.min()) - 1),
+                    directed=self._directed,
+                )
 
-            batch.seed_nids.append(seed_nodes)  # type: ignore
-            batch.seed_times.append(seed_times)  # type: ignore
-            batch.nbr_nids.append(nbr_nids)  # type: ignore
-            batch.nbr_edge_time.append(nbr_edge_time)  # type: ignore
-            batch.nbr_edge_x.append(nbr_edge_x)  # type: ignore
+                batch_seed_nids.append(seed_nodes)
+                batch_seed_times.append(seed_times)
+                batch_nbr_nids.append(nbr_nids)
+                batch_nbr_edge_time.append(nbr_edge_time)
+                batch_nbr_edge_x.append(nbr_edge_x)
 
-        batch.seed_node_nbr_mask = seed_node_nbr_mask  # type: ignore
+        self.add_attribute_to_batch(batch, 'seed_nids', batch_seed_nids)
+        self.add_attribute_to_batch(batch, 'seed_times', batch_seed_times)
+        self.add_attribute_to_batch(batch, 'nbr_nids', batch_nbr_nids)
+        self.add_attribute_to_batch(batch, 'nbr_edge_time', batch_nbr_edge_time)
+        self.add_attribute_to_batch(batch, 'nbr_edge_x', batch_nbr_edge_x)
+        self.add_attribute_to_batch(batch, 'seed_node_nbr_mask', seed_node_nbr_mask)
+
         return batch
 
     def _get_seed_tensors(
@@ -298,15 +294,6 @@ class RecencyNeighborHook(StatefulHook, SeedableHook):
         self._nbr_feats = None
         self._id = id
         self.seed_keys = seed_nodes_keys
-        # self.requires = {'edge_src', 'edge_dst', 'edge_time'} | set(seed_nodes_keys)
-        # self.produces = {
-        #     'seed_nids',
-        #     'seed_times',
-        #     'nbr_nids',
-        #     'nbr_edge_time',
-        #     'nbr_edge_x',
-        #     'seed_node_nbr_mask',
-        # }
         self.__post_init__()
 
     @property
@@ -325,51 +312,54 @@ class RecencyNeighborHook(StatefulHook, SeedableHook):
         self._initialize_nbr_feats_if_needed(dg)
         self._move_queues_to_device_if_needed(dg.device)
 
-        batch.seed_nids, batch.seed_times = [], []  # type: ignore
-        batch.nbr_nids, batch.nbr_edge_time = [], []  # type: ignore
-        batch.nbr_edge_x = []  # type: ignore
+        batch_seed_nids, batch_seed_times = [], []
+        batch_nbr_nids, batch_nbr_edge_time = [], []
+        batch_nbr_edge_x = []
 
         def _append_empty_hop() -> None:
-            batch.seed_nids.append(torch.empty(0, dtype=torch.int32))  # type: ignore
-            batch.seed_times.append(torch.empty(0, dtype=torch.int64))  # type: ignore
-            batch.nbr_nids.append(torch.empty(0, dtype=torch.int32))  # type: ignore
-            batch.nbr_edge_time.append(torch.empty(0, dtype=torch.int64))  # type: ignore
-            batch.nbr_edge_x.append(  # type: ignore
-                torch.empty(0, dg.edge_x_dim).float()  # type: ignore
-            )
+            batch_seed_nids.append(torch.empty(0, dtype=torch.int32))
+            batch_seed_times.append(torch.empty(0, dtype=torch.int64))
+            batch_nbr_nids.append(torch.empty(0, dtype=torch.int32))
+            batch_nbr_edge_time.append(torch.empty(0, dtype=torch.int64))
+            batch_nbr_edge_x.append(torch.empty(0, dg.edge_x_dim).float())  # type: ignore[arg-type]
 
         seed_nodes, seed_times, seed_node_mask = self._get_seed_tensors(batch)
         if not seed_nodes.numel():
             logger.debug('No seed_nodes found, appending empty hop information')
             for _ in self.num_nbrs:
                 _append_empty_hop()
-            return batch
+        else:
+            for hop, num_nbrs in enumerate(self.num_nbrs):
+                if hop > 0:
+                    seed_nodes = batch_nbr_nids[hop - 1].flatten()
+                    seed_times = batch_nbr_edge_time[hop - 1].flatten()
 
-        for hop, num_nbrs in enumerate(self.num_nbrs):
-            if hop > 0:
-                seed_nodes = batch.nbr_nids[hop - 1].flatten()  # type: ignore
-                seed_times = batch.nbr_edge_time[hop - 1].flatten()  # type: ignore
+                logger.debug(
+                    'Getting last %d nbrs for hop %d with %d seed nodes',
+                    num_nbrs,
+                    hop,
+                    seed_nodes.numel(),
+                )
+                nbr_nids, nbr_edge_time, nbr_edge_x = self._get_recency_neighbors(
+                    seed_nodes, seed_times, num_nbrs
+                )
 
-            logger.debug(
-                'Getting last %d nbrs for hop %d with %d seed nodes',
-                num_nbrs,
-                hop,
-                seed_nodes.numel(),
-            )
-            nbr_nids, nbr_edge_time, nbr_edge_x = self._get_recency_neighbors(
-                seed_nodes, seed_times, num_nbrs
-            )
+                batch_seed_nids.append(seed_nodes)
+                batch_seed_times.append(seed_times)
+                batch_nbr_nids.append(nbr_nids)
+                batch_nbr_edge_time.append(nbr_edge_time)
+                batch_nbr_edge_x.append(nbr_edge_x)
 
-            batch.seed_nids.append(seed_nodes)  # type: ignore
-            batch.seed_times.append(seed_times)  # type: ignore
-            batch.nbr_nids.append(nbr_nids)  # type: ignore
-            batch.nbr_edge_time.append(nbr_edge_time)  # type: ignore
-            batch.nbr_edge_x.append(nbr_edge_x)  # type: ignore
+            if batch.edge_src.numel():
+                logger.debug('Updating circular buffers')
+                self._update(batch)
 
-        batch.seed_node_nbr_mask = seed_node_mask  # type: ignore
-        if batch.edge_src.numel():
-            logger.debug('Updating circular buffers')
-            self._update(batch)
+        self.add_attribute_to_batch(batch, 'seed_nids', batch_seed_nids)
+        self.add_attribute_to_batch(batch, 'seed_times', batch_seed_times)
+        self.add_attribute_to_batch(batch, 'nbr_nids', batch_nbr_nids)
+        self.add_attribute_to_batch(batch, 'nbr_edge_time', batch_nbr_edge_time)
+        self.add_attribute_to_batch(batch, 'nbr_edge_x', batch_nbr_edge_x)
+        self.add_attribute_to_batch(batch, 'seed_node_nbr_mask', seed_node_mask)
         return batch
 
     def _get_seed_tensors(

--- a/tgm/hooks/neighbors.py
+++ b/tgm/hooks/neighbors.py
@@ -41,7 +41,7 @@ class NeighborSamplerHook(StatelessHook):
         seed_times_keys: List[str],
         directed: bool = False,
     ) -> None:
-        self.requires = {'edge_src', 'edge_dst', 'edge_time'}
+        self.requires = {'edge_src', 'edge_dst', 'edge_time'} | set(seed_nodes_keys)
         self.produces = {
             'seed_nids',
             'seed_times',
@@ -200,15 +200,7 @@ class NeighborSamplerHook(StatelessHook):
 
 
 class RecencyNeighborHook(StatefulHook):
-    requires = {'edge_src', 'edge_dst', 'edge_time'}
-    produces = {
-        'seed_nids',
-        'seed_times',
-        'nbr_nids',
-        'nbr_edge_time',
-        'nbr_edge_x',
-        'seed_node_nbr_mask',
-    }
+    
 
     """Load neighbors from DGraph using a recency sampling. Each node maintains a fixed number of recent neighbors.
 
@@ -240,6 +232,15 @@ class RecencyNeighborHook(StatefulHook):
         seed_times_keys: List[str],
         directed: bool = False,
     ) -> None:
+        self.requires = {'edge_src', 'edge_dst', 'edge_time'} | set(seed_nodes_keys)
+        self.produces = {
+            'seed_nids',
+            'seed_times',
+            'nbr_nids',
+            'nbr_edge_time',
+            'nbr_edge_x',
+            'seed_node_nbr_mask',
+        }
         if not len(num_nbrs):
             raise ValueError('num_nbrs must be non-empty')
         if not all([isinstance(x, int) and (x > 0) for x in num_nbrs]):

--- a/tgm/hooks/neighbors.py
+++ b/tgm/hooks/neighbors.py
@@ -34,16 +34,6 @@ class NeighborSamplerHook(StatelessHook):
         ValueError: If len(seed_nodes_keys) != len(seed_times_keys).
     """
 
-    requires = {'edge_src', 'edge_dst', 'edge_time'}
-    produces = {
-        'seed_nids',
-        'seed_times',
-        'nbr_nids',
-        'nbr_edge_time',
-        'nbr_edge_x',
-        'seed_node_nbr_mask',
-    }
-
     def __init__(
         self,
         num_nbrs: List[int],
@@ -51,6 +41,16 @@ class NeighborSamplerHook(StatelessHook):
         seed_times_keys: List[str],
         directed: bool = False,
     ) -> None:
+        self.requires = {'edge_src', 'edge_dst', 'edge_time'}
+        self.produces = {
+            'seed_nids',
+            'seed_times',
+            'nbr_nids',
+            'nbr_edge_time',
+            'nbr_edge_x',
+            'seed_node_nbr_mask',
+        }
+
         if not len(num_nbrs):
             raise ValueError('num_nbrs must be non-empty')
         if not all([isinstance(x, int) and (x > 0) for x in num_nbrs]):

--- a/tgm/hooks/neighbors.py
+++ b/tgm/hooks/neighbors.py
@@ -8,13 +8,13 @@ import torch
 from tgm import DGBatch, DGraph
 from tgm.constants import PADDED_NODE_ID
 from tgm.core._storage import DGSliceTracker
-from tgm.hooks import StatefulHook, StatelessHook
+from tgm.hooks import SeedableHook, StatefulHook, StatelessHook
 from tgm.util.logging import _get_logger
 
 logger = _get_logger(__name__)
 
 
-class NeighborSamplerHook(StatelessHook):
+class NeighborSamplerHook(StatelessHook, SeedableHook):
     """Load data from DGraph using a memory based sampling function.
 
     Args:
@@ -36,6 +36,16 @@ class NeighborSamplerHook(StatelessHook):
         ValueError: If len(seed_nodes_keys) != len(seed_times_keys).
     """
 
+    _cls_requires = {'edge_src', 'edge_dst', 'edge_time'}
+    _cls_produces = {
+        'seed_nids',
+        'seed_times',
+        'nbr_nids',
+        'nbr_edge_time',
+        'nbr_edge_x',
+        'seed_node_nbr_mask',
+    }
+
     def __init__(
         self,
         num_nbrs: List[int],
@@ -44,6 +54,7 @@ class NeighborSamplerHook(StatelessHook):
         directed: bool = False,
         id: str | None = None,
     ) -> None:
+        super().__init__()
         if not len(num_nbrs):
             raise ValueError('num_nbrs must be non-empty')
         if not all([isinstance(x, int) and (x > 0) for x in num_nbrs]):
@@ -66,16 +77,17 @@ class NeighborSamplerHook(StatelessHook):
             self._seed_times_keys,
         )
         self._warned_seed_None = False
-        self.id = id
-        self.requires = {'edge_src', 'edge_dst', 'edge_time'} | set(seed_nodes_keys)
-        self.produces = {
-            'seed_nids',
-            'seed_times',
-            'nbr_nids',
-            'nbr_edge_time',
-            'nbr_edge_x',
-            'seed_node_nbr_mask',
-        }
+        self._id = id
+        self.seed_keys = seed_nodes_keys
+        # self.requires = {'edge_src', 'edge_dst', 'edge_time'} | set(seed_nodes_keys)
+        # self.produces = {
+        #     'seed_nids',
+        #     'seed_times',
+        #     'nbr_nids',
+        #     'nbr_edge_time',
+        #     'nbr_edge_x',
+        #     'seed_node_nbr_mask',
+        # }
         self.__post_init__()
 
     @property
@@ -203,7 +215,7 @@ class NeighborSamplerHook(StatelessHook):
         return seed_nodes, seed_times, seed_node_mask  # type: ignore
 
 
-class RecencyNeighborHook(StatefulHook):
+class RecencyNeighborHook(StatefulHook, SeedableHook):
     """Load neighbors from DGraph using a recency sampling. Each node maintains a fixed number of recent neighbors.
 
     Args:
@@ -227,6 +239,16 @@ class RecencyNeighborHook(StatefulHook):
         ValueError: If len(seed_nodes_keys) != len(seed_times_keys).
     """
 
+    _cls_requires = {'edge_src', 'edge_dst', 'edge_time'}
+    _cls_produces = {
+        'seed_nids',
+        'seed_times',
+        'nbr_nids',
+        'nbr_edge_time',
+        'nbr_edge_x',
+        'seed_node_nbr_mask',
+    }
+
     def __init__(
         self,
         num_nodes: int,
@@ -236,6 +258,7 @@ class RecencyNeighborHook(StatefulHook):
         directed: bool = False,
         id: str | None = None,
     ) -> None:
+        super().__init__()
         if not len(num_nbrs):
             raise ValueError('num_nbrs must be non-empty')
         if not all([isinstance(x, int) and (x > 0) for x in num_nbrs]):
@@ -273,16 +296,17 @@ class RecencyNeighborHook(StatefulHook):
         self._need_to_initialize_nbr_feats = True
         self._edge_x_dim = None
         self._nbr_feats = None
-        self.id = id
-        self.requires = {'edge_src', 'edge_dst', 'edge_time'} | set(seed_nodes_keys)
-        self.produces = {
-            'seed_nids',
-            'seed_times',
-            'nbr_nids',
-            'nbr_edge_time',
-            'nbr_edge_x',
-            'seed_node_nbr_mask',
-        }
+        self._id = id
+        self.seed_keys = seed_nodes_keys
+        # self.requires = {'edge_src', 'edge_dst', 'edge_time'} | set(seed_nodes_keys)
+        # self.produces = {
+        #     'seed_nids',
+        #     'seed_times',
+        #     'nbr_nids',
+        #     'nbr_edge_time',
+        #     'nbr_edge_x',
+        #     'seed_node_nbr_mask',
+        # }
         self.__post_init__()
 
     @property

--- a/tgm/hooks/node_analytics.py
+++ b/tgm/hooks/node_analytics.py
@@ -38,16 +38,15 @@ class NodeAnalyticsHook(StatefulHook):
             - new_edge_count: Number of new edges in the batch, that is not seen in previous batches.
     """
 
-    requires = {
-        'edge_src',
-        'edge_dst',
-        'edge_time',
-        'node_x_time',
-        'node_x_nids',
-    }
-    produces = {'node_stats', 'node_macro_stats', 'edge_stats'}
-
     def __init__(self, tracked_nodes: Tensor, num_nodes: int) -> None:
+        self.requires = {
+            'edge_src',
+            'edge_dst',
+            'edge_time',
+            'node_x_time',
+            'node_x_nids',
+        }
+        self.produces = {'node_stats', 'node_macro_stats', 'edge_stats'}
         if num_nodes <= 0:
             raise ValueError('num_nodes must be positive')
         self.tracked_nodes = tracked_nodes.unique()

--- a/tgm/hooks/node_analytics.py
+++ b/tgm/hooks/node_analytics.py
@@ -358,8 +358,8 @@ class NodeAnalyticsHook(StatefulHook):
         node_batch_stats = self._compute_node_statistics(batch)
         edge_batch_stats = self._compute_edge_statistics(batch)
 
-        batch.node_stats = node_stats  # type: ignore[attr-defined]
-        batch.node_macro_stats = node_batch_stats  # type: ignore[attr-defined]
-        batch.edge_stats = edge_batch_stats  # type: ignore[attr-defined]
+        self.add_attribute_to_batch(batch, 'node_stats', node_stats)
+        self.add_attribute_to_batch(batch, 'node_macro_stats', node_batch_stats)
+        self.add_attribute_to_batch(batch, 'edge_stats', edge_batch_stats)
 
         return batch

--- a/tgm/hooks/node_analytics.py
+++ b/tgm/hooks/node_analytics.py
@@ -360,8 +360,8 @@ class NodeAnalyticsHook(StatefulHook):
         node_batch_stats = self._compute_node_statistics(batch)
         edge_batch_stats = self._compute_edge_statistics(batch)
 
-        self.add_attribute_to_batch(batch, 'node_stats', node_stats)
-        self.add_attribute_to_batch(batch, 'node_macro_stats', node_batch_stats)
-        self.add_attribute_to_batch(batch, 'edge_stats', edge_batch_stats)
+        self.add_batch_attribute(batch, 'node_stats', node_stats)
+        self.add_batch_attribute(batch, 'node_macro_stats', node_batch_stats)
+        self.add_batch_attribute(batch, 'edge_stats', edge_batch_stats)
 
         return batch

--- a/tgm/hooks/node_analytics.py
+++ b/tgm/hooks/node_analytics.py
@@ -20,6 +20,7 @@ class NodeAnalyticsHook(StatefulHook):
     Args:
         tracked_nodes (Tensor): 1D tensor of node IDs to track statistics for.
         num_nodes (int): Total number of nodes in the graph.
+        id (str): A unique identifier for the hook. The hook’s name and all attributes it produces will be suffixed with this `id`.
 
     Produces:
         node_stats (Dict[int, Dict[str, float]]): Dictionary mapping node_id to statistics:
@@ -38,15 +39,9 @@ class NodeAnalyticsHook(StatefulHook):
             - new_edge_count: Number of new edges in the batch, that is not seen in previous batches.
     """
 
-    def __init__(self, tracked_nodes: Tensor, num_nodes: int) -> None:
-        self.requires = {
-            'edge_src',
-            'edge_dst',
-            'edge_time',
-            'node_x_time',
-            'node_x_nids',
-        }
-        self.produces = {'node_stats', 'node_macro_stats', 'edge_stats'}
+    def __init__(
+        self, tracked_nodes: Tensor, num_nodes: int, id: str | None = None
+    ) -> None:
         if num_nodes <= 0:
             raise ValueError('num_nodes must be positive')
         self.tracked_nodes = tracked_nodes.unique()
@@ -73,6 +68,17 @@ class NodeAnalyticsHook(StatefulHook):
 
         # Edge tracking
         self._seen_edges: Set[tuple] = set()
+
+        self.id = id
+        self.requires = {
+            'edge_src',
+            'edge_dst',
+            'edge_time',
+            'node_x_time',
+            'node_x_nids',
+        }
+        self.produces = {'node_stats', 'node_macro_stats', 'edge_stats'}
+        self.__post_init__()
 
     def _compute_node_degrees(self, batch: DGBatch, nodes: Tensor) -> Dict[int, int]:
         """Compute degree for each node in the given set."""

--- a/tgm/hooks/node_analytics.py
+++ b/tgm/hooks/node_analytics.py
@@ -39,9 +39,19 @@ class NodeAnalyticsHook(StatefulHook):
             - new_edge_count: Number of new edges in the batch, that is not seen in previous batches.
     """
 
+    _cls_requires = {
+        'edge_src',
+        'edge_dst',
+        'edge_time',
+        'node_x_time',
+        'node_x_nids',
+    }
+    _cls_produces = {'node_stats', 'node_macro_stats', 'edge_stats'}
+
     def __init__(
         self, tracked_nodes: Tensor, num_nodes: int, id: str | None = None
     ) -> None:
+        super().__init__()
         if num_nodes <= 0:
             raise ValueError('num_nodes must be positive')
         self.tracked_nodes = tracked_nodes.unique()
@@ -69,15 +79,7 @@ class NodeAnalyticsHook(StatefulHook):
         # Edge tracking
         self._seen_edges: Set[tuple] = set()
 
-        self.id = id
-        self.requires = {
-            'edge_src',
-            'edge_dst',
-            'edge_time',
-            'node_x_time',
-            'node_x_nids',
-        }
-        self.produces = {'node_stats', 'node_macro_stats', 'edge_stats'}
+        self._id = id
         self.__post_init__()
 
     def _compute_node_degrees(self, batch: DGBatch, nodes: Tensor) -> Dict[int, int]:

--- a/tgm/hooks/node_tracks.py
+++ b/tgm/hooks/node_tracks.py
@@ -51,10 +51,10 @@ class EdgeEventsSeenNodesTrackHook(StatefulHook):
 
         self._seen_mask[edge_event_nodes] = True
         previous_seen = self._seen_mask[batch_nodes]
-        self.add_attribute_to_batch(
+        self.add_batch_attribute(
             batch, 'batch_nodes_mask', torch.nonzero(previous_seen, as_tuple=True)[0]
         )
-        self.add_attribute_to_batch(batch, 'seen_nodes', batch_nodes[previous_seen])
+        self.add_batch_attribute(batch, 'seen_nodes', batch_nodes[previous_seen])
         return batch
 
     def _move_to_device_if_needed(self, device: torch.device) -> None:

--- a/tgm/hooks/node_tracks.py
+++ b/tgm/hooks/node_tracks.py
@@ -49,8 +49,10 @@ class EdgeEventsSeenNodesTrackHook(StatefulHook):
 
         self._seen_mask[edge_event_nodes] = True
         previous_seen = self._seen_mask[batch_nodes]
-        batch.batch_nodes_mask = torch.nonzero(previous_seen, as_tuple=True)[0]  # type: ignore[attr-defined]
-        batch.seen_nodes = batch_nodes[previous_seen]  # type: ignore[attr-defined]
+        self.add_attribute_to_batch(
+            batch, 'batch_nodes_mask', torch.nonzero(previous_seen, as_tuple=True)[0]
+        )
+        self.add_attribute_to_batch(batch, 'seen_nodes', batch_nodes[previous_seen])
         return batch
 
     def _move_to_device_if_needed(self, device: torch.device) -> None:

--- a/tgm/hooks/node_tracks.py
+++ b/tgm/hooks/node_tracks.py
@@ -15,19 +15,22 @@ class EdgeEventsSeenNodesTrackHook(StatefulHook):
 
     Args:
         num_nodes (int): Total number of nodes to track.
+        id (str): A unique identifier for the hook. The hook’s name and all attributes it produces will be suffixed with this `id`.
 
     Raises:
         ValueError: If the num_nodes list is negative.
     """
 
-    def __init__(self, num_nodes: int) -> None:
-        self.requires = {'edge_src', 'edge_dst'}
-        self.produces = {'seen_nodes', 'batch_nodes_mask'}
-
+    def __init__(self, num_nodes: int, id: str | None = None) -> None:
         if num_nodes < 0:
             raise ValueError('num_nodes must be non-negative')
         self._seen_mask = torch.zeros(num_nodes, dtype=torch.bool)
         self._device = torch.device('cpu')
+
+        self.id = id
+        self.requires = {'edge_src', 'edge_dst'}
+        self.produces = {'seen_nodes', 'batch_nodes_mask'}
+        self.__post_init__()
 
     def reset_state(self) -> None:
         logger.debug('Reset state of the hook')

--- a/tgm/hooks/node_tracks.py
+++ b/tgm/hooks/node_tracks.py
@@ -21,15 +21,17 @@ class EdgeEventsSeenNodesTrackHook(StatefulHook):
         ValueError: If the num_nodes list is negative.
     """
 
+    _cls_requires = {'edge_src', 'edge_dst'}
+    _cls_produces = {'seen_nodes', 'batch_nodes_mask'}
+
     def __init__(self, num_nodes: int, id: str | None = None) -> None:
+        super().__init__()
         if num_nodes < 0:
             raise ValueError('num_nodes must be non-negative')
         self._seen_mask = torch.zeros(num_nodes, dtype=torch.bool)
         self._device = torch.device('cpu')
 
-        self.id = id
-        self.requires = {'edge_src', 'edge_dst'}
-        self.produces = {'seen_nodes', 'batch_nodes_mask'}
+        self._id = id
         self.__post_init__()
 
     def reset_state(self) -> None:

--- a/tgm/hooks/node_tracks.py
+++ b/tgm/hooks/node_tracks.py
@@ -20,10 +20,10 @@ class EdgeEventsSeenNodesTrackHook(StatefulHook):
         ValueError: If the num_nodes list is negative.
     """
 
-    requires = {'edge_src', 'edge_dst'}
-    produces = {'seen_nodes', 'batch_nodes_mask'}
-
     def __init__(self, num_nodes: int) -> None:
+        self.requires = {'edge_src', 'edge_dst'}
+        self.produces = {'seen_nodes', 'batch_nodes_mask'}
+
         if num_nodes < 0:
             raise ValueError('num_nodes must be non-negative')
         self._seen_mask = torch.zeros(num_nodes, dtype=torch.bool)


### PR DESCRIPTION
### Summary / Description

This PR covered:
- Made `requires` and `produces` as instance-level variables for each hook
- Added `id` to each hook constructor
- Removed [hack that forces the dedup hook always run at the end ](https://github.com/tgm-team/tgm/pull/380)

**Related Issues:** #381

#### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking Change
- [X] Refactoring
- [ ] Documentation update

#### Test Evidence

Describe how this PR has been tested.

- [X] Unit tests
- [ ] Integration tests
- [ ] Performance tests

#### Questions / Discussion Points

I will add this function to `BaseDGHook`:
```python
    def add_attribute_to_batch(self, batch: DGBatch ,name: str, value: Any) -> None:
        """
        Add a new attribute to providede batch.

        If `id` is specified, the new attribute name will be appended with the given `id` as a suffix.
        """
        if self.id:
            name = f'{name}_{self.id}'
        setattr(batch, name, value)
```

I will refactor our code so we use this method every time we add a new attribute to the batch

This is a draft, and unit tests will be added to improve codecov.
