### PR TITLE
Update TGB Version to py-tgb 2.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
 [dependency-groups]
 analytics = [
     "networkx>=3.2.1",
-    "py-tgb>=2.2.0",
+    "py-tgb>=2.3.0",
     "scipy>=1.15.2",
     "tqdm>=4.67.1",
 ]
@@ -29,7 +29,7 @@ dev = [
     "pytest-cov>=6.0.0",
     "pytest>=8.3.3",
     "ruff==0.11.1",
-    "py-tgb>=2.2.0",
+    "py-tgb>=2.3.0",
     "pandas>=1.5.3",
     "pytest-xdist>=3.7.0",
     "pytest-benchmark>=5.1.0",
@@ -42,7 +42,7 @@ docs = [
 ]
 examples = [
     "pandas>=2.3.0",
-    "py-tgb>=2.2.0",
+    "py-tgb>=2.3.0",
     "tgb-seq>=0.1.2",
     "torchmetrics>=1.7.0",
     "tqdm>=4.67.1",

--- a/test/performance/test_iteration.py
+++ b/test/performance/test_iteration.py
@@ -6,8 +6,7 @@ from tgm import DGraph
 from tgm.data import DGDataLoader
 from tgm.hooks import (
     HookManager,
-    NegativeEdgeSamplerHook,
-    NeighborSamplerHook,
+    RandomNegativeEdgeSamplerHook,
     RecencyNeighborHook,
     TGBNegativeEdgeSamplerHook,
 )
@@ -21,7 +20,7 @@ def setup_no_hooks(dg, data, dataset):
 
 def setup_random_negs(dg, data, dataset):
     dst = dg.edge_dst
-    hook = NegativeEdgeSamplerHook(low=int(dst.min()), high=int(dst.max()))
+    hook = RandomNegativeEdgeSamplerHook(low=int(dst.min()), high=int(dst.max()))
     return create_hook_manager(hooks=[hook])
 
 
@@ -49,7 +48,7 @@ def setup_tgb_negs(dg, data, dataset, sampler_type=None, num_nbrs=None):
         )
     elif sampler_type == 'uniform':
         hooks.append(
-            NeighborSamplerHook(
+            RandomNegativeEdgeSamplerHook(
                 num_nbrs=num_nbrs,
                 seed_nodes_keys=seed_nodes_keys,
                 seed_times_keys=seed_times_keys,

--- a/test/performance/test_iteration.py
+++ b/test/performance/test_iteration.py
@@ -6,6 +6,7 @@ from tgm import DGraph
 from tgm.data import DGDataLoader
 from tgm.hooks import (
     HookManager,
+    NeighborSamplerHook,
     RandomNegativeEdgeSamplerHook,
     RecencyNeighborHook,
     TGBNegativeEdgeSamplerHook,
@@ -48,7 +49,7 @@ def setup_tgb_negs(dg, data, dataset, sampler_type=None, num_nbrs=None):
         )
     elif sampler_type == 'uniform':
         hooks.append(
-            RandomNegativeEdgeSamplerHook(
+            NeighborSamplerHook(
                 num_nbrs=num_nbrs,
                 seed_nodes_keys=seed_nodes_keys,
                 seed_times_keys=seed_times_keys,

--- a/uv.lock
+++ b/uv.lock
@@ -1831,7 +1831,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 analytics = [
     { name = "networkx", specifier = ">=3.2.1" },
-    { name = "py-tgb", specifier = ">=2.2.0" },
+    { name = "py-tgb", specifier = ">=2.3.0" },
     { name = "scipy", specifier = ">=1.15.2" },
     { name = "tqdm", specifier = ">=4.67.1" },
 ]
@@ -1840,7 +1840,7 @@ dev = [
     { name = "mypy", specifier = ">=1.13.0" },
     { name = "pandas", specifier = ">=1.5.3" },
     { name = "pre-commit", specifier = ">=4.0.1" },
-    { name = "py-tgb", specifier = ">=2.2.0" },
+    { name = "py-tgb", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-benchmark", specifier = ">=5.1.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
@@ -1855,7 +1855,7 @@ docs = [
 ]
 examples = [
     { name = "pandas", specifier = ">=2.3.0" },
-    { name = "py-tgb", specifier = ">=2.2.0" },
+    { name = "py-tgb", specifier = ">=2.3.0" },
     { name = "tgb-seq", specifier = ">=0.1.2" },
     { name = "torchmetrics", specifier = ">=1.7.0" },
     { name = "tqdm", specifier = ">=4.67.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version < '3.11'",
@@ -1409,7 +1409,7 @@ wheels = [
 
 [[package]]
 name = "py-tgb"
-version = "2.2.0"
+version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "clint" },
@@ -1417,12 +1417,11 @@ dependencies = [
     { name = "pandas" },
     { name = "requests" },
     { name = "scikit-learn" },
-    { name = "torch-geometric" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/92/ad/9aa5963f598cd0e908c39f9471e63e08ae9913cab7463e97754e1edfb891/py_tgb-2.2.0.tar.gz", hash = "sha256:f8873a5621beba637db60d16ac12774aef81272b184ed3a310d7ea1952f17001", size = 107987, upload-time = "2025-10-05T17:36:14.059Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/92/5bd1459f0355a57278c96e721b30eb8b61729c11ce1a3de1cbc90a30d578/py_tgb-2.3.0.tar.gz", hash = "sha256:769984eb825d85624fec8e7136565ce149866fa490ef9a6f739cee2d769dd3e4", size = 111223, upload-time = "2026-07-27T00:23:45.874Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/b2/87ff16174a8ffe660d19742a23f826142ae94fd47c66bb09ffc0e4e36ec2/py_tgb-2.2.0-py3-none-any.whl", hash = "sha256:67b704a71606cc18cee7944b151da66b900b78026124a235bf410ac425cfd742", size = 154353, upload-time = "2025-10-05T17:36:13.1Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bf/29df7eb22596db3fa4523f9a5dd67a52c53d9a11b58a352f63b4ec282d7c/py_tgb-2.3.0-py3-none-any.whl", hash = "sha256:2d230d869741964ac6382ab83de534d539c0e4e56d5a49f7542bc16a2e1e1839", size = 156192, upload-time = "2026-07-27T00:23:47.049Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Summary / Description

Recent TGB dataset download link migration will introduce changes to tgm. This PR addresses #422 


**Related Issues:** #422 

#### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking Change
- [x] Refactoring
- [ ] Documentation update

#### Test Evidence

- [x] Unit tests
- [ ] Integration tests
- [x] Performance tests

Currently missing integration tests because `integration.yml` currently fails on every scheduled run (self-hosted SLURM runner) with a `PermissionError` unrelated to this PR — filed separately, needs a CI infra fix before it can be used to validate anything.

While verifying this PR, found and fixed two issues beyond the version bump itself:

1. **`test/performance/test_iteration.py`**: the `'uniform'` branch of `setup_tgb_negs` had been accidentally switched to `RandomNegativeEdgeSamplerHook(num_nbrs=..., seed_nodes_keys=..., seed_times_keys=...)`, but that hook's constructor only accepts `(low, high, neg_ratio, id)` — it would raise `TypeError` immediately. Restored `NeighborSamplerHook`, which is the correct hook for that branch.
2. **`uv.lock`**: the `requires-dist`/`requires-dev` specifier blocks were bumped to `py-tgb>=2.3.0`, but the actual `[[package]]` entry for `py-tgb` was never re-resolved and stayed pinned at `2.2.0`. A plain `uv sync` (including CI's `uv sync --frozen`) would have silently kept installing the old version, defeating the point of this PR. Forced a real re-resolution so the lock now correctly pins `2.3.0`.
